### PR TITLE
Using the ClientOptions provided at App initialization to create the …

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -71,8 +71,13 @@ type Client struct {
 // This function can only be invoked from within the SDK. Client applications should access the
 // the Auth service through firebase.App.
 func NewClient(c *internal.AuthConfig) (*Client, error) {
+	ks, err := newHTTPKeySource(c.Ctx, googleCertURL, c.Opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
-		ks:        newHTTPKeySource(googleCertURL),
+		ks:        ks,
 		projectID: c.ProjectID,
 	}
 	if c.Creds == nil || len(c.Creds.JSON) == 0 {
@@ -83,8 +88,7 @@ func NewClient(c *internal.AuthConfig) (*Client, error) {
 		ClientEmail string `json:"client_email"`
 		PrivateKey  string `json:"private_key"`
 	}
-	err := json.Unmarshal(c.Creds.JSON, &svcAcct)
-	if err != nil {
+	if err := json.Unmarshal(c.Creds.JSON, &svcAcct); err != nil {
 		return nil, err
 	}
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -16,7 +16,7 @@ package auth
 
 import (
 	"errors"
-	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -99,18 +99,15 @@ func TestMain(m *testing.M) {
 	opt := option.WithCredentialsFile("../testdata/service_account.json")
 	creds, err = transport.Creds(context.Background(), opt)
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 
 	client, err = NewClient(&internal.AuthConfig{
-		Ctx:       context.Background(),
 		Creds:     creds,
 		ProjectID: "mock-project-id",
 	})
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 	client.ks = &fileKeySource{FilePath: "../testdata/public_certs.json"}
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -98,14 +99,17 @@ func TestMain(m *testing.M) {
 	opt := option.WithCredentialsFile("../testdata/service_account.json")
 	creds, err = transport.Creds(context.Background(), opt)
 	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 
 	client, err = NewClient(&internal.AuthConfig{
+		Ctx:       context.Background(),
 		Creds:     creds,
 		ProjectID: "mock-project-id",
 	})
 	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 	client.ks = &fileKeySource{FilePath: "../testdata/public_certs.json"}

--- a/auth/crypto.go
+++ b/auth/crypto.go
@@ -76,10 +76,17 @@ type httpKeySource struct {
 }
 
 func newHTTPKeySource(ctx context.Context, uri string, opts ...option.ClientOption) (*httpKeySource, error) {
-	hc, _, err := transport.NewHTTPClient(ctx, opts...)
-	if err != nil {
-		return nil, err
+	var hc *http.Client
+	if ctx != nil && len(opts) > 0 {
+		var err error
+		hc, _, err = transport.NewHTTPClient(ctx, opts...)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		hc = http.DefaultClient
 	}
+
 	return &httpKeySource{
 		KeyURI:     uri,
 		HTTPClient: hc,

--- a/auth/crypto_test.go
+++ b/auth/crypto_test.go
@@ -15,13 +15,14 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"google.golang.org/api/option"
 )

--- a/auth/crypto_test.go
+++ b/auth/crypto_test.go
@@ -15,11 +15,15 @@
 package auth
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"google.golang.org/api/option"
 )
 
 type mockHTTPResponse struct {
@@ -35,6 +39,27 @@ type mockReadCloser struct {
 	data       string
 	index      int64
 	closeCount int
+}
+
+func newHTTPClient(data []byte) (*http.Client, *mockReadCloser) {
+	rc := &mockReadCloser{
+		data:       string(data),
+		closeCount: 0,
+	}
+	client := &http.Client{
+		Transport: &mockHTTPResponse{
+			Response: http.Response{
+				Status:     "200 OK",
+				StatusCode: 200,
+				Header: http.Header{
+					"Cache-Control": {"public, max-age=100"},
+				},
+				Body: rc,
+			},
+			Err: nil,
+		},
+	}
+	return client, rc
 }
 
 func (r *mockReadCloser) Read(p []byte) (n int, err error) {
@@ -61,39 +86,57 @@ func TestHTTPKeySource(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	ks, err := newHTTPKeySource(context.Background(), "http://mock.url")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ks.HTTPClient == nil {
+		t.Errorf("HTTPClient = nil; want non-nil")
+	}
+	hc, rc := newHTTPClient(data)
+	ks.HTTPClient = hc
+	if err := verifyHTTPKeySource(ks, rc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHTTPKeySourceWithClient(t *testing.T) {
+	data, err := ioutil.ReadFile("../testdata/public_certs.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hc, rc := newHTTPClient(data)
+	ks, err := newHTTPKeySource(context.Background(), "http://mock.url", option.WithHTTPClient(hc))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ks.HTTPClient != hc {
+		t.Errorf("HTTPClient = %v; want %v", ks.HTTPClient, hc)
+	}
+	if err := verifyHTTPKeySource(ks, rc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func verifyHTTPKeySource(ks *httpKeySource, rc *mockReadCloser) error {
 	mc := &mockClock{now: time.Unix(0, 0)}
-	rc := &mockReadCloser{
-		data:       string(data),
-		closeCount: 0,
-	}
-	ks := newHTTPKeySource("http://mock.url")
-	ks.HTTPClient = &http.Client{
-		Transport: &mockHTTPResponse{
-			Response: http.Response{
-				Status:     "200 OK",
-				StatusCode: 200,
-				Header: http.Header{
-					"Cache-Control": {"public, max-age=100"},
-				},
-				Body: rc,
-			},
-			Err: nil,
-		},
-	}
 	ks.Clock = mc
 
 	exp := time.Unix(100, 0)
 	for i := 0; i <= 100; i++ {
 		keys, err := ks.Keys()
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 		if len(keys) != 3 {
-			t.Errorf("Keys: %d; want: 3", len(keys))
+			return fmt.Errorf("Keys: %d; want: 3", len(keys))
 		} else if rc.closeCount != 1 {
-			t.Errorf("HTTP calls: %d; want: 1", rc.closeCount)
+			return fmt.Errorf("HTTP calls: %d; want: 1", rc.closeCount)
 		} else if ks.ExpiryTime != exp {
-			t.Errorf("Expiry: %v; want: %v", ks.ExpiryTime, exp)
+			return fmt.Errorf("Expiry: %v; want: %v", ks.ExpiryTime, exp)
 		}
 		mc.now = mc.now.Add(time.Second)
 	}
@@ -101,11 +144,12 @@ func TestHTTPKeySource(t *testing.T) {
 	mc.now = time.Unix(101, 0)
 	keys, err := ks.Keys()
 	if err != nil {
-		t.Fatal(err)
+		return err
 	}
 	if len(keys) != 3 {
-		t.Errorf("Keys: %d; want: 3", len(keys))
+		return fmt.Errorf("Keys: %d; want: 3", len(keys))
 	} else if rc.closeCount != 2 {
-		t.Errorf("HTTP calls: %d; want: 2", rc.closeCount)
+		return fmt.Errorf("HTTP calls: %d; want: 2", rc.closeCount)
 	}
+	return nil
 }

--- a/firebase.go
+++ b/firebase.go
@@ -53,8 +53,10 @@ type Config struct {
 // Auth returns an instance of auth.Client.
 func (a *App) Auth() (*auth.Client, error) {
 	conf := &internal.AuthConfig{
+		Ctx:       a.ctx,
 		Creds:     a.creds,
 		ProjectID: a.projectID,
+		Opts:      a.opts,
 	}
 	return auth.NewClient(conf)
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -16,11 +16,16 @@
 package internal
 
 import (
+	"golang.org/x/net/context"
+	"google.golang.org/api/option"
+
 	"golang.org/x/oauth2/google"
 )
 
 // AuthConfig represents the configuration of Firebase Auth service.
 type AuthConfig struct {
+	Ctx       context.Context
+	Opts      []option.ClientOption
 	Creds     *google.DefaultCredentials
 	ProjectID string
 }


### PR DESCRIPTION
Currently we use `http.DefaultClient` in the `auth` package to contact certificate server. But this [does not work](https://stackoverflow.com/questions/46038318/using-firebase-admin-sdk-for-go-from-appengine) in App Engine (and possibly some other environments). 

This PR makes it so that the client options used to initialize the App are also used to initialize the http client in `auth`. This allows users to pass in an App Engine specific http client to the App, which will then get passed into the auth module.