### PR TITLE
Auth Package Internal Cleanup

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -101,6 +101,7 @@ func NewClient(ctx context.Context, c *internal.AuthConfig) (*Client, error) {
 		}
 		email = svcAcct.ClientEmail
 	}
+
 	var snr signer
 	if email != "" && pk != nil {
 		snr = serviceAcctSigner{email: email, pk: pk}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -22,7 +22,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"firebase.google.com/go/internal"
@@ -111,21 +110,15 @@ func NewClient(ctx context.Context, c *internal.AuthConfig) (*Client, error) {
 			return nil, err
 		}
 	}
-	hc := http.DefaultClient
-	if len(c.Opts) > 0 { // TODO: fix the default when len = 0
-		hc, _, err = transport.NewHTTPClient(ctx, c.Opts...)
-		if err != nil {
-			return nil, err
-		}
-	}
-	ks, err := newHTTPKeySource(googleCertURL, hc)
+
+	hc, _, err := transport.NewHTTPClient(ctx, c.Opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
 		hc:        &internal.HTTPClient{Client: hc},
-		ks:        ks,
+		ks:        newHTTPKeySource(googleCertURL, hc),
 		projectID: c.ProjectID,
 		snr:       snr,
 		url:       idToolKitURL,

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -47,6 +47,7 @@ func TestMain(m *testing.M) {
 		ks    keySource
 		ctx   context.Context
 		creds *google.DefaultCredentials
+		opts  []option.ClientOption
 	)
 	if appengine.IsDevAppServer() {
 		aectx, aedone, err := aetest.NewContext()
@@ -62,8 +63,8 @@ func TestMain(m *testing.M) {
 		}
 	} else {
 		ctx = context.Background()
-		opt := option.WithCredentialsFile("../testdata/service_account.json")
-		creds, err = transport.Creds(ctx, opt)
+		opts = append(opts, option.WithCredentialsFile("../testdata/service_account.json"))
+		creds, err = transport.Creds(ctx, opts...)
 		if err != nil {
 			log.Fatalln(err)
 		}
@@ -72,7 +73,7 @@ func TestMain(m *testing.M) {
 	}
 	client, err = NewClient(ctx, &internal.AuthConfig{
 		Creds:     creds,
-		Opts:      []option.ClientOption{option.WithCredentialsFile("../testdata/service_account.json")},
+		Opts:      opts,
 		ProjectID: "mock-project-id",
 	})
 	if err != nil {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -41,6 +41,10 @@ var testIDToken string
 var testGetUserResponse []byte
 var testListUsersResponse []byte
 
+var defaultTestOpts = []option.ClientOption{
+	option.WithCredentialsFile("../testdata/service_account.json"),
+}
+
 func TestMain(m *testing.M) {
 	var (
 		err   error
@@ -63,7 +67,7 @@ func TestMain(m *testing.M) {
 		}
 	} else {
 		ctx = context.Background()
-		opts = append(opts, option.WithCredentialsFile("../testdata/service_account.json"))
+		opts = defaultTestOpts
 		creds, err = transport.Creds(ctx, opts...)
 		if err != nil {
 			log.Fatalln(err)
@@ -171,7 +175,9 @@ func TestCustomTokenError(t *testing.T) {
 }
 
 func TestCustomTokenInvalidCredential(t *testing.T) {
-	s, err := NewClient(context.Background(), &internal.AuthConfig{})
+	// AuthConfig with nil Creds
+	conf := &internal.AuthConfig{Opts: defaultTestOpts}
+	s, err := NewClient(context.Background(), conf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +244,9 @@ func TestVerifyIDTokenError(t *testing.T) {
 }
 
 func TestNoProjectID(t *testing.T) {
-	c, err := NewClient(context.Background(), &internal.AuthConfig{})
+	// AuthConfig with empty ProjectID
+	conf := &internal.AuthConfig{Opts: defaultTestOpts}
+	c, err := NewClient(context.Background(), conf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth/crypto.go
+++ b/auth/crypto.go
@@ -75,13 +75,13 @@ type httpKeySource struct {
 	Mutex      *sync.Mutex
 }
 
-func newHTTPKeySource(uri string, hc *http.Client) (*httpKeySource, error) {
+func newHTTPKeySource(uri string, hc *http.Client) *httpKeySource {
 	return &httpKeySource{
 		KeyURI:     uri,
 		HTTPClient: hc,
 		Clock:      systemClock{},
 		Mutex:      &sync.Mutex{},
-	}, nil
+	}
 }
 
 // Keys returns the RSA Public Keys hosted at this key source's URI. Refreshes the data if

--- a/auth/crypto_test.go
+++ b/auth/crypto_test.go
@@ -83,11 +83,8 @@ func TestHTTPKeySource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ks, err := newHTTPKeySource("http://mock.url", http.DefaultClient)
-	if err != nil {
-		t.Fatal(err)
-	}
 
+	ks := newHTTPKeySource("http://mock.url", http.DefaultClient)
 	if ks.HTTPClient == nil {
 		t.Errorf("HTTPClient = nil; want non-nil")
 	}
@@ -105,11 +102,7 @@ func TestHTTPKeySourceWithClient(t *testing.T) {
 	}
 
 	hc, rc := newTestHTTPClient(data)
-	ks, err := newHTTPKeySource("http://mock.url", hc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ks := newHTTPKeySource("http://mock.url", hc)
 	if ks.HTTPClient != hc {
 		t.Errorf("HTTPClient = %v; want %v", ks.HTTPClient, hc)
 	}
@@ -120,11 +113,7 @@ func TestHTTPKeySourceWithClient(t *testing.T) {
 
 func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 	hc, _ := newTestHTTPClient([]byte(""))
-	ks, err := newHTTPKeySource("http://mock.url", hc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ks := newHTTPKeySource("http://mock.url", hc)
 	if keys, err := ks.Keys(); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
@@ -132,11 +121,7 @@ func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 
 func TestHTTPKeySourceIncorrectResponse(t *testing.T) {
 	hc, _ := newTestHTTPClient([]byte("{\"foo\": 1}"))
-	ks, err := newHTTPKeySource("http://mock.url", hc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ks := newHTTPKeySource("http://mock.url", hc)
 	if keys, err := ks.Keys(); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
@@ -148,11 +133,7 @@ func TestHTTPKeySourceTransportError(t *testing.T) {
 			Err: errors.New("transport error"),
 		},
 	}
-	ks, err := newHTTPKeySource("http://mock.url", hc)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ks := newHTTPKeySource("http://mock.url", hc)
 	if keys, err := ks.Keys(); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -709,12 +709,13 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 	})
 	s.Srv = httptest.NewServer(handler)
 
-	authClient, err := NewClient(context.Background(), &internal.AuthConfig{
+	conf := &internal.AuthConfig{
 		Opts: []option.ClientOption{
 			option.WithTokenSource(&mockTokenSource{testToken}),
 		},
 		Version: testVersion,
-	})
+	}
+	authClient, err := NewClient(context.Background(), conf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -25,8 +25,11 @@ import (
 	"testing"
 
 	"firebase.google.com/go/internal"
+
 	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
 )
 
 var testUser = &UserRecord{
@@ -621,24 +624,17 @@ func TestMakeExportedUser(t *testing.T) {
 }
 
 func TestHTTPError(t *testing.T) {
-	s := mockAuthServer{}
-	s.Srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.Req = append(s.Req, r)
-		w.WriteHeader(500)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"error":"test"}`))
-	}))
+	s := echoServer([]byte(`{"error":"test"}`), t)
 	defer s.Close()
+	s.Status = 500
 
-	client, err := NewClient(context.Background(), &internal.AuthConfig{})
-	if err != nil {
-		t.Fatal()
+	u, err := s.Client.GetUser(context.Background(), "some uid")
+	if u != nil || err == nil {
+		t.Fatalf("GetUser() = (%v, %v); want = (nil, error)", u, err)
 	}
-	client.url = s.Srv.URL + "/"
 
 	want := `http error status: 500; reason: {"error":"test"}`
-	_, err = client.GetUser(context.Background(), "some uid")
-	if err == nil || err.Error() != want {
+	if err.Error() != want {
 		t.Errorf("GetUser() = %v; want = %q", err, want)
 	}
 }
@@ -664,7 +660,6 @@ type mockAuthServer struct {
 func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 	var b []byte
 	var err error
-	testVersion := "test.version"
 	switch v := resp.(type) {
 	case nil:
 		b = []byte("")
@@ -678,19 +673,30 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 	}
 	s := mockAuthServer{Resp: b}
 
+	const testToken = "test.token"
+	const testVersion = "test.version"
+
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 		reqBody, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal(err)
 		}
-		s.Req = append(s.Req, r)
-		vh := r.Header.Get("X-Client-Version")
-		wantvh := "Go/Admin/" + testVersion
-		if vh != wantvh {
-			t.Errorf("version header = %s; want: %s", vh, wantvh)
-		}
 		s.Rbody = reqBody
+		s.Req = append(s.Req, r)
+
+		gh := r.Header.Get("Authorization")
+		wh := "Bearer " + testToken
+		if gh != wh {
+			t.Errorf("Authorization header = %q; want = %q", gh, wh)
+		}
+
+		gh = r.Header.Get("X-Client-Version")
+		wh = "Go/Admin/" + testVersion
+		if gh != wh {
+			t.Errorf("X-Client-Version header = %q; want: %q", gh, wh)
+		}
+
 		for k, v := range s.Header {
 			w.Header().Set(k, v)
 		}
@@ -702,7 +708,13 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 
 	})
 	s.Srv = httptest.NewServer(handler)
-	authClient, err := NewClient(context.Background(), &internal.AuthConfig{Version: testVersion})
+
+	authClient, err := NewClient(context.Background(), &internal.AuthConfig{
+		Opts: []option.ClientOption{
+			option.WithTokenSource(&mockTokenSource{testToken}),
+		},
+		Version: testVersion,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -713,4 +725,12 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 
 func (s *mockAuthServer) Close() {
 	s.Srv.Close()
+}
+
+type mockTokenSource struct {
+	AccessToken string
+}
+
+func (m *mockTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{AccessToken: m.AccessToken}, nil
 }


### PR DESCRIPTION
* Addressing a TODO related to how `http.Client` is initialized in `NewClient()`. With this, we no longer use `http.DefaultClient` in the code.
* Simplified the `httpKeySource` constructor. It can no longer return an error.
* Updated and fixed the affected tests.