### PR TITLE
constant provider id plus tests

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -30,6 +30,8 @@ import (
 const maxReturnedResults = 1000
 const maxLenPayloadCC = 1000
 
+const defaultProviderID = "firebase"
+
 var commonValidators = map[string]func(interface{}) error{
 	"displayName": validateDisplayName,
 	"email":       validateEmail,
@@ -622,6 +624,7 @@ func makeExportedUser(r *identitytoolkit.UserInfo) (*ExportedUserRecord, error) 
 				Email:       r.Email,
 				PhoneNumber: r.PhoneNumber,
 				PhotoURL:    r.PhotoUrl,
+				ProviderID:  defaultProviderID,
 				UID:         r.LocalId,
 			},
 			CustomClaims:     cc,

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -53,14 +53,14 @@ func (c *Client) setHeader(ic identitytoolkitCall) {
 
 // UserInfo is a collection of standard profile information for a user.
 type UserInfo struct {
-	DisplayName string `json:"displayName,omitempty"`
-	Email       string `json:"email,omitempty"`
-	PhoneNumber string `json:"phoneNumber,omitempty"`
-	PhotoURL    string `json:"photoUrl,omitempty"`
+	DisplayName string
+	Email       string
+	PhoneNumber string
+	PhotoURL    string
 	// ProviderID can be a short domain name (e.g. google.com),
 	// or the identity of an OpenID identity provider.
-	ProviderID string `json:"providerId,omitempty"`
-	UID        string `json:"localId,omitempty"`
+	ProviderID string
+	UID        string
 }
 
 // UserMetadata contains additional metadata associated with a user account.
@@ -500,32 +500,32 @@ func (u *UserToUpdate) preparePayload(user *identitytoolkit.IdentitytoolkitRelyi
 // Response Types -------------------------------
 
 type getUserResponse struct {
-	RequestType string               `json:"kind,omitempty"`
-	Users       []responseUserRecord `json:"users,omitempty"`
+	RequestType string
+	Users       []responseUserRecord
 }
 
 type responseUserRecord struct {
-	UID                string      `json:"localId,omitempty"`
-	DisplayName        string      `json:"displayName,omitempty"`
-	Email              string      `json:"email,omitempty"`
-	PhoneNumber        string      `json:"phoneNumber,omitempty"`
-	PhotoURL           string      `json:"photoUrl,omitempty"`
-	CreationTimestamp  int64       `json:"createdAt,string,omitempty"`
-	LastLogInTimestamp int64       `json:"lastLoginAt,string,omitempty"`
-	ProviderID         string      `json:"providerId,omitempty"`
-	CustomClaims       string      `json:"customAttributes,omitempty"`
-	Disabled           bool        `json:"disabled,omitempty"`
-	EmailVerified      bool        `json:"emailVerified,omitempty"`
-	ProviderUserInfo   []*UserInfo `json:"providerUserInfo,omitempty"`
-	PasswordHash       string      `json:"passwordHash,omitempty"`
-	PasswordSalt       string      `json:"salt,omitempty"`
-	ValidSince         int64       `json:"validSince,string,omitempty"`
+	UID                string
+	DisplayName        string
+	Email              string
+	PhoneNumber        string
+	PhotoURL           string
+	CreationTimestamp  int64
+	LastLogInTimestamp int64
+	ProviderID         string
+	CustomClaims       string
+	Disabled           bool
+	EmailVerified      bool
+	ProviderUserInfo   []*UserInfo
+	PasswordHash       string
+	PasswordSalt       string
+	ValidSince         int64
 }
 
 type listUsersResponse struct {
-	RequestType string               `json:"kind,omitempty"`
-	Users       []responseUserRecord `json:"users,omitempty"`
-	NextPage    string               `json:"nextPageToken,omitempty"`
+	RequestType string
+	Users       []responseUserRecord
+	NextPage    string
 }
 
 // Helper functions for retrieval and HTTP calls.

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -57,8 +57,9 @@ type UserInfo struct {
 	Email       string
 	PhoneNumber string
 	PhotoURL    string
-	// ProviderID can be a short domain name (e.g. google.com),
+	// In the ProviderUserInfo[] ProviderID can be a short domain name (e.g. google.com),
 	// or the identity of an OpenID identity provider.
+	// In UserRecord.UserInfo it will return the constant string "firebase".
 	ProviderID string
 	UID        string
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -41,6 +41,7 @@ var testUser = &UserRecord{
 		PhoneNumber: "+1234567890",
 		DisplayName: "Test User",
 		PhotoURL:    "http://www.example.com/testuser/photo.png",
+		ProviderID:  defaultProviderID,
 	},
 	Disabled: false,
 

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -212,7 +212,10 @@ func testUpdateUser(t *testing.T) {
 	}
 
 	want := &auth.UserRecord{
-		UserInfo: &auth.UserInfo{UID: testFixtures.sampleUserBlank.UID},
+		UserInfo: &auth.UserInfo{
+			UID:        testFixtures.sampleUserBlank.UID,
+			ProviderID: "firebase",
+		},
 		UserMetadata: &auth.UserMetadata{
 			CreationTimestamp: testFixtures.sampleUserBlank.UserMetadata.CreationTimestamp,
 		},
@@ -241,6 +244,7 @@ func testUpdateUser(t *testing.T) {
 			DisplayName: "name",
 			PhoneNumber: "+12345678901",
 			PhotoURL:    "http://photo.png",
+			ProviderID:  "firebase",
 			Email:       "abc@ab.ab",
 		},
 		UserMetadata: &auth.UserMetadata{


### PR DESCRIPTION
Setting the Provider ID to be the constant `firebase` for the UserInfo.
This is not part of the data stored for a user, it is overwritten for the returned value.

Also cleaning the json struct tags as they are no longer being used