### PR TITLE
Passing a non-nil context to AuthConfig during testing; Replacing Pri…

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -103,6 +103,7 @@ func TestMain(m *testing.M) {
 	}
 
 	client, err = NewClient(&internal.AuthConfig{
+		Ctx:       context.Background(),
 		Creds:     creds,
 		ProjectID: "mock-project-id",
 	})
@@ -164,7 +165,7 @@ func TestCustomTokenError(t *testing.T) {
 }
 
 func TestCustomTokenInvalidCredential(t *testing.T) {
-	s, err := NewClient(&internal.AuthConfig{})
+	s, err := NewClient(&internal.AuthConfig{Ctx: context.Background()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +228,7 @@ func TestVerifyIDTokenError(t *testing.T) {
 }
 
 func TestNoProjectID(t *testing.T) {
-	c, err := NewClient(&internal.AuthConfig{Creds: creds})
+	c, err := NewClient(&internal.AuthConfig{Ctx: context.Background(), Creds: creds})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"testing"
@@ -37,18 +38,18 @@ var client *auth.Client
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Short() {
-		fmt.Println("skipping auth integration tests in short mode.")
+		log.Println("skipping auth integration tests in short mode.")
 		os.Exit(0)
 	}
 
 	app, err := internal.NewTestApp(context.Background())
 	if err != nil {
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 
 	client, err = app.Auth()
 	if err != nil {
-		os.Exit(1)
+		log.Fatalln(err)
 	}
 
 	os.Exit(m.Run())


### PR DESCRIPTION
…nt+Exit calls with log.Fatal()

