### PR TITLE
Implemented IID Delete API

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -23,6 +23,7 @@ import (
 	"cloud.google.com/go/firestore"
 
 	"firebase.google.com/go/auth"
+	"firebase.google.com/go/iid"
 	"firebase.google.com/go/internal"
 	"firebase.google.com/go/storage"
 
@@ -85,6 +86,15 @@ func (a *App) Firestore(ctx context.Context) (*firestore.Client, error) {
 		return nil, errors.New("project id is required to access Firestore")
 	}
 	return firestore.NewClient(ctx, a.projectID, a.opts...)
+}
+
+// InstanceID returns an instance of iid.Client.
+func (a *App) InstanceID(ctx context.Context) (*iid.Client, error) {
+	conf := &internal.InstanceIDConfig{
+		ProjectID: a.projectID,
+		Opts:      a.opts,
+	}
+	return iid.NewClient(ctx, conf)
 }
 
 // NewApp creates a new App from the provided config and client options.

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -281,6 +281,18 @@ func TestFirestoreWithNoProjectID(t *testing.T) {
 	}
 }
 
+func TestInstanceID(t *testing.T) {
+	ctx := context.Background()
+	app, err := NewApp(ctx, nil, option.WithCredentialsFile("testdata/service_account.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c, err := app.InstanceID(ctx); c == nil || err != nil {
+		t.Errorf("InstanceID() = (%v, %v); want (iid, nil)", c, err)
+	}
+}
+
 func TestCustomTokenSource(t *testing.T) {
 	ctx := context.Background()
 	ts := &testTokenSource{AccessToken: "mock-token-from-custom"}

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -29,8 +29,9 @@ import (
 
 const iidEndpoint = "https://console.firebase.google.com/v1"
 
-// Client is the interface for the Firebase instance ID service.
+// Client is the interface for the Firebase Instance ID service.
 type Client struct {
+	// To enable testing against arbitrary endpoints.
 	endpoint string
 	client   *internal.HTTPClient
 	project  string

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -29,6 +29,17 @@ import (
 
 const iidEndpoint = "https://console.firebase.google.com/v1"
 
+var errorCodes = map[int]string{
+	400: "Invalid argument. Instance ID %q is malformed.",
+	401: "Request not authorized.",
+	403: "Permission denied. Project does not match instance ID or the client does not have sufficient privileges.",
+	404: "Failed to find the instance ID: %q.",
+	409: "Instance ID %q is already deleted.",
+	429: "Request throttled out by the backend server.",
+	500: "Internal server error.",
+	503: "Backend servers are over capacity. Try again later.",
+}
+
 // Client is the interface for the Firebase Instance ID service.
 type Client struct {
 	// To enable testing against arbitrary endpoints.
@@ -71,6 +82,10 @@ func (c *Client) DeleteInstanceID(ctx context.Context, iid string) error {
 	resp, err := c.client.Do(ctx, &internal.Request{Method: "DELETE", URL: url})
 	if err != nil {
 		return err
+	}
+
+	if msg, ok := errorCodes[resp.Status]; ok {
+		return fmt.Errorf(msg, iid)
 	}
 	return resp.CheckStatus(http.StatusOK)
 }

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -71,8 +71,5 @@ func (c *Client) DeleteInstanceID(ctx context.Context, iid string) error {
 	if err != nil {
 		return err
 	}
-	if err := resp.CheckStatus(http.StatusOK); err != nil {
-		return err
-	}
-	return nil
+	return resp.CheckStatus(http.StatusOK)
 }

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package iid contains functions for deleting instance IDs from Firebase projects.
+package iid
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"google.golang.org/api/transport"
+
+	"firebase.google.com/go/internal"
+
+	"golang.org/x/net/context"
+)
+
+const iidEndpoint = "https://console.firebase.google.com/v1"
+
+// Client is the interface for the Firebase instance ID service.
+type Client struct {
+	endpoint string
+	client   *internal.HTTPClient
+	project  string
+}
+
+// NewClient creates a new instance of the Firebase instance ID Client.
+//
+// This function can only be invoked from within the SDK. Client applications should access the
+// the instance ID service through firebase.App.
+func NewClient(ctx context.Context, c *internal.InstanceIDConfig) (*Client, error) {
+	if c.ProjectID == "" {
+		return nil, errors.New("project id is required to access instance id client")
+	}
+
+	hc, _, err := transport.NewHTTPClient(ctx, c.Opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		endpoint: iidEndpoint,
+		client:   &internal.HTTPClient{Client: hc},
+		project:  c.ProjectID,
+	}, nil
+}
+
+// DeleteInstanceID deletes an instance ID from Firebase.
+//
+// This can be used to delete an instance ID and associated user data from a Firebase project,
+// pursuant to the General Data protection Regulation (GDPR).
+func (c *Client) DeleteInstanceID(ctx context.Context, iid string) error {
+	if iid == "" {
+		return errors.New("instance id must not be empty")
+	}
+
+	url := fmt.Sprintf("%s/project/%s/instanceId/%s", c.endpoint, c.project, iid)
+	resp, err := c.client.Do(ctx, &internal.Request{Method: "DELETE", URL: url})
+	if err != nil {
+		return err
+	}
+	if err := resp.CheckStatus(http.StatusOK); err != nil {
+		return err
+	}
+	return nil
+}

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -30,14 +30,14 @@ import (
 const iidEndpoint = "https://console.firebase.google.com/v1"
 
 var errorCodes = map[int]string{
-	400: "Invalid argument. Instance ID %q is malformed.",
-	401: "Request not authorized.",
-	403: "Permission denied. Project does not match instance ID or the client does not have sufficient privileges.",
-	404: "Failed to find the instance ID: %q.",
-	409: "Instance ID %q is already deleted.",
-	429: "Request throttled out by the backend server.",
-	500: "Internal server error.",
-	503: "Backend servers are over capacity. Try again later.",
+	400: "malformed instance id argument",
+	401: "request not authorized",
+	403: "project does not match instance ID or the client does not have sufficient privileges",
+	404: "failed to find the instance id",
+	409: "already deleted",
+	429: "request throttled out by the backend server",
+	500: "internal server error",
+	503: "backend servers are over capacity",
 }
 
 // Client is the interface for the Firebase Instance ID service.
@@ -85,7 +85,7 @@ func (c *Client) DeleteInstanceID(ctx context.Context, iid string) error {
 	}
 
 	if msg, ok := errorCodes[resp.Status]; ok {
-		return fmt.Errorf(msg, iid)
+		return fmt.Errorf("instance id %q: %s", iid, msg)
 	}
 	return resp.CheckStatus(http.StatusOK)
 }

--- a/iid/iid_test.go
+++ b/iid/iid_test.go
@@ -111,7 +111,7 @@ func TestDeleteInstanceIDError(t *testing.T) {
 			t.Fatal("DeleteInstanceID() = nil; want = error")
 		}
 
-		want := fmt.Sprintf(v, "test-iid")
+		want := fmt.Sprintf("instance id %q: %s", "test-iid", v)
 		if err.Error() != want {
 			t.Errorf("DeleteInstanceID() = %v; want = %v", err, want)
 		}

--- a/iid/iid_test.go
+++ b/iid/iid_test.go
@@ -1,0 +1,139 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iid
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+
+	"firebase.google.com/go/internal"
+
+	"golang.org/x/net/context"
+)
+
+var testIIDConfig = &internal.InstanceIDConfig{
+	ProjectID: "test-project",
+	Opts: []option.ClientOption{
+		option.WithTokenSource(&internal.MockTokenSource{AccessToken: "test-token"}),
+	},
+}
+
+func TestNoProjectID(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.InstanceIDConfig{})
+	if client != nil || err == nil {
+		t.Errorf("NewClient() = (%v, %v); want = (nil, error)", client, err)
+	}
+}
+
+func TestInvalidInstanceID(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, testIIDConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client.DeleteInstanceID(ctx, ""); err == nil {
+		t.Errorf("DeleteInstanceID(empty) = nil; want error")
+	}
+}
+
+func TestDeleteInstanceID(t *testing.T) {
+	var tr *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testIIDConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.endpoint = ts.URL
+	if err := client.DeleteInstanceID(ctx, "test-iid"); err != nil {
+		t.Errorf("DeleteInstanceID() = %v; want nil", err)
+	}
+
+	if tr == nil {
+		t.Fatalf("Request = nil; want non-nil")
+	}
+	if tr.Method != "DELETE" {
+		t.Errorf("Method = %q; want = %q", tr.Method, "DELETE")
+	}
+	if tr.URL.Path != "/project/test-project/instanceId/test-iid" {
+		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/project/test-project/instanceId/test-iid")
+	}
+	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+	}
+}
+
+func TestDeleteInstanceIDError(t *testing.T) {
+	var tr *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		w.WriteHeader(500)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testIIDConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.endpoint = ts.URL
+	if err := client.DeleteInstanceID(ctx, "test-iid"); err == nil {
+		t.Errorf("DeleteInstanceID() = nil; want = error")
+		return
+	}
+
+	if tr == nil {
+		t.Fatalf("Request = nil; want non-nil")
+	}
+	if tr.Method != "DELETE" {
+		t.Errorf("Method = %q; want = %q", tr.Method, "DELETE")
+	}
+	if tr.URL.Path != "/project/test-project/instanceId/test-iid" {
+		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/project/test-project/instanceId/test-iid")
+	}
+	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+	}
+}
+
+func TestDeleteInstanceIDConnectionError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Do nothing
+	}))
+	ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testIIDConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.endpoint = ts.URL
+	if err := client.DeleteInstanceID(ctx, "test-iid"); err == nil {
+		t.Errorf("DeleteInstanceID() = nil; want = error")
+		return
+	}
+}

--- a/integration/iid/iid_test.go
+++ b/integration/iid/iid_test.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"log"
 	"os"
-	"strings"
 	"testing"
 
 	"firebase.google.com/go/iid"
@@ -55,7 +54,8 @@ func TestNonExisting(t *testing.T) {
 	if err == nil {
 		t.Errorf("DeleteInstanceID(non-existing) = nil; want error")
 	}
-	if !strings.HasPrefix(err.Error(), "http error status: 404") {
-		t.Errorf("DeleteInstanceID(non-existing) = %v; want = 404", err)
+	want := `Failed to find the instance ID: "non-existing".`
+	if err.Error() != want {
+		t.Errorf("DeleteInstanceID(non-existing) = %v; want = %v", err, want)
 	}
 }

--- a/integration/iid/iid_test.go
+++ b/integration/iid/iid_test.go
@@ -1,0 +1,59 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package iid contains integration tests for the firebase.google.com/go/iid package.
+package iid
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"firebase.google.com/go/iid"
+	"firebase.google.com/go/integration/internal"
+)
+
+var client *iid.Client
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		log.Println("skipping instance ID integration tests in short mode.")
+		os.Exit(0)
+	}
+
+	ctx := context.Background()
+	app, err := internal.NewTestApp(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	client, err = app.InstanceID(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func TestNonExisting(t *testing.T) {
+	if err := client.DeleteInstanceID(context.Background(), "non-existing"); err == nil {
+		t.Errorf("DeleteInstanceID(non-existing) = nil; want error")
+	} else {
+		fmt.Println(err)
+	}
+}

--- a/integration/iid/iid_test.go
+++ b/integration/iid/iid_test.go
@@ -18,9 +18,9 @@ package iid
 import (
 	"context"
 	"flag"
-	"fmt"
 	"log"
 	"os"
+	"strings"
 	"testing"
 
 	"firebase.google.com/go/iid"
@@ -51,9 +51,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestNonExisting(t *testing.T) {
-	if err := client.DeleteInstanceID(context.Background(), "non-existing"); err == nil {
+	err := client.DeleteInstanceID(context.Background(), "non-existing")
+	if err == nil {
 		t.Errorf("DeleteInstanceID(non-existing) = nil; want error")
-	} else {
-		fmt.Println(err)
+	}
+	if !strings.HasPrefix(err.Error(), "http error status: 404") {
+		t.Errorf("DeleteInstanceID(non-existing) = %v; want = 404", err)
 	}
 }

--- a/integration/iid/iid_test.go
+++ b/integration/iid/iid_test.go
@@ -54,7 +54,7 @@ func TestNonExisting(t *testing.T) {
 	if err == nil {
 		t.Errorf("DeleteInstanceID(non-existing) = nil; want error")
 	}
-	want := `Failed to find the instance ID: "non-existing".`
+	want := `instance id "non-existing": failed to find the instance id`
 	if err.Error() != want {
 		t.Errorf("DeleteInstanceID(non-existing) = %v; want = %v", err, want)
 	}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -16,6 +16,7 @@
 package internal
 
 import (
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
@@ -27,8 +28,24 @@ type AuthConfig struct {
 	ProjectID string
 }
 
+// InstanceIDConfig represents the configuration of Firebase Instance ID service.
+type InstanceIDConfig struct {
+	Opts      []option.ClientOption
+	ProjectID string
+}
+
 // StorageConfig represents the configuration of Google Cloud Storage service.
 type StorageConfig struct {
 	Opts   []option.ClientOption
 	Bucket string
+}
+
+// MockTokenSource is a TokenSource implementation that can be used for testing.
+type MockTokenSource struct {
+	AccessToken string
+}
+
+// Token returns the test token associated with the TokenSource.
+func (ts *MockTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: ts.AccessToken}, nil
 }


### PR DESCRIPTION
A new API that enables deleting instance IDs associated with a Firebase project.

```
client, err := app.InstanceID(ctx)
if err != nil {
  // handle error
}

if err := client.DeleteInstanceID(iid); err != nil {
  // handle error
}
```

go/firebase-admin-iid