### PR TITLE
Reusable HTTP Client API

### DIFF
--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package internal contains functionality that is only accessible from within the Admin SDK.
 package internal
 
 import (

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -16,12 +16,13 @@ package internal
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+
+	"golang.org/x/net/context"
 )
 
 // Null represents JSON null value.

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -1,0 +1,138 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal contains functionality that is only accessible from within the Admin SDK.
+package internal
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+type Request struct {
+	Method string
+	URL    string
+	Body   interface{}
+	Opts   []HTTPOption
+}
+
+func (r *Request) Send(ctx context.Context, hc *http.Client) (*Response, error) {
+	req, err := r.newHTTPRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := hc.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &Response{
+		Status: resp.StatusCode,
+		Body:   b,
+		Header: resp.Header,
+	}, nil
+}
+
+func (r *Request) newHTTPRequest() (*http.Request, error) {
+	var opts []HTTPOption
+	var data io.Reader
+	if r.Body != nil {
+		b, err := json.Marshal(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		data = bytes.NewBuffer(b)
+		opts = append(opts, WithHeader("Content-Type", "application/json"))
+	}
+
+	req, err := http.NewRequest(r.Method, r.URL, data)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, r.Opts...)
+	for _, o := range opts {
+		o(req)
+	}
+	return req, nil
+}
+
+type Response struct {
+	Status int
+	Header http.Header
+	Body   []byte
+}
+
+func (r *Response) CheckStatus(want int, ep ErrorParser) error {
+	if r.Status == want {
+		return nil
+	}
+
+	var msg string
+	if ep != nil {
+		msg = ep(r)
+	}
+	if msg == "" {
+		msg = string(r.Body)
+	}
+	return fmt.Errorf("http error status: %d; reason: %s", r.Status, msg)
+}
+
+func (r *Response) Unmarshal(want int, ep ErrorParser, v interface{}) error {
+	if err := r.CheckStatus(want, ep); err != nil {
+		return err
+	} else if err := json.Unmarshal(r.Body, v); err != nil {
+		return err
+	}
+	return nil
+}
+
+type ErrorParser func(r *Response) string
+
+type HTTPOption func(*http.Request)
+
+func WithHeader(key, value string) HTTPOption {
+	return func(r *http.Request) {
+		r.Header.Set(key, value)
+	}
+}
+
+func WithQueryParam(key, value string) HTTPOption {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		q.Add(key, value)
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
+func WithQueryParams(qp map[string]string) HTTPOption {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		for k, v := range qp {
+			q.Add(k, v)
+		}
+		r.URL.RawQuery = q.Encode()
+	}
+}

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -39,7 +39,7 @@ type HTTPClient struct {
 
 // Do executes the given Request, and returns a Response.
 func (c *HTTPClient) Do(ctx context.Context, r *Request) (*Response, error) {
-	req, err := r.newHTTPRequest()
+	req, err := r.buildHTTPRequest()
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ type Request struct {
 	Opts   []HTTPOption
 }
 
-func (r *Request) newHTTPRequest() (*http.Request, error) {
+func (r *Request) buildHTTPRequest() (*http.Request, error) {
 	var opts []HTTPOption
 	var data io.Reader
 	if r.Body != nil {

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -152,7 +152,8 @@ func (r *Response) CheckStatus(want int) error {
 func (r *Response) Unmarshal(want int, v interface{}) error {
 	if err := r.CheckStatus(want); err != nil {
 		return err
-	} else if err := json.Unmarshal(r.Body, v); err != nil {
+	}
+	if err := json.Unmarshal(r.Body, v); err != nil {
 		return err
 	}
 	return nil

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -14,13 +14,14 @@
 package internal
 
 import (
-	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 var cases = []struct {

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -1,3 +1,16 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package internal
 
 import (

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -149,7 +149,7 @@ func TestHTTPClient(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	client := &HTTPClient{HC: http.DefaultClient}
+	client := &HTTPClient{Client: http.DefaultClient}
 	for _, tc := range cases {
 		tc.req.URL = server.URL
 		resp, err := client.Do(context.Background(), tc.req)
@@ -200,8 +200,8 @@ func TestErrorParser(t *testing.T) {
 		return p.Error
 	}
 	client := &HTTPClient{
-		HC: http.DefaultClient,
-		EP: ep,
+		Client:    http.DefaultClient,
+		ErrParser: ep,
 	}
 	req := &Request{Method: "GET", URL: server.URL}
 	resp, err := client.Do(context.Background(), req)
@@ -227,7 +227,7 @@ func TestInvalidURL(t *testing.T) {
 		Method: "GET",
 		URL:    "http://localhost:250/mock.url",
 	}
-	client := &HTTPClient{HC: http.DefaultClient}
+	client := &HTTPClient{Client: http.DefaultClient}
 	_, err := client.Do(context.Background(), req)
 	if err == nil {
 		t.Errorf("Send() = nil; want error")
@@ -251,7 +251,7 @@ func TestUnmarshalError(t *testing.T) {
 	defer server.Close()
 
 	req := &Request{Method: "GET", URL: server.URL}
-	client := &HTTPClient{HC: http.DefaultClient}
+	client := &HTTPClient{Client: http.DefaultClient}
 	resp, err := client.Do(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -1,0 +1,259 @@
+package internal
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+var cases = []struct {
+	req     *Request
+	method  string
+	body    interface{}
+	headers map[string]string
+	query   map[string]string
+}{
+	{
+		req: &Request{
+			Method: "GET",
+		},
+		method: "GET",
+	},
+	{
+		req: &Request{
+			Method: "GET",
+			Opts: []HTTPOption{
+				WithHeader("Test-Header", "value1"),
+				WithQueryParam("testParam", "value2"),
+			},
+		},
+		method:  "GET",
+		headers: map[string]string{"Test-Header": "value1"},
+		query:   map[string]string{"testParam": "value2"},
+	},
+	{
+		req: &Request{
+			Method: "POST",
+			Body:   map[string]string{"foo": "bar"},
+			Opts: []HTTPOption{
+				WithHeader("Test-Header", "value1"),
+				WithQueryParam("testParam1", "value2"),
+				WithQueryParam("testParam2", "value3"),
+			},
+		},
+		method:  "POST",
+		body:    map[string]string{"foo": "bar"},
+		headers: map[string]string{"Test-Header": "value1"},
+		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
+	},
+	{
+		req: &Request{
+			Method: "POST",
+			Body:   "body",
+			Opts: []HTTPOption{
+				WithHeader("Test-Header", "value1"),
+				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
+			},
+		},
+		method:  "POST",
+		body:    "body",
+		headers: map[string]string{"Test-Header": "value1"},
+		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
+	},
+	{
+		req: &Request{
+			Method: "PUT",
+			Body:   Null,
+			Opts: []HTTPOption{
+				WithHeader("Test-Header", "value1"),
+				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
+			},
+		},
+		method:  "PUT",
+		body:    Null,
+		headers: map[string]string{"Test-Header": "value1"},
+		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
+	},
+}
+
+func TestSend(t *testing.T) {
+	want := map[string]interface{}{
+		"key1": "value1",
+		"key2": float64(100),
+	}
+	b, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idx := 0
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := cases[idx]
+		if r.Method != want.method {
+			t.Errorf("[%d] Method = %q; want = %q", idx, r.Method, want.method)
+		}
+		for k, v := range want.headers {
+			h := r.Header.Get(k)
+			if h != v {
+				t.Errorf("[%d] Header(%q) = %q; want = %q", idx, k, h, v)
+			}
+		}
+		if want.query == nil {
+			if r.URL.Query().Encode() != "" {
+				t.Errorf("[%d] Query = %v; want = empty", idx, r.URL.Query().Encode())
+			}
+		}
+		for k, v := range want.query {
+			q := r.URL.Query().Get(k)
+			if q != v {
+				t.Errorf("[%d] Query(%q) = %q; want = %q", idx, k, q, v)
+			}
+		}
+		if want.body != nil {
+			h := r.Header.Get("Content-Type")
+			if h != "application/json" {
+				t.Errorf("[%d] Content-Type = %q; want = %q", idx, h, "application/json")
+			}
+
+			var wb []byte
+			if want.body == Null {
+				wb = []byte("null")
+			} else {
+				wb, err = json.Marshal(want.body)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			gb, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(wb, gb) {
+				t.Errorf("[%d] Body = %q; want = %q", idx, string(gb), string(wb))
+			}
+		}
+
+		idx++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	for _, tc := range cases {
+		tc.req.URL = server.URL
+		resp, err := tc.req.Send(context.Background(), http.DefaultClient)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := resp.CheckStatus(http.StatusOK, nil); err != nil {
+			t.Errorf("CheckStatus() = %v; want nil", err)
+		}
+		if err := resp.CheckStatus(http.StatusCreated, nil); err == nil {
+			t.Errorf("CheckStatus() = nil; want error")
+		}
+
+		var got map[string]interface{}
+		if err := resp.Unmarshal(http.StatusOK, nil, &got); err != nil {
+			t.Errorf("Unmarshal() = %v; want nil", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("Body = %v; want = %v", got, want)
+		}
+	}
+}
+
+func TestErrorParser(t *testing.T) {
+	data := map[string]interface{}{
+		"error": "test error",
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req := &Request{
+		Method: "GET",
+		URL:    server.URL,
+	}
+	resp, err := req.Send(context.Background(), http.DefaultClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ep := func(r *Response) string {
+		var b struct {
+			Error string `json:"error"`
+		}
+		if err := json.Unmarshal(r.Body, &b); err != nil {
+			return ""
+		}
+		return b.Error
+	}
+
+	want := "http error status: 500; reason: test error"
+	if err := resp.CheckStatus(http.StatusOK, ep); err.Error() != want {
+		t.Errorf("CheckStatus() = %q; want = %q", err.Error(), want)
+	}
+	var got map[string]interface{}
+	if err := resp.Unmarshal(http.StatusOK, ep, &got); err.Error() != want {
+		t.Errorf("CheckStatus() = %q; want = %q", err.Error(), want)
+	}
+	if got != nil {
+		t.Errorf("Body = %v; want = nil", got)
+	}
+}
+
+func TestInvalidURL(t *testing.T) {
+	req := &Request{
+		Method: "GET",
+		URL:    "http://localhost:250/mock.url",
+	}
+	_, err := req.Send(context.Background(), http.DefaultClient)
+	if err == nil {
+		t.Errorf("Send() = nil; want error")
+	}
+}
+
+func TestUnmarshalError(t *testing.T) {
+	data := map[string]interface{}{
+		"foo": "bar",
+	}
+	b, err := json.Marshal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(b)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	req := &Request{
+		Method: "GET",
+		URL:    server.URL,
+	}
+	resp, err := req.Send(context.Background(), http.DefaultClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got func()
+	if err := resp.Unmarshal(http.StatusOK, nil, &got); err == nil {
+		t.Errorf("Unmarshal() = nil; want error")
+	}
+}

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -27,7 +27,7 @@ import (
 var cases = []struct {
 	req     *Request
 	method  string
-	body    interface{}
+	body    string
 	headers map[string]string
 	query   map[string]string
 }{
@@ -52,7 +52,7 @@ var cases = []struct {
 	{
 		req: &Request{
 			Method: "POST",
-			Body:   map[string]string{"foo": "bar"},
+			Body:   NewJSONEntity(map[string]string{"foo": "bar"}),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParam("testParam1", "value2"),
@@ -60,35 +60,35 @@ var cases = []struct {
 			},
 		},
 		method:  "POST",
-		body:    map[string]string{"foo": "bar"},
+		body:    "{\"foo\":\"bar\"}",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
 	},
 	{
 		req: &Request{
 			Method: "POST",
-			Body:   "body",
+			Body:   NewJSONEntity("body"),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
 			},
 		},
 		method:  "POST",
-		body:    "body",
+		body:    "\"body\"",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
 	},
 	{
 		req: &Request{
 			Method: "PUT",
-			Body:   Null,
+			Body:   NewJSONEntity(nil),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
 			},
 		},
 		method:  "PUT",
-		body:    Null,
+		body:    "null",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
 	},
@@ -127,21 +127,12 @@ func TestHTTPClient(t *testing.T) {
 				t.Errorf("[%d] Query(%q) = %q; want = %q", idx, k, q, v)
 			}
 		}
-		if want.body != nil {
+		if want.body != "" {
 			h := r.Header.Get("Content-Type")
 			if h != "application/json" {
 				t.Errorf("[%d] Content-Type = %q; want = %q", idx, h, "application/json")
 			}
-
-			var wb []byte
-			if want.body == Null {
-				wb = []byte("null")
-			} else {
-				wb, err = json.Marshal(want.body)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
+			wb := []byte(want.body)
 			gb, err := ioutil.ReadAll(r.Body)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Now that we are working on implementing RTDB and user management APIs, we need some API/framework to make JSON+HTTP requests easily. Therefore I'm adding this new internal API.

Usage:
```
client := &internal.HTTPClient{HC: hc}

// Simple GET request
req := &internal.Request{
  Method: "GET",
  URL: someURL,
}
resp, err := client.Do(ctx, req)
var m map[string]interface{}
err := resp.Unmarshal(http.StatusOK, &m)
```

```
// POST request with headers
req := &internal.Request{
  Method: "POST",
  URL: someURL,
  Body: jsonMap,
  Opts: []internal.HTTPOption{internal.WithHeader("Name", "Value")},
}
resp, err := client.Do(ctx, req)
var m map[string]interface{}
err := resp.Unmarshal(http.StatusOK, &m)
```