### PR TITLE
Auth Unit Test Improvements

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -38,6 +38,8 @@ import (
 
 var client *Client
 var testIDToken string
+var testGetUserResponse []byte
+var testListUsersResponse []byte
 
 func TestMain(m *testing.M) {
 	var (
@@ -77,6 +79,16 @@ func TestMain(m *testing.M) {
 		log.Fatalln(err)
 	}
 	client.ks = ks
+
+	testGetUserResponse, err = ioutil.ReadFile("../testdata/get_user.json")
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	testListUsersResponse, err = ioutil.ReadFile("../testdata/list_users.json")
+	if err != nil {
+		log.Fatalln(err)
+	}
 
 	testIDToken = getIDToken(nil)
 	os.Exit(m.Run())

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -96,7 +96,7 @@ func (u *UserToCreate) set(key string, value interface{}) {
 }
 
 // Disabled setter.
-func (u *UserToCreate) Disabled(d bool) *UserToCreate { u.set("disableUser", d); return u }
+func (u *UserToCreate) Disabled(d bool) *UserToCreate { u.set("disabled", d); return u }
 
 // DisplayName setter.
 func (u *UserToCreate) DisplayName(dn string) *UserToCreate { u.set("displayName", dn); return u }
@@ -484,7 +484,7 @@ func (c *Client) updateUser(ctx context.Context, uid string, user *UserToUpdate)
 		return err
 	}
 	if user == nil || user.params == nil {
-		return fmt.Errorf("user must not be nil or empty for update")
+		return fmt.Errorf("update parameters must not be nil or empty")
 	}
 	user.params["localId"] = uid
 

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -207,7 +207,7 @@ func TestInvalidCreateUser(t *testing.T) {
 			"uid must not be empty",
 		}, {
 			(&UserToCreate{}).UID(strings.Repeat("a", 129)),
-			"uid must be a string at most 128 characters long",
+			"uid string must not be longer than 128 characters",
 		}, {
 			(&UserToCreate{}).DisplayName(""),
 			"display name must be a non-empty string",
@@ -437,8 +437,14 @@ func TestDeleteUser(t *testing.T) {
 	}`
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
-	if err := s.Client.DeleteUser(context.Background(), ""); err != nil {
-		t.Error(err)
+	if err := s.Client.DeleteUser(context.Background(), "uid"); err != nil {
+		t.Errorf("DeleteUser() = %v; want = nil", err)
+	}
+}
+
+func TestInvalidDeleteUser(t *testing.T) {
+	if err := client.DeleteUser(context.Background(), ""); err == nil {
+		t.Errorf("DeleteUser('') = nil; want = error")
 	}
 }
 
@@ -461,7 +467,7 @@ func TestMakeExportedUser(t *testing.T) {
 			}},
 		PhotoURL:     "http://www.example.com/testuser/photo.png",
 		PasswordHash: "passwordhash",
-		PasswordSalt: "salt===",
+		PasswordSalt: "salt",
 
 		ValidSince:         1494364393,
 		Disabled:           false,
@@ -472,7 +478,7 @@ func TestMakeExportedUser(t *testing.T) {
 	want := &ExportedUserRecord{
 		UserRecord:   testUser,
 		PasswordHash: "passwordhash",
-		PasswordSalt: "salt===",
+		PasswordSalt: "salt",
 	}
 	exported, err := makeExportedUser(rur)
 	if err != nil {
@@ -633,9 +639,8 @@ func TestHTTPError(t *testing.T) {
 	client.url = s.Srv.URL + "/"
 
 	want := `http error status: 500; reason: {"error":"test"}`
-	_, err = client.GetUser(context.Background(), "some uid")
-	if err == nil || err.Error() != want {
-		t.Errorf("got error = %v; want: `%v`", err, want)
+	if _, err = client.GetUser(context.Background(), "some uid"); err == nil || err.Error() != want {
+		t.Errorf("GetUser() = %v; want: `%v`", err, want)
 	}
 }
 

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -41,7 +41,34 @@ type mockAuthServer struct {
 	Client *Client
 }
 
-var listUsers []*ExportedUserRecord
+var testUser = &UserRecord{
+	UserInfo: &UserInfo{
+		UID:         "testuser",
+		Email:       "testuser@example.com",
+		PhoneNumber: "+1234567890",
+		DisplayName: "Test User",
+		PhotoURL:    "http://www.example.com/testuser/photo.png",
+	},
+	Disabled: false,
+
+	EmailVerified: true,
+	ProviderUserInfo: []*UserInfo{
+		{
+			ProviderID:  "password",
+			DisplayName: "Test User",
+			PhotoURL:    "http://www.example.com/testuser/photo.png",
+			Email:       "testuser@example.com",
+		}, {
+			ProviderID:  "phone",
+			PhoneNumber: "+1234567890",
+		},
+	},
+	UserMetadata: &UserMetadata{
+		CreationTimestamp:  1234567890,
+		LastLogInTimestamp: 1233211232,
+	},
+	CustomClaims: map[string]interface{}{"admin": true, "package": "gold"},
+}
 
 func TestGetUser(t *testing.T) {
 	s := echoServer("get_user.json", t)
@@ -51,46 +78,67 @@ func TestGetUser(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := &UserRecord{
-		UserInfo: &UserInfo{
-			UID:         "testuser",
-			Email:       "testuser@example.com",
-			PhoneNumber: "+1234567890",
-			DisplayName: "Test User",
-			PhotoURL:    "http://www.example.com/testuser/photo.png",
-		},
-		Disabled: false,
-
-		EmailVerified: true,
-		ProviderUserInfo: []*UserInfo{
-			{
-				ProviderID:  "password",
-				DisplayName: "Test User",
-				PhotoURL:    "http://www.example.com/testuser/photo.png",
-				Email:       "testuser@example.com",
-			}, {
-				ProviderID:  "phone",
-				PhoneNumber: "+1234567890",
-			},
-		},
-		UserMetadata: &UserMetadata{
-			CreationTimestamp:  1234567890,
-			LastLogInTimestamp: 1233211232,
-		},
-		CustomClaims: map[string]interface{}{"admin": true, "package": "gold"},
+	if !reflect.DeepEqual(user, testUser) {
+		t.Errorf("GetUser() = %#v; want = %#v", user, testUser)
 	}
-	if !reflect.DeepEqual(user, want) {
-		t.Errorf("GetUser() = %#v; want = %#v", user, want)
+
+	want := `{"localId":["ignored_id"]}`
+	got := string(s.Rbody)
+	if got != want {
+		t.Errorf("GetUser() Req = %v; want = %v", got, want)
+	}
+}
+
+func TestGetUserByEmail(t *testing.T) {
+	s := echoServer("get_user.json", t)
+	defer s.Close()
+
+	user, err := s.Client.GetUserByEmail(context.Background(), "test@email.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(user, testUser) {
+		t.Errorf("GetUserByEmail() = %#v; want = %#v", user, testUser)
+	}
+
+	want := `{"email":["test@email.com"]}`
+	got := string(s.Rbody)
+	if got != want {
+		t.Errorf("GetUserByEmail() Req = %v; want = %v", got, want)
+	}
+}
+
+func TestGetUserByPhoneNumber(t *testing.T) {
+	s := echoServer("get_user.json", t)
+	defer s.Close()
+
+	user, err := s.Client.GetUserByPhoneNumber(context.Background(), "+1234567890")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(user, testUser) {
+		t.Errorf("GetUserByPhoneNumber() = %#v; want = %#v", user, testUser)
+	}
+
+	want := `{"phoneNumber":["+1234567890"]}`
+	got := string(s.Rbody)
+	if got != want {
+		t.Errorf("GetUserByPhoneNumber() Req = %v; want = %v", got, want)
 	}
 }
 
 func TestListUsers(t *testing.T) {
-	setListUsers()
 	s := echoServer("list_users.json", t)
 	defer s.Close()
 	iter := s.Client.Users(context.Background(), "")
 
-	for i := 0; i < len(listUsers); i++ {
+	want := []*ExportedUserRecord{
+		&ExportedUserRecord{UserRecord: testUser, PasswordHash: "passwordhash", PasswordSalt: "salt==="},
+		&ExportedUserRecord{UserRecord: testUser, PasswordHash: "passwordhash", PasswordSalt: "salt==="},
+		&ExportedUserRecord{UserRecord: testUser, PasswordHash: "passwordhash", PasswordSalt: "salt==="},
+	}
+	count := 0
+	for i := 0; i < len(want); i++ {
 		user, err := iter.Next()
 		if err == iterator.Done {
 			break
@@ -98,56 +146,27 @@ func TestListUsers(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if i >= len(listUsers) {
-			t.Errorf("Users() got %d users, want at least %d users", i+1, len(listUsers))
+		if !reflect.DeepEqual(user.UserRecord, want[i].UserRecord) {
+			t.Errorf("Users() iterator [%d] = %#v; want = %#v", i, user, want[i])
 		}
-		if !reflect.DeepEqual(user, listUsers[i]) {
-			t.Errorf("Users() iterator [%d], got: %#v, want: %#v", i, user, listUsers[i])
-			testCompareUserRecords("Users() iterator - Next()", user.UserRecord, listUsers[i].UserRecord, t)
+		if user.PasswordHash != want[i].PasswordHash {
+			t.Errorf("Users() PasswordHash = %q; want = %q", user.PasswordHash, want[i].PasswordHash)
 		}
+		if user.PasswordSalt != want[i].PasswordSalt {
+			t.Errorf("Users() PasswordSalt = %q; want = %q", user.PasswordSalt, want[i].PasswordSalt)
+		}
+		count++
+	}
+	if count != len(want) {
+		t.Errorf("Users() = %d; want = %d", count, len(want))
 	}
 	if _, err := iter.Next(); err != iterator.Done {
-		t.Errorf("Users() itereator got more than %d users, want %d", len(listUsers), len(listUsers))
+		t.Errorf("Users() = %v, want %v", err, iterator.Done)
 	}
 }
 
-func TestGetUserBy(t *testing.T) {
-	s := echoServer(nil, t)
-	defer s.Close()
-
-	tests := []struct {
-		name   string
-		getfun func(context.Context, string) (*UserRecord, error)
-		param  string
-		want   string
-	}{
-		{"GetUser()",
-			s.Client.GetUser,
-			"uid",
-			`{"localId":["uid"]}`,
-		},
-		{"GetUserByEmail()",
-			s.Client.GetUserByEmail,
-			"email@email.com",
-			`{"email":["email@email.com"]}`,
-		},
-		{"GetUserByPhoneNumber",
-			s.Client.GetUserByPhoneNumber,
-			"+12341234123",
-			`{"phoneNumber":["+12341234123"]}`,
-		},
-	}
-
-	for _, test := range tests {
-		test.getfun(context.Background(), test.param)
-		if string(s.Rbody) != test.want {
-			t.Errorf("%s [request body] =  %q; want: %q", test.name, s.Rbody, test.want)
-		}
-	}
-}
-
-func TestCreateUserValidatorsFail(t *testing.T) {
-	badUserParams := []struct {
+func TestInvalidCreateUser(t *testing.T) {
+	cases := []struct {
 		params *UserToCreate
 		want   string
 	}{
@@ -192,25 +211,27 @@ func TestCreateUserValidatorsFail(t *testing.T) {
 			`malformed email string: "a@a@a"`,
 		},
 	}
-	for i, test := range badUserParams {
-		_, err := client.CreateUser(context.Background(), test.params)
-		if err == nil {
-			t.Errorf("[%d] error = nil; want: error %q", i, test.want)
+	for i, tc := range cases {
+		user, err := client.CreateUser(context.Background(), tc.params)
+		if user != nil || err == nil {
+			t.Errorf("[%d] CreateUser() = (%v, %v); want = (nil, error)", i, user, err)
 		}
-		if err.Error() != test.want {
-			t.Errorf("[%d] error = %q; want error: %q", i, err.Error(), test.want)
+		if err.Error() != tc.want {
+			t.Errorf("[%d] CreateUser() = %v; want = %v", i, err.Error(), tc.want)
 		}
 	}
 }
 
-func TestCreateUserValidatorsPass(t *testing.T) {
-	s := echoServer([]byte(`{
+func TestCreateUser(t *testing.T) {
+	resp := `{
 		"kind": "identitytoolkit#SignupNewUserResponse",
 		"email": "",
 		"localId": "expectedUserID"
-	   }`), t)
+	}`
+	s := echoServer([]byte(resp), t)
 	defer s.Close()
-	goodParams := []*UserToCreate{
+
+	cases := []*UserToCreate{
 		nil,
 		{},
 		(&UserToCreate{}).Password("123456"),
@@ -221,8 +242,8 @@ func TestCreateUserValidatorsPass(t *testing.T) {
 		(&UserToCreate{}).Email("a@a"),
 		(&UserToCreate{}).PhoneNumber("+1"),
 	}
-	for _, par := range goodParams {
-		_, err := s.Client.CreateUser(context.Background(), par)
+	for _, tc := range cases {
+		_, err := s.Client.CreateUser(context.Background(), tc)
 		// There are two calls to the server, the first one, on creation retunrs the above []byte
 		// that's how we know the params passed validation
 		// the second call to GetUser, tries to get the user with the returned ID above, it fails
@@ -591,81 +612,6 @@ func provString(e *ExportedUserRecord) string {
 		}
 	}
 	return providerStr
-}
-
-// used as a referece for the wanted results given by the list_users.json data file
-func setListUsers() {
-	listUsers = []*ExportedUserRecord{
-		{
-			UserRecord: &UserRecord{
-				UserInfo: &UserInfo{
-					UID: "VHHROt3NAjPoc1hanwMRcTdCESz2",
-				},
-				UserMetadata: &UserMetadata{
-					LastLogInTimestamp: 0,
-					CreationTimestamp:  1511284665000,
-				},
-				Disabled: false,
-			},
-		},
-		{
-			UserRecord: &UserRecord{
-				UserInfo: &UserInfo{
-					UID:         "tefwfd1234",
-					DisplayName: "display_name",
-					Email:       "tefwfd1234eml5f@test.com",
-				},
-				UserMetadata: &UserMetadata{
-					LastLogInTimestamp: 0,
-					CreationTimestamp:  1511284665000,
-				},
-				Disabled:      false,
-				EmailVerified: false,
-				ProviderUserInfo: []*UserInfo{
-					{
-						ProviderID:  "password",
-						DisplayName: "display_name",
-						Email:       "tefwfd1234eml5f@test.com",
-					},
-				},
-				CustomClaims: map[string]interface{}{"asssssdf": true, "asssssdfdf": "ffd"},
-			},
-			PasswordHash: "pwhash==",
-			PasswordSalt: "pwsalt==",
-		},
-		{
-			UserRecord: &UserRecord{
-				UserInfo: &UserInfo{
-					DisplayName: "Test User",
-					Email:       "testuser@example.com",
-					UID:         "testuser0",
-					PhoneNumber: "+1234567890",
-					PhotoURL:    "http://www.example.com/testuser/photo.png",
-				},
-				UserMetadata: &UserMetadata{
-					LastLogInTimestamp: 0,
-					CreationTimestamp:  1234567890,
-				},
-				Disabled:      false,
-				EmailVerified: true,
-				ProviderUserInfo: []*UserInfo{
-					{
-						ProviderID:  "password",
-						DisplayName: "Test User",
-						Email:       "testuser@example.com",
-						PhotoURL:    "http://www.example.com/testuser/photo.png",
-					},
-					{
-						ProviderID:  "phone",
-						PhoneNumber: "+1234567890",
-					},
-				},
-				CustomClaims: map[string]interface{}{"admin": true, "package": "gold"},
-			},
-			PasswordHash: "passwordHash",
-			PasswordSalt: "passwordSalt",
-		},
-	}
 }
 
 // for drilling down comparison.

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -17,11 +17,9 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
-	"go/build"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -61,7 +59,7 @@ var testUser = &UserRecord{
 }
 
 func TestGetUser(t *testing.T) {
-	s := echoServer("get_user.json", t)
+	s := echoServer(testGetUserResponse, t)
 	defer s.Close()
 
 	user, err := s.Client.GetUser(context.Background(), "ignored_id")
@@ -79,22 +77,8 @@ func TestGetUser(t *testing.T) {
 	}
 }
 
-func TestGetNonExistingUser(t *testing.T) {
-	resp := `{
-		"kind" : "identitytoolkit#GetAccountInfoResponse",
-		"users" : []
-	}`
-	s := echoServer([]byte(resp), t)
-	defer s.Close()
-
-	user, err := s.Client.GetUser(context.Background(), "ignored_id")
-	if user != nil || err == nil {
-		t.Errorf("GetUser(non-existing) = (%v, %v); want = (nil, error)", user, err)
-	}
-}
-
 func TestGetUserByEmail(t *testing.T) {
-	s := echoServer("get_user.json", t)
+	s := echoServer(testGetUserResponse, t)
 	defer s.Close()
 
 	user, err := s.Client.GetUserByEmail(context.Background(), "test@email.com")
@@ -113,7 +97,7 @@ func TestGetUserByEmail(t *testing.T) {
 }
 
 func TestGetUserByPhoneNumber(t *testing.T) {
-	s := echoServer("get_user.json", t)
+	s := echoServer(testGetUserResponse, t)
 	defer s.Close()
 
 	user, err := s.Client.GetUserByPhoneNumber(context.Background(), "+1234567890")
@@ -131,8 +115,45 @@ func TestGetUserByPhoneNumber(t *testing.T) {
 	}
 }
 
+func TestInvalidGetUser(t *testing.T) {
+	user, err := client.GetUser(context.Background(), "")
+	if user != nil || err == nil {
+		t.Errorf("GetUser('') = (%v, %v); want = (nil, error)", user, err)
+	}
+	user, err = client.GetUserByEmail(context.Background(), "")
+	if user != nil || err == nil {
+		t.Errorf("GetUserByEmail('') = (%v, %v); want = (nil, error)", user, err)
+	}
+	user, err = client.GetUserByPhoneNumber(context.Background(), "")
+	if user != nil || err == nil {
+		t.Errorf("GetUserPhoneNumber('') = (%v, %v); want = (nil, error)", user, err)
+	}
+}
+
+func TestGetNonExistingUser(t *testing.T) {
+	resp := `{
+		"kind" : "identitytoolkit#GetAccountInfoResponse",
+		"users" : []
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	user, err := s.Client.GetUser(context.Background(), "ignored_id")
+	if user != nil || err == nil {
+		t.Errorf("GetUser(non-existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+	user, err = s.Client.GetUserByEmail(context.Background(), "test@email.com")
+	if user != nil || err == nil {
+		t.Errorf("GetUserByEmail(non-existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+	user, err = s.Client.GetUserByPhoneNumber(context.Background(), "+1234567890")
+	if user != nil || err == nil {
+		t.Errorf("GetUserPhoneNumber(non-existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+}
+
 func TestListUsers(t *testing.T) {
-	s := echoServer("list_users.json", t)
+	s := echoServer(testListUsersResponse, t)
 	defer s.Close()
 
 	want := []*ExportedUserRecord{
@@ -245,27 +266,71 @@ func TestInvalidCreateUser(t *testing.T) {
 func TestCreateUser(t *testing.T) {
 	resp := `{
 		"kind": "identitytoolkit#SignupNewUserResponse",
-		"email": "",
 		"localId": "expectedUserID"
 	}`
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
 
-	cases := []*UserToCreate{
-		nil,
-		{},
-		(&UserToCreate{}).Password("123456"),
-		(&UserToCreate{}).UID("1"),
-		(&UserToCreate{}).UID(strings.Repeat("a", 128)),
-		(&UserToCreate{}).PhoneNumber("+1"),
-		(&UserToCreate{}).DisplayName("a"),
-		(&UserToCreate{}).Email("a@a"),
-		(&UserToCreate{}).PhoneNumber("+1"),
+	cases := []struct {
+		params *UserToCreate
+		req    map[string]interface{}
+	}{
+		{
+			nil,
+			map[string]interface{}{},
+		},
+		{
+			&UserToCreate{},
+			map[string]interface{}{},
+		},
+		{
+			(&UserToCreate{}).Password("123456"),
+			map[string]interface{}{"password": "123456"},
+		},
+		{
+			(&UserToCreate{}).UID("1"),
+			map[string]interface{}{"localId": "1"},
+		},
+		{
+			(&UserToCreate{}).UID(strings.Repeat("a", 128)),
+			map[string]interface{}{"localId": strings.Repeat("a", 128)},
+		},
+		{
+			(&UserToCreate{}).PhoneNumber("+1"),
+			map[string]interface{}{"phoneNumber": "+1"},
+		},
+		{
+			(&UserToCreate{}).DisplayName("a"),
+			map[string]interface{}{"displayName": "a"},
+		},
+		{
+			(&UserToCreate{}).Email("a@a"),
+			map[string]interface{}{"email": "a@a"},
+		},
+		{
+			(&UserToCreate{}).Disabled(true),
+			map[string]interface{}{"disabled": true},
+		},
+		{
+			(&UserToCreate{}).EmailVerified(true),
+			map[string]interface{}{"emailVerified": true},
+		},
+		{
+			(&UserToCreate{}).PhotoURL("http://some.url"),
+			map[string]interface{}{"photoUrl": "http://some.url"},
+		},
 	}
 	for _, tc := range cases {
-		uid, err := s.Client.createUser(context.Background(), tc)
+		uid, err := s.Client.createUser(context.Background(), tc.params)
 		if uid != "expectedUserID" || err != nil {
-			t.Errorf("createUser(%v) = (%q, %v); want = (%q, nil)", tc, uid, err, "expectedUserID")
+			t.Errorf("createUser(%v) = (%q, %v); want = (%q, nil)", tc.params, uid, err, "expectedUserID")
+		}
+		want, err := json.Marshal(tc.req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(s.Rbody, want) {
+			t.Errorf("createUser() request = %v; want = %v", string(s.Rbody), string(want))
 		}
 	}
 }
@@ -277,10 +342,10 @@ func TestInvalidUpdateUser(t *testing.T) {
 	}{
 		{
 			nil,
-			"user must not be nil or empty for update",
+			"update parameters must not be nil or empty",
 		}, {
 			&UserToUpdate{},
-			"user must not be nil or empty for update",
+			"update parameters must not be nil or empty",
 		}, {
 			(&UserToUpdate{}).PhoneNumber("1"),
 			"phone number must be a valid, E.164 compliant identifier",
@@ -323,35 +388,87 @@ func TestUpdateUserEmptyUID(t *testing.T) {
 func TestUpdateUser(t *testing.T) {
 	resp := `{
 		"kind": "identitytoolkit#SetAccountInfoResponse",
-		"localId": "expectedUserID",
-		"email": "tefwfd1234eml5f@test.com",
-		"displayName": "display_name",
-		"passwordHash": "UkVEQUNURUQ=",
-		"providerUserInfo": [
-		 {
-		  "providerId": "password",
-		  "federatedId": "tefwfd1234eml5f@test.com",
-		  "displayName": "display_name"
-		 }
-		],
-		"emailVerified": false
+		"localId": "expectedUserID"
 	}`
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
 
-	cases := []*UserToUpdate{
-		(&UserToUpdate{}).Password("123456"),
-		(&UserToUpdate{}).PhoneNumber("+1"),
-		(&UserToUpdate{}).DisplayName("a"),
-		(&UserToUpdate{}).Email("a@a"),
-		(&UserToUpdate{}).PhoneNumber("+1"),
-		(&UserToUpdate{}).CustomClaims(map[string]interface{}{"a": strings.Repeat("a", 992)}),
+	cases := []struct {
+		params *UserToUpdate
+		req    map[string]interface{}
+	}{
+		{
+			(&UserToUpdate{}).Password("123456"),
+			map[string]interface{}{"password": "123456"},
+		},
+		{
+			(&UserToUpdate{}).PhoneNumber("+1"),
+			map[string]interface{}{"phoneNumber": "+1"},
+		},
+		{
+			(&UserToUpdate{}).DisplayName("a"),
+			map[string]interface{}{"displayName": "a"},
+		},
+		{
+			(&UserToUpdate{}).Email("a@a"),
+			map[string]interface{}{"email": "a@a"},
+		},
+		{
+			(&UserToUpdate{}).Disabled(true),
+			map[string]interface{}{"disableUser": true},
+		},
+		{
+			(&UserToUpdate{}).EmailVerified(true),
+			map[string]interface{}{"emailVerified": true},
+		},
+		{
+			(&UserToUpdate{}).PhotoURL("http://some.url"),
+			map[string]interface{}{"photoUrl": "http://some.url"},
+		},
+		{
+			(&UserToUpdate{}).DisplayName(""),
+			map[string]interface{}{"deleteAttribute": []string{"DISPLAY_NAME"}},
+		},
+		{
+			(&UserToUpdate{}).PhoneNumber(""),
+			map[string]interface{}{"deleteProvider": []string{"phone"}},
+		},
+		{
+			(&UserToUpdate{}).PhotoURL(""),
+			map[string]interface{}{"deleteAttribute": []string{"PHOTO_URL"}},
+		},
+		{
+			(&UserToUpdate{}).PhotoURL("").PhoneNumber("").DisplayName(""),
+			map[string]interface{}{
+				"deleteAttribute": []string{"DISPLAY_NAME", "PHOTO_URL"},
+				"deleteProvider":  []string{"phone"},
+			},
+		},
+		{
+			(&UserToUpdate{}).CustomClaims(map[string]interface{}{"a": strings.Repeat("a", 992)}),
+			map[string]interface{}{"customAttributes": fmt.Sprintf(`{"a":%q}`, strings.Repeat("a", 992))},
+		},
+		{
+			(&UserToUpdate{}).CustomClaims(map[string]interface{}{}),
+			map[string]interface{}{"customAttributes": "{}"},
+		},
+		{
+			(&UserToUpdate{}).CustomClaims(nil),
+			map[string]interface{}{"customAttributes": "{}"},
+		},
 	}
-
 	for _, tc := range cases {
-		err := s.Client.updateUser(context.Background(), "expectedUserID", tc)
+		err := s.Client.updateUser(context.Background(), "uid", tc.params)
 		if err != nil {
-			t.Errorf("updateUser(%v) = %v; want = nil", tc, err)
+			t.Errorf("updateUser(%v) = %v; want = nil", tc.params, err)
+		}
+		tc.req["localId"] = "uid"
+		want, err := json.Marshal(tc.req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(s.Rbody, want) {
+			t.Errorf("updateUser() request = %v; want = %v", string(s.Rbody), string(want))
 		}
 	}
 }
@@ -360,10 +477,16 @@ func TestInvalidSetCustomClaims(t *testing.T) {
 	cases := []struct {
 		cc   map[string]interface{}
 		want string
-	}{{
-		map[string]interface{}{"a": strings.Repeat("a", 993)},
-		"serialized custom claims must not exceed 1000 characters",
-	}}
+	}{
+		{
+			map[string]interface{}{"a": strings.Repeat("a", 993)},
+			"serialized custom claims must not exceed 1000 characters",
+		},
+		{
+			map[string]interface{}{"a": func() {}},
+			"custom claims marshaling error: json: unsupported type: func()",
+		},
+	}
 
 	for _, res := range reservedClaims {
 		s := struct {
@@ -379,7 +502,7 @@ func TestInvalidSetCustomClaims(t *testing.T) {
 	for _, tc := range cases {
 		err := client.SetCustomUserClaims(context.Background(), "uid", tc.cc)
 		if err == nil {
-			t.Errorf("SetCustomUserClaims() = nil; want = error: %s", tc.want)
+			t.Errorf("SetCustomUserClaims() = nil; want error: %s", tc.want)
 		}
 		if err.Error() != tc.want {
 			t.Errorf("SetCustomUserClaims() = %q; want = %q", err.Error(), tc.want)
@@ -392,6 +515,7 @@ func TestSetCustomClaims(t *testing.T) {
 		nil,
 		map[string]interface{}{},
 		map[string]interface{}{"admin": true},
+		map[string]interface{}{"admin": true, "package": "gold"},
 	}
 
 	resp := `{
@@ -403,7 +527,7 @@ func TestSetCustomClaims(t *testing.T) {
 	for _, tc := range cases {
 		err := s.Client.SetCustomUserClaims(context.Background(), "uid", tc)
 		if err != nil {
-			t.Errorf("SetCustomUserClaims(%v) = %v; want = nil", tc, err)
+			t.Errorf("SetCustomUserClaims(%v) = %v; want nil", tc, err)
 		}
 
 		input := tc
@@ -444,7 +568,7 @@ func TestDeleteUser(t *testing.T) {
 
 func TestInvalidDeleteUser(t *testing.T) {
 	if err := client.DeleteUser(context.Background(), ""); err == nil {
-		t.Errorf("DeleteUser('') = nil; want = error")
+		t.Errorf("DeleteUser('') = nil; want error")
 	}
 }
 
@@ -496,132 +620,6 @@ func TestMakeExportedUser(t *testing.T) {
 	}
 }
 
-func TestCreateRequest(t *testing.T) {
-	tests := []struct {
-		utc  *UserToCreate
-		want string
-	}{
-		{
-			nil,
-			`{}`,
-		}, {
-			(&UserToCreate{}),
-			`{}`,
-		}, {
-			(&UserToCreate{}).Disabled(true),
-			`{"disableUser":true}`,
-		}, {
-			(&UserToCreate{}).DisplayName("a"),
-			`{"displayName":"a"}`,
-		}, {
-			(&UserToCreate{}).Email("a@a.a"),
-			`{"email":"a@a.a"}`,
-		}, {
-			(&UserToCreate{}).EmailVerified(true),
-			`{"emailVerified":true}`,
-		}, {
-			(&UserToCreate{}).Password("654321"),
-			`{"password":"654321"}`,
-		}, {
-			(&UserToCreate{}).PhoneNumber("+1"),
-			`{"phoneNumber":"+1"}`,
-		}, {
-			(&UserToCreate{}).UID("1"),
-			`{"localId":"1"}`,
-		}, {
-			(&UserToCreate{}).PhotoURL("http://some.url"),
-			`{"photoUrl":"http://some.url"}`,
-		}, {
-			(&UserToCreate{}).UID(strings.Repeat("a", 128)),
-			`{"localId":"` + strings.Repeat("aaaa", 32) + `"}`,
-		},
-	}
-
-	for _, test := range tests {
-		s := echoServer(nil, t) // the returned json is of no importance, we just need the request body.
-		defer s.Close()
-		s.Client.CreateUser(context.Background(), test.utc)
-		if string(s.Rbody) != test.want {
-			t.Errorf("CreateUser() request body = %q; want: %q", s.Rbody, test.want)
-		}
-	}
-}
-
-func TestUpdateRequest(t *testing.T) {
-	tests := []struct {
-		utup *UserToUpdate
-		want string
-	}{
-		{
-			(&UserToUpdate{}).Disabled(true),
-			`{"disableUser":true,"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).DisplayName("a"),
-			`{"displayName":"a","localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).DisplayName(""),
-			`{"deleteAttribute":["DISPLAY_NAME"],"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).Email("a@a.a"),
-			`{"email":"a@a.a","localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).EmailVerified(true),
-			`{"emailVerified":true,"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).Password("654321"),
-			`{"localId":"uid","password":"654321"}`,
-		}, {
-			(&UserToUpdate{}).PhoneNumber("+1"),
-			`{"localId":"uid","phoneNumber":"+1"}`,
-		}, {
-			(&UserToUpdate{}).PhoneNumber(""),
-			`{"deleteProvider":["phone"],"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).PhotoURL("http://some.url"),
-			`{"localId":"uid","photoUrl":"http://some.url"}`,
-		}, {
-			(&UserToUpdate{}).PhotoURL(""),
-			`{"deleteAttribute":["PHOTO_URL"],"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).PhotoURL("").PhoneNumber("").DisplayName(""),
-			`{"deleteAttribute":["DISPLAY_NAME","PHOTO_URL"],"deleteProvider":["phone"],"localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).CustomClaims(map[string]interface{}{"a": "b", "b": true, "c": 1}),
-			`{"customAttributes":"{\"a\":\"b\",\"b\":true,\"c\":1}","localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).CustomClaims(map[string]interface{}{}),
-			`{"customAttributes":"{}","localId":"uid"}`,
-		}, {
-			(&UserToUpdate{}).CustomClaims(map[string]interface{}(nil)),
-			`{"customAttributes":"{}","localId":"uid"}`,
-		},
-	}
-
-	for _, test := range tests {
-		s := echoServer(nil, t) // the returned json is of no importance, we just need the request body.
-		defer s.Close()
-
-		s.Client.UpdateUser(context.Background(), "uid", test.utup)
-		var got, want map[string]interface{}
-		err := json.Unmarshal(s.Rbody, &got)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = json.Unmarshal([]byte(test.want), &want)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Test params regqrdless of order
-		if !reflect.DeepEqual(got, want) {
-			t.Errorf("UpdateUser() request body = %q; want: %q", s.Rbody, test.want)
-		}
-		// json should have sorted keys.
-		if string(s.Rbody) != test.want {
-			t.Errorf("UpdateUser() request body = %q; want: %q", s.Rbody, test.want)
-		}
-	}
-}
-
 func TestHTTPError(t *testing.T) {
 	s := mockAuthServer{}
 	s.Srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -639,8 +637,9 @@ func TestHTTPError(t *testing.T) {
 	client.url = s.Srv.URL + "/"
 
 	want := `http error status: 500; reason: {"error":"test"}`
-	if _, err = client.GetUser(context.Background(), "some uid"); err == nil || err.Error() != want {
-		t.Errorf("GetUser() = %v; want: `%v`", err, want)
+	_, err = client.GetUser(context.Background(), "some uid")
+	if err == nil || err.Error() != want {
+		t.Errorf("GetUser() = %v; want = %q", err, want)
 	}
 }
 
@@ -658,7 +657,6 @@ type mockAuthServer struct {
 //
 // echoServer returns a server whose client will reply with depending on the input type:
 //   * []byte: the []byte it got
-//   * string: the contents of the file named by the string in []byte form
 //   * object: the marshalled object, in []byte form
 //   * nil: "{}" empty json, in case we aren't interested in the returned value, just the marshalled request
 // The marshalled request is available through s.rbody, s being the retuned server.
@@ -671,12 +669,6 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 		b = []byte("")
 	case []byte:
 		b = v
-	case string:
-		fp := filepath.Join([]string{build.Default.GOPATH, "src", "firebase.google.com", "go", "testdata", v}...)
-		b, err = ioutil.ReadFile(fp)
-		if err != nil {
-			t.Fatal(err)
-		}
 	default:
 		b, err = json.Marshal(resp)
 		if err != nil {

--- a/testdata/list_users.json
+++ b/testdata/list_users.json
@@ -20,8 +20,8 @@
                 "rawId" : "+1234567890"
             } ],
             "photoUrl" : "http://www.example.com/testuser/photo.png",
-            "passwordHash" : "passwordhash",
-            "salt" : "salt===",
+            "passwordHash" : "passwordhash1",
+            "salt" : "salt1",
             "passwordUpdatedAt" : 1.494364393E+12,
             "validSince" : "1494364393",
             "disabled" : false,
@@ -48,8 +48,8 @@
                 "rawId" : "+1234567890"
             } ],
             "photoUrl" : "http://www.example.com/testuser/photo.png",
-            "passwordHash" : "passwordhash",
-            "salt" : "salt===",
+            "passwordHash" : "passwordhash2",
+            "salt" : "salt2",
             "passwordUpdatedAt" : 1.494364393E+12,
             "validSince" : "1494364393",
             "disabled" : false,
@@ -76,8 +76,8 @@
                 "rawId" : "+1234567890"
             } ],
             "photoUrl" : "http://www.example.com/testuser/photo.png",
-            "passwordHash" : "passwordhash",
-            "salt" : "salt===",
+            "passwordHash" : "passwordhash3",
+            "salt" : "salt3",
             "passwordUpdatedAt" : 1.494364393E+12,
             "validSince" : "1494364393",
             "disabled" : false,

--- a/testdata/list_users.json
+++ b/testdata/list_users.json
@@ -2,63 +2,88 @@
     "kind": "identitytoolkit#DownloadAccountResponse",
     "users": [
         {
-            "localId": "VHHROt3NAjPoc1hanwMRcTdCESz2",
-            "validSince": "1511284665",
-            "disabled": false,
-            "createdAt": "1511284665000"
+            "localId" : "testuser",
+            "email" : "testuser@example.com",
+            "phoneNumber" : "+1234567890",
+            "emailVerified" : true,
+            "displayName" : "Test User",
+            "providerUserInfo" : [ {
+            "providerId" : "password",
+            "displayName" : "Test User",
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "federatedId" : "testuser@example.com",
+            "email" : "testuser@example.com",
+            "rawId" : "testuser@example.com"
+            }, {
+                "providerId" : "phone",
+                "phoneNumber" : "+1234567890",
+                "rawId" : "+1234567890"
+            } ],
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "passwordHash" : "passwordhash",
+            "salt" : "salt===",
+            "passwordUpdatedAt" : 1.494364393E+12,
+            "validSince" : "1494364393",
+            "disabled" : false,
+            "createdAt" : "1234567890",
+            "lastLoginAt"	:"1233211232",
+            "customAttributes" : "{\"admin\": true, \"package\": \"gold\"}"
         },
         {
-            "localId": "tefwfd1234",
-            "email": "tefwfd1234eml5f@test.com",
-            "emailVerified": false,
-            "displayName": "display_name",
-            "providerUserInfo": [
-                {
-                    "providerId": "password",
-                    "displayName": "display_name",
-                    "federatedId": "tefwfd1234eml5f@test.com",
-                    "email": "tefwfd1234eml5f@test.com",
-                    "rawId": "tefwfd1234eml5f@test.com"
-                }
-            ],
-            "passwordHash": "pwhash==",
-            "salt": "pwsalt==",
-            "version": 0,
-            "passwordUpdatedAt": 1.511284666E12,
-            "validSince": "1511284666",
-            "disabled": false,
-            "createdAt": "1511284665000",
-            "customAttributes": "{\"asssssdf\":true,\"asssssdfdf\":\"ffd\"}"
+            "localId" : "testuser",
+            "email" : "testuser@example.com",
+            "phoneNumber" : "+1234567890",
+            "emailVerified" : true,
+            "displayName" : "Test User",
+            "providerUserInfo" : [ {
+            "providerId" : "password",
+            "displayName" : "Test User",
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "federatedId" : "testuser@example.com",
+            "email" : "testuser@example.com",
+            "rawId" : "testuser@example.com"
+            }, {
+                "providerId" : "phone",
+                "phoneNumber" : "+1234567890",
+                "rawId" : "+1234567890"
+            } ],
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "passwordHash" : "passwordhash",
+            "salt" : "salt===",
+            "passwordUpdatedAt" : 1.494364393E+12,
+            "validSince" : "1494364393",
+            "disabled" : false,
+            "createdAt" : "1234567890",
+            "lastLoginAt"	:"1233211232",
+            "customAttributes" : "{\"admin\": true, \"package\": \"gold\"}"
         },
         {
-            "localId": "testuser0",
-            "email": "testuser@example.com",
-            "phoneNumber": "+1234567890",
-            "emailVerified": true,
-            "displayName": "Test User",
-            "providerUserInfo": [
-                {
-                    "providerId": "password",
-                    "displayName": "Test User",
-                    "photoUrl": "http://www.example.com/testuser/photo.png",
-                    "federatedId": "testuser@example.com",
-                    "email": "testuser@example.com",
-                    "rawId": "testuser@example.com"
-                },
-                {
-                    "providerId": "phone",
-                    "phoneNumber": "+1234567890",
-                    "rawId": "+1234567890"
-                }
-            ],
-            "photoUrl": "http://www.example.com/testuser/photo.png",
-            "passwordHash": "passwordHash",
-            "salt": "passwordSalt",
-            "passwordUpdatedAt": 1.494364393E+12,
-            "validSince": "1494364393",
-            "disabled": false,
-            "createdAt": "1234567890",
-            "customAttributes": "{\"admin\": true, \"package\": \"gold\"}"
+            "localId" : "testuser",
+            "email" : "testuser@example.com",
+            "phoneNumber" : "+1234567890",
+            "emailVerified" : true,
+            "displayName" : "Test User",
+            "providerUserInfo" : [ {
+            "providerId" : "password",
+            "displayName" : "Test User",
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "federatedId" : "testuser@example.com",
+            "email" : "testuser@example.com",
+            "rawId" : "testuser@example.com"
+            }, {
+                "providerId" : "phone",
+                "phoneNumber" : "+1234567890",
+                "rawId" : "+1234567890"
+            } ],
+            "photoUrl" : "http://www.example.com/testuser/photo.png",
+            "passwordHash" : "passwordhash",
+            "salt" : "salt===",
+            "passwordUpdatedAt" : 1.494364393E+12,
+            "validSince" : "1494364393",
+            "disabled" : false,
+            "createdAt" : "1234567890",
+            "lastLoginAt"	:"1233211232",
+            "customAttributes" : "{\"admin\": true, \"package\": \"gold\"}"
         }
     ],
     "nextPageToken": ""


### PR DESCRIPTION
* Removed most of the verbose struct literal definitions
* Loading testdata files at the test initialization
* Combined related test cases together
* Added new test cases to cover several edge cases

* Fixed a bug in `UserToCreate.Disabed()`
* Added more argument validation
* Removed the redundant `commonParams` type