### PR TITLE
Create the 5th user in the integration tests for user management.

### DIFF
--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -48,7 +48,7 @@ func TestUserManagement(t *testing.T) {
 
 func testCreateUsers(t *testing.T) {
 	// Create users with uid
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		params := (&auth.UserToCreate{}).UID(fmt.Sprintf("tempTestUserID-%d", i))
 		u, err := client.CreateUser(context.Background(), params)
 		if err != nil {


### PR DESCRIPTION
tiny fix, 
we check for 5 users and 3 pages, but we only create 4 users, 
a fifth user is created by the verifyToken tests, but that is in parallel and we shouldn't count on it.