### PR TITLE
Google Cloud Storage API

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"firebase.google.com/go/internal"
+	"golang.org/x/net/context"
 )
 
 const firebaseAudience = "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
@@ -73,7 +74,7 @@ type signer interface {
 //
 // This function can only be invoked from within the SDK. Client applications should access the
 // the Auth service through firebase.App.
-func NewClient(c *internal.AuthConfig) (*Client, error) {
+func NewClient(ctx context.Context, c *internal.AuthConfig) (*Client, error) {
 	var (
 		err   error
 		email string
@@ -99,13 +100,13 @@ func NewClient(c *internal.AuthConfig) (*Client, error) {
 	if email != "" && pk != nil {
 		snr = serviceAcctSigner{email: email, pk: pk}
 	} else {
-		snr, err = newSigner(c.Ctx)
+		snr, err = newSigner(ctx)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	ks, err := newHTTPKeySource(c.Ctx, googleCertURL, c.Opts...)
+	ks, err := newHTTPKeySource(ctx, googleCertURL, c.Opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -58,8 +58,8 @@ func TestMain(m *testing.M) {
 			log.Fatalln(err)
 		}
 	} else {
-		opt := option.WithCredentialsFile("../testdata/service_account.json")
-		creds, err = transport.Creds(context.Background(), opt)
+		ctx = context.Background()
+		creds, err = transport.Creds(ctx, option.WithCredentialsFile("../testdata/service_account.json"))
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -67,8 +67,7 @@ func TestMain(m *testing.M) {
 		ks = &fileKeySource{FilePath: "../testdata/public_certs.json"}
 	}
 
-	client, err = NewClient(&internal.AuthConfig{
-		Ctx:       ctx,
+	client, err = NewClient(ctx, &internal.AuthConfig{
 		Creds:     creds,
 		ProjectID: "mock-project-id",
 	})
@@ -130,7 +129,7 @@ func TestCustomTokenError(t *testing.T) {
 }
 
 func TestCustomTokenInvalidCredential(t *testing.T) {
-	s, err := NewClient(&internal.AuthConfig{Ctx: context.Background()})
+	s, err := NewClient(context.Background(), &internal.AuthConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +192,7 @@ func TestVerifyIDTokenError(t *testing.T) {
 }
 
 func TestNoProjectID(t *testing.T) {
-	c, err := NewClient(&internal.AuthConfig{Ctx: context.Background()})
+	c, err := NewClient(context.Background(), &internal.AuthConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -86,11 +86,8 @@ func TestNewClientInvalidCredentials(t *testing.T) {
 	creds := &google.DefaultCredentials{
 		JSON: []byte("foo"),
 	}
-	conf := &internal.AuthConfig{
-		Ctx:   context.Background(),
-		Creds: creds,
-	}
-	if c, err := NewClient(conf); c != nil || err == nil {
+	conf := &internal.AuthConfig{Creds: creds}
+	if c, err := NewClient(context.Background(), conf); c != nil || err == nil {
 		t.Errorf("NewCient() = (%v,%v); want = (nil, error)", c, err)
 	}
 }
@@ -105,11 +102,8 @@ func TestNewClientInvalidPrivateKey(t *testing.T) {
 		t.Fatal(err)
 	}
 	creds := &google.DefaultCredentials{JSON: b}
-	conf := &internal.AuthConfig{
-		Ctx:   context.Background(),
-		Creds: creds,
-	}
-	if c, err := NewClient(conf); c != nil || err == nil {
+	conf := &internal.AuthConfig{Creds: creds}
+	if c, err := NewClient(context.Background(), conf); c != nil || err == nil {
 		t.Errorf("NewCient() = (%v,%v); want = (nil, error)", c, err)
 	}
 }

--- a/firebase.go
+++ b/firebase.go
@@ -39,7 +39,6 @@ const Version = "1.0.2"
 
 // An App holds configuration and state common to all Firebase services that are exposed from the SDK.
 type App struct {
-	ctx       context.Context
 	creds     *google.DefaultCredentials
 	projectID string
 	opts      []option.ClientOption
@@ -51,14 +50,13 @@ type Config struct {
 }
 
 // Auth returns an instance of auth.Client.
-func (a *App) Auth() (*auth.Client, error) {
+func (a *App) Auth(ctx context.Context) (*auth.Client, error) {
 	conf := &internal.AuthConfig{
-		Ctx:       a.ctx,
 		Creds:     a.creds,
 		ProjectID: a.projectID,
 		Opts:      a.opts,
 	}
-	return auth.NewClient(conf)
+	return auth.NewClient(ctx, conf)
 }
 
 // NewApp creates a new App from the provided config and client options.
@@ -85,7 +83,6 @@ func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*
 	}
 
 	return &App{
-		ctx:       ctx,
 		creds:     creds,
 		projectID: pid,
 		opts:      o,

--- a/firebase.go
+++ b/firebase.go
@@ -20,6 +20,7 @@ package firebase
 import (
 	"firebase.google.com/go/auth"
 	"firebase.google.com/go/internal"
+	"firebase.google.com/go/storage"
 
 	"os"
 
@@ -30,6 +31,7 @@ import (
 )
 
 var firebaseScopes = []string{
+	"https://www.googleapis.com/auth/devstorage.full_control",
 	"https://www.googleapis.com/auth/firebase",
 	"https://www.googleapis.com/auth/userinfo.email",
 }
@@ -39,14 +41,16 @@ const Version = "1.0.2"
 
 // An App holds configuration and state common to all Firebase services that are exposed from the SDK.
 type App struct {
-	creds     *google.DefaultCredentials
-	projectID string
-	opts      []option.ClientOption
+	creds         *google.DefaultCredentials
+	projectID     string
+	storageBucket string
+	opts          []option.ClientOption
 }
 
 // Config represents the configuration used to initialize an App.
 type Config struct {
-	ProjectID string
+	ProjectID     string
+	StorageBucket string
 }
 
 // Auth returns an instance of auth.Client.
@@ -57,6 +61,15 @@ func (a *App) Auth(ctx context.Context) (*auth.Client, error) {
 		Opts:      a.opts,
 	}
 	return auth.NewClient(ctx, conf)
+}
+
+// Storage returns a new instance of storage.Client.
+func (a *App) Storage(ctx context.Context) (*storage.Client, error) {
+	conf := &internal.StorageConfig{
+		Opts:   a.opts,
+		Bucket: a.storageBucket,
+	}
+	return storage.NewClient(ctx, conf)
 }
 
 // NewApp creates a new App from the provided config and client options.
@@ -73,8 +86,12 @@ func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*
 		return nil, err
 	}
 
+	if config == nil {
+		config = &Config{}
+	}
+
 	var pid string
-	if config != nil && config.ProjectID != "" {
+	if config.ProjectID != "" {
 		pid = config.ProjectID
 	} else if creds.ProjectID != "" {
 		pid = creds.ProjectID
@@ -83,8 +100,9 @@ func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*
 	}
 
 	return &App{
-		creds:     creds,
-		projectID: pid,
-		opts:      o,
+		creds:         creds,
+		projectID:     pid,
+		storageBucket: config.StorageBucket,
+		opts:          o,
 	}, nil
 }

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -216,6 +216,18 @@ func TestAuth(t *testing.T) {
 	}
 }
 
+func TestStorage(t *testing.T) {
+	ctx := context.Background()
+	app, err := NewApp(ctx, nil, option.WithCredentialsFile("testdata/service_account.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c, err := app.Storage(ctx); c == nil || err != nil {
+		t.Errorf("Storage() = (%v, %v); want (auth, nil)", c, err)
+	}
+}
+
 func TestCustomTokenSource(t *testing.T) {
 	ctx := context.Background()
 	ts := &testTokenSource{AccessToken: "mock-token-from-custom"}

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -40,7 +40,18 @@ func TestServiceAcctFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	verifyServiceAcct(t, app)
+
+	if app.projectID != "mock-project-id" {
+		t.Errorf("Project ID: %q; want: %q", app.projectID, "mock-project-id")
+	}
+	if len(app.opts) != 2 {
+		t.Errorf("Client opts: %d; want: 2", len(app.opts))
+	}
+	if app.creds == nil {
+		t.Error("Credentials: nil; want creds")
+	} else if len(app.creds.JSON) == 0 {
+		t.Error("JSON: empty; want; non-empty")
+	}
 }
 
 func TestClientOptions(t *testing.T) {
@@ -90,8 +101,10 @@ func TestRefreshTokenFile(t *testing.T) {
 	if len(app.opts) != 2 {
 		t.Errorf("Client opts: %d; want: 2", len(app.opts))
 	}
-	if app.ctx == nil {
-		t.Error("Context: nil; want: ctx")
+	if app.creds == nil {
+		t.Error("Credentials: nil; want creds")
+	} else if len(app.creds.JSON) == 0 {
+		t.Error("JSON: empty; want; non-empty")
 	}
 }
 
@@ -107,8 +120,10 @@ func TestRefreshTokenFileWithConfig(t *testing.T) {
 	if len(app.opts) != 2 {
 		t.Errorf("Client opts: %d; want: 2", len(app.opts))
 	}
-	if app.ctx == nil {
-		t.Error("Context: nil; want: ctx")
+	if app.creds == nil {
+		t.Error("Credentials: nil; want creds")
+	} else if len(app.creds.JSON) == 0 {
+		t.Error("JSON: empty; want; non-empty")
 	}
 }
 
@@ -128,11 +143,10 @@ func TestRefreshTokenWithEnvVar(t *testing.T) {
 	if app.projectID != "mock-project-id" {
 		t.Errorf("Project ID: %q; want: mock-project-id", app.projectID)
 	}
-	if len(app.opts) != 2 {
-		t.Errorf("Client opts: %d; want: 2", len(app.opts))
-	}
-	if app.ctx == nil {
-		t.Error("Context: nil; want: ctx")
+	if app.creds == nil {
+		t.Error("Credentials: nil; want creds")
+	} else if len(app.creds.JSON) == 0 {
+		t.Error("JSON: empty; want; non-empty")
 	}
 }
 
@@ -145,8 +159,7 @@ func TestAppDefault(t *testing.T) {
 	}
 	defer os.Setenv(varName, current)
 
-	ctx := context.Background()
-	app, err := NewApp(ctx, nil)
+	app, err := NewApp(context.Background(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,8 +167,10 @@ func TestAppDefault(t *testing.T) {
 	if len(app.opts) != 1 {
 		t.Errorf("Client opts: %d; want: 1", len(app.opts))
 	}
-	if app.ctx == nil {
-		t.Error("Context: nil; want: ctx")
+	if app.creds == nil {
+		t.Error("Credentials: nil; want creds")
+	} else if len(app.creds.JSON) == 0 {
+		t.Error("JSON: empty; want; non-empty")
 	}
 }
 
@@ -190,12 +205,13 @@ func TestInvalidCredentialFile(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	app, err := NewApp(context.Background(), nil, option.WithCredentialsFile("testdata/service_account.json"))
+	ctx := context.Background()
+	app, err := NewApp(ctx, nil, option.WithCredentialsFile("testdata/service_account.json"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if c, err := app.Auth(); c == nil || err != nil {
+	if c, err := app.Auth(ctx); c == nil || err != nil {
 		t.Errorf("Auth() = (%v, %v); want (auth, nil)", c, err)
 	}
 }
@@ -255,19 +271,6 @@ func (t *testTokenSource) Token() (*oauth2.Token, error) {
 		AccessToken: t.AccessToken,
 		Expiry:      t.Expiry,
 	}, nil
-}
-
-func verifyServiceAcct(t *testing.T, app *App) {
-	// TODO: Compare creds JSON
-	if app.projectID != "mock-project-id" {
-		t.Errorf("Project ID: %q; want: %q", app.projectID, "mock-project-id")
-	}
-	if len(app.opts) != 2 {
-		t.Errorf("Client opts: %d; want: 2", len(app.opts))
-	}
-	if app.ctx == nil {
-		t.Error("Context: nil; want: ctx")
-	}
 }
 
 // mockServiceAcct generates a service account configuration with the provided URL as the

--- a/integration/auth/auth_test.go
+++ b/integration/auth/auth_test.go
@@ -43,12 +43,13 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
-	app, err := internal.NewTestApp(context.Background())
+	ctx := context.Background()
+	app, err := internal.NewTestApp(ctx)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	client, err = app.Auth()
+	client, err = app.Auth(ctx)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -139,5 +140,8 @@ func postRequest(url string, req []byte) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected http status code: %d", resp.StatusCode)
+	}
 	return ioutil.ReadAll(resp.Body)
 }

--- a/integration/storage/storage_test.go
+++ b/integration/storage/storage_test.go
@@ -1,0 +1,123 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	gcs "cloud.google.com/go/storage"
+	"firebase.google.com/go/integration/internal"
+	"firebase.google.com/go/storage"
+	"golang.org/x/net/context"
+)
+
+var ctx context.Context
+var client *storage.Client
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		log.Println("skipping storage integration tests in short mode.")
+		os.Exit(0)
+	}
+
+	ctx = context.Background()
+	app, err := internal.NewTestApp(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	client, err = app.Storage(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestDefaultBucket(t *testing.T) {
+	bucket, err := client.DefaultBucket()
+	if bucket == nil || err != nil {
+		t.Errorf("DefaultBucket() = (%v, %v); want (bucket, nil)", bucket, err)
+	}
+	if err := verifyBucket(bucket); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCustomBucket(t *testing.T) {
+	pid, err := internal.ProjectID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bucket, err := client.Bucket(pid + ".appspot.com")
+	if bucket == nil || err != nil {
+		t.Errorf("Bucket() = (%v, %v); want (bucket, nil)", bucket, err)
+	}
+	if err := verifyBucket(bucket); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNonExistingBucket(t *testing.T) {
+	bucket, err := client.Bucket("non-existing")
+	if bucket == nil || err != nil {
+		t.Errorf("Bucket() = (%v, %v); want (bucket, nil)", bucket, err)
+	}
+	if _, err := bucket.Attrs(context.Background()); err == nil {
+		t.Errorf("bucket.Attr() = nil; want error")
+	}
+}
+
+func verifyBucket(bucket *gcs.BucketHandle) error {
+	const expected = "Hello World"
+
+	// Create new object
+	o := bucket.Object("data")
+	w := o.NewWriter(ctx)
+	w.ContentType = "text/plain"
+	if _, err := w.Write([]byte(expected)); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+
+	// Read the created object
+	r, err := o.NewReader(ctx)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if string(b) != expected {
+		return fmt.Errorf("fetched content: %q; want: %q", string(b), expected)
+	}
+
+	// Delete the object
+	if err := o.Delete(ctx); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -27,3 +27,9 @@ type AuthConfig struct {
 	Creds     *google.DefaultCredentials
 	ProjectID string
 }
+
+// StorageConfig represents the configuration of Google Cloud Storage service.
+type StorageConfig struct {
+	Opts   []option.ClientOption
+	Bucket string
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -16,7 +16,6 @@
 package internal
 
 import (
-	"golang.org/x/net/context"
 	"google.golang.org/api/option"
 
 	"golang.org/x/oauth2/google"
@@ -24,7 +23,6 @@ import (
 
 // AuthConfig represents the configuration of Firebase Auth service.
 type AuthConfig struct {
-	Ctx       context.Context
 	Opts      []option.ClientOption
 	Creds     *google.DefaultCredentials
 	ProjectID string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,58 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package storage provides functions for accessing Google Cloud Storge buckets.
+package storage
+
+import (
+	"context"
+	"errors"
+
+	"cloud.google.com/go/storage"
+	"firebase.google.com/go/internal"
+)
+
+// Client is the interface for the Firebase Storage service.
+type Client struct {
+	client *storage.Client
+	bucket string
+}
+
+// NewClient creates a new instance of the Firebase Storage Client.
+//
+// This function can only be invoked from within the SDK. Client applications should access the
+// the Storage service through firebase.App.
+func NewClient(ctx context.Context, c *internal.StorageConfig) (*Client, error) {
+	client, err := storage.NewClient(ctx, c.Opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{client: client, bucket: c.Bucket}, nil
+}
+
+// DefaultBucket returns a handle to the default Cloud Storage bucket.
+//
+// To use this method, the default bucket name must be specified via firebase.Config when
+// initializing the App.
+func (c *Client) DefaultBucket() (*storage.BucketHandle, error) {
+	return c.Bucket(c.bucket)
+}
+
+// Bucket returns a handle to the specified Cloud Storage bucket.
+func (c *Client) Bucket(name string) (*storage.BucketHandle, error) {
+	if name == "" {
+		return nil, errors.New("bucket name not specified")
+	}
+	return c.client.Bucket(name), nil
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -17,12 +17,20 @@ package storage
 import (
 	"testing"
 
+	"google.golang.org/api/option"
+
 	"firebase.google.com/go/internal"
 	"golang.org/x/net/context"
 )
 
+var opts = []option.ClientOption{
+	option.WithCredentialsFile("../testdata/service_account.json"),
+}
+
 func TestNoBucketName(t *testing.T) {
-	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	client, err := NewClient(context.Background(), &internal.StorageConfig{
+		Opts: opts,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +40,9 @@ func TestNoBucketName(t *testing.T) {
 }
 
 func TestEmptyBucketName(t *testing.T) {
-	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	client, err := NewClient(context.Background(), &internal.StorageConfig{
+		Opts: opts,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,6 +54,7 @@ func TestEmptyBucketName(t *testing.T) {
 func TestDefaultBucket(t *testing.T) {
 	client, err := NewClient(context.Background(), &internal.StorageConfig{
 		Bucket: "bucket.name",
+		Opts:   opts,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"firebase.google.com/go/internal"
+	"golang.org/x/net/context"
+)
+
+func TestNoBucketName(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.DefaultBucket(); err == nil {
+		t.Errorf("DefaultBucket() = nil; want error")
+	}
+}
+
+func TestEmptyBucketName(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Bucket(""); err == nil {
+		t.Errorf("Bucket('') = nil; want error")
+	}
+}
+
+func TestDefaultBucket(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.StorageConfig{
+		Bucket: "bucket.name",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucket, err := client.DefaultBucket()
+	if bucket == nil || err != nil {
+		t.Errorf("DefaultBucket() = (%v, %v); want: (bucket, nil)", bucket, err)
+	}
+
+}
+
+func TestBucket(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucket, err := client.Bucket("bucket.name")
+	if bucket == nil || err != nil {
+		t.Errorf("Bucket() = (%v, %v); want: (bucket, nil)", bucket, err)
+	}
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -67,7 +67,9 @@ func TestDefaultBucket(t *testing.T) {
 }
 
 func TestBucket(t *testing.T) {
-	client, err := NewClient(context.Background(), &internal.StorageConfig{})
+	client, err := NewClient(context.Background(), &internal.StorageConfig{
+		Opts: opts,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Implemented support for:
* Specifying a GCS bucket name when creating an `App`.
* Initializing a `storage.Client` instance from an `App`.
* Initializing an authenticated reference to a GCS bucket

```
conf := &firebase.Config{StorageBucket: "bucket-name"}
app, err := firebase.NewApp(ctx, conf)
if err != nil {
  return
}

gcs, err := app.Storage(ctx)
if err != nil {
  return
}

bucket, err := gcs.DefaultBucket()
```

This PR also changes the existing `app.Auth()` function to accept a context. With this we no longer have to store/cache a context within the `App`.