### PR TITLE
golint - remove redundant if ...; err != nil check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: go
 go_import_path: firebase.google.com/go
-script: go test -v -test.short ./...
+before_install:
+    - go get github.com/golang/lint/golint
+script:
+    - golint -set_exit_status $(go list ./...)
+    - go test -v -test.short ./...
 

--- a/integration/storage/storage_test.go
+++ b/integration/storage/storage_test.go
@@ -116,8 +116,5 @@ func verifyBucket(bucket *gcs.BucketHandle) error {
 	}
 
 	// Delete the object
-	if err := o.Delete(ctx); err != nil {
-		return err
-	}
-	return nil
+	return o.Delete(ctx)
 }


### PR DESCRIPTION
I just check the code with golint and fix a redundant if on a test.

```
golint -set_exit_status $(go list ./...)
/Users/chemidy/go/src/firebase.google.com/go/integration/storage/storage_test.go:119:2: redundant if ...; err != nil check, just return error ins
tead.
Found 1 lint suggestions; failing.
```

I think we can add a golint on travis.yml for each build ?
