### PR TITLE
use const for Common HTTP methods and HTTP status codes

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -22,6 +22,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"firebase.google.com/go/internal"
@@ -131,7 +132,7 @@ func NewClient(ctx context.Context, c *internal.AuthConfig) (*Client, error) {
 func (c *Client) makeHTTPCall(ctx context.Context, serviceName string, payload interface{}, result interface{}) error {
 	versionHeader := internal.WithHeader("X-Client-Version", c.version)
 	request := &internal.Request{
-		Method: "POST",
+		Method: http.MethodPost,
 		URL:    c.url + serviceName,
 		Body:   internal.NewJSONEntity(payload),
 		Opts:   []internal.HTTPOption{versionHeader},
@@ -140,7 +141,7 @@ func (c *Client) makeHTTPCall(ctx context.Context, serviceName string, payload i
 	if err != nil {
 		return err
 	}
-	return resp.Unmarshal(200, result)
+	return resp.Unmarshal(http.StatusOK, result)
 }
 
 // CustomToken creates a signed custom authentication token with the specified user ID. The resulting

--- a/auth/crypto_test.go
+++ b/auth/crypto_test.go
@@ -48,7 +48,7 @@ func newTestHTTPClient(data []byte) (*http.Client, *mockReadCloser) {
 		Transport: &mockHTTPResponse{
 			Response: http.Response{
 				Status:     "200 OK",
-				StatusCode: 200,
+				StatusCode: http.StatusOK,
 				Header: http.Header{
 					"Cache-Control": {"public, max-age=100"},
 				},

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -626,7 +626,7 @@ func TestMakeExportedUser(t *testing.T) {
 func TestHTTPError(t *testing.T) {
 	s := echoServer([]byte(`{"error":"test"}`), t)
 	defer s.Close()
-	s.Status = 500
+	s.Status = http.StatusInternalServerError
 
 	u, err := s.Client.GetUser(context.Background(), "some uid")
 	if u != nil || err == nil {

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -85,8 +85,8 @@ func TestClientOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
-		t.Errorf("Status: %d; want: 200", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Status: %d; want: %q", resp.StatusCode, http.StatusOK)
 	}
 	if bearer != "Bearer mock-token" {
 		t.Errorf("Bearer token: %q; want: %q", bearer, "Bearer mock-token")
@@ -318,8 +318,8 @@ func TestCustomTokenSource(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != 200 {
-		t.Errorf("Status: %d; want: 200", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Status: %d; want: %d", resp.StatusCode, http.StatusOK)
 	}
 	if bearer != "Bearer "+ts.AccessToken {
 		t.Errorf("Bearer token: %q; want: %q", bearer, "Bearer "+ts.AccessToken)

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -86,7 +86,7 @@ func TestClientOptions(t *testing.T) {
 		t.Fatal(err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Status: %d; want: %q", resp.StatusCode, http.StatusOK)
+		t.Errorf("Status: %d; want: %d", resp.StatusCode, http.StatusOK)
 	}
 	if bearer != "Bearer mock-token" {
 		t.Errorf("Bearer token: %q; want: %q", bearer, "Bearer mock-token")

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -30,14 +30,14 @@ import (
 const iidEndpoint = "https://console.firebase.google.com/v1"
 
 var errorCodes = map[int]string{
-	400: "malformed instance id argument",
-	401: "request not authorized",
-	403: "project does not match instance ID or the client does not have sufficient privileges",
-	404: "failed to find the instance id",
-	409: "already deleted",
-	429: "request throttled out by the backend server",
-	500: "internal server error",
-	503: "backend servers are over capacity",
+	http.StatusBadRequest:          "malformed instance id argument",
+	http.StatusUnauthorized:        "request not authorized",
+	http.StatusForbidden:           "project does not match instance ID or the client does not have sufficient privileges",
+	http.StatusNotFound:            "failed to find the instance id",
+	http.StatusConflict:            "already deleted",
+	http.StatusTooManyRequests:     "request throttled out by the backend server",
+	http.StatusInternalServerError: "internal server error",
+	http.StatusServiceUnavailable:  "backend servers are over capacity",
 }
 
 // Client is the interface for the Firebase Instance ID service.
@@ -79,7 +79,7 @@ func (c *Client) DeleteInstanceID(ctx context.Context, iid string) error {
 	}
 
 	url := fmt.Sprintf("%s/project/%s/instanceId/%s", c.endpoint, c.project, iid)
-	resp, err := c.client.Do(ctx, &internal.Request{Method: "DELETE", URL: url})
+	resp, err := c.client.Do(ctx, &internal.Request{Method: http.MethodDelete, URL: url})
 	if err != nil {
 		return err
 	}

--- a/iid/iid_test.go
+++ b/iid/iid_test.go
@@ -75,8 +75,8 @@ func TestDeleteInstanceID(t *testing.T) {
 	if tr == nil {
 		t.Fatalf("Request = nil; want non-nil")
 	}
-	if tr.Method != "DELETE" {
-		t.Errorf("Method = %q; want = %q", tr.Method, "DELETE")
+	if tr.Method != http.MethodDelete {
+		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodDelete)
 	}
 	if tr.URL.Path != "/project/test-project/instanceId/test-iid" {
 		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/project/test-project/instanceId/test-iid")
@@ -87,7 +87,7 @@ func TestDeleteInstanceID(t *testing.T) {
 }
 
 func TestDeleteInstanceIDError(t *testing.T) {
-	status := 200
+	status := http.StatusOK
 	var tr *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tr = r
@@ -119,8 +119,8 @@ func TestDeleteInstanceIDError(t *testing.T) {
 		if tr == nil {
 			t.Fatalf("Request = nil; want non-nil")
 		}
-		if tr.Method != "DELETE" {
-			t.Errorf("Method = %q; want = %q", tr.Method, "DELETE")
+		if tr.Method != http.MethodDelete {
+			t.Errorf("Method = %q; want = %q", tr.Method, http.MethodDelete)
 		}
 		if tr.URL.Path != "/project/test-project/instanceId/test-iid" {
 			t.Errorf("Path = %q; want = %q", tr.URL.Path, "/project/test-project/instanceId/test-iid")
@@ -162,8 +162,8 @@ func TestDeleteInstanceIDUnexpectedError(t *testing.T) {
 	if tr == nil {
 		t.Fatalf("Request = nil; want non-nil")
 	}
-	if tr.Method != "DELETE" {
-		t.Errorf("Method = %q; want = %q", tr.Method, "DELETE")
+	if tr.Method != http.MethodDelete {
+		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodDelete)
 	}
 	if tr.URL.Path != "/project/test-project/instanceId/test-iid" {
 		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/project/test-project/instanceId/test-iid")

--- a/integration/auth/auth_test.go
+++ b/integration/auth/auth_test.go
@@ -139,7 +139,7 @@ func postRequest(url string, req []byte) ([]byte, error) {
 	}
 
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected http status code: %d", resp.StatusCode)
 	}
 	return ioutil.ReadAll(resp.Body)

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -33,25 +33,25 @@ var cases = []struct {
 }{
 	{
 		req: &Request{
-			Method: "GET",
+			Method: http.MethodGet,
 		},
-		method: "GET",
+		method: http.MethodGet,
 	},
 	{
 		req: &Request{
-			Method: "GET",
+			Method: http.MethodGet,
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParam("testParam", "value2"),
 			},
 		},
-		method:  "GET",
+		method:  http.MethodGet,
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam": "value2"},
 	},
 	{
 		req: &Request{
-			Method: "POST",
+			Method: http.MethodPost,
 			Body:   NewJSONEntity(map[string]string{"foo": "bar"}),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
@@ -59,35 +59,35 @@ var cases = []struct {
 				WithQueryParam("testParam2", "value3"),
 			},
 		},
-		method:  "POST",
+		method:  http.MethodPost,
 		body:    "{\"foo\":\"bar\"}",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
 	},
 	{
 		req: &Request{
-			Method: "POST",
+			Method: http.MethodPost,
 			Body:   NewJSONEntity("body"),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
 			},
 		},
-		method:  "POST",
+		method:  http.MethodPost,
 		body:    "\"body\"",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
 	},
 	{
 		req: &Request{
-			Method: "PUT",
+			Method: http.MethodPut,
 			Body:   NewJSONEntity(nil),
 			Opts: []HTTPOption{
 				WithHeader("Test-Header", "value1"),
 				WithQueryParams(map[string]string{"testParam1": "value2", "testParam2": "value3"}),
 			},
 		},
-		method:  "PUT",
+		method:  http.MethodPut,
 		body:    "null",
 		headers: map[string]string{"Test-Header": "value1"},
 		query:   map[string]string{"testParam1": "value2", "testParam2": "value3"},
@@ -184,7 +184,7 @@ func TestContext(t *testing.T) {
 	client := &HTTPClient{Client: http.DefaultClient}
 	ctx, cancel := context.WithCancel(context.Background())
 	resp, err := client.Do(ctx, &Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    server.URL,
 	})
 	if err != nil {
@@ -196,7 +196,7 @@ func TestContext(t *testing.T) {
 
 	cancel()
 	resp, err = client.Do(ctx, &Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    server.URL,
 	})
 	if resp != nil || err == nil {
@@ -234,7 +234,7 @@ func TestErrorParser(t *testing.T) {
 		Client:    http.DefaultClient,
 		ErrParser: ep,
 	}
-	req := &Request{Method: "GET", URL: server.URL}
+	req := &Request{Method: http.MethodGet, URL: server.URL}
 	resp, err := client.Do(context.Background(), req)
 	if err != nil {
 		t.Fatal(err)
@@ -255,7 +255,7 @@ func TestErrorParser(t *testing.T) {
 
 func TestInvalidURL(t *testing.T) {
 	req := &Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL:    "http://localhost:250/mock.url",
 	}
 	client := &HTTPClient{Client: http.DefaultClient}
@@ -281,7 +281,7 @@ func TestUnmarshalError(t *testing.T) {
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	req := &Request{Method: "GET", URL: server.URL}
+	req := &Request{Method: http.MethodGet, URL: server.URL}
 	client := &HTTPClient{Client: http.DefaultClient}
 	resp, err := client.Do(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
Just small changes to use const for Common HTTP methods and HTTP status codes instead of "200" and "GET"

