### PR TITLE
Renamed some tests and test parameters for clarity

### DIFF
--- a/testdata/firebase_config.json
+++ b/testdata/firebase_config.json
@@ -1,4 +1,4 @@
 {
-  "projectId": "hipster-chat-mock",
-  "storageBucket": "hipster-chat.appspot.mock"
+  "projectId": "auto-init-project-id",
+  "storageBucket": "auto-init.storage.bucket"
 }

--- a/testdata/firebase_config_invalid_key.json
+++ b/testdata/firebase_config_invalid_key.json
@@ -1,4 +1,4 @@
 {
-  "project1d_bad_key": "hipster-chat-mock",
-  "storageBucket": "hipster-chat.appspot.mock"
+  "project1d_bad_key": "auto-init-project-id",
+  "storageBucket": "auto-init.storage.bucket"
 }

--- a/testdata/firebase_config_partial.json
+++ b/testdata/firebase_config_partial.json
@@ -1,3 +1,3 @@
 {
-  "projectId": "hipster-chat-mock"
+  "projectId": "auto-init-project-id"
 }


### PR DESCRIPTION
And also to adhere to Go conventions.

Sample output:

```
--- PASS: TestAutoInit (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=nil,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=file,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=string,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=file_missing_fields,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=string_missing_fields,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=file,opts=non-empty>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=string,opts=non-empty>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=file,opts=empty>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=string,opts=empty>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=file_unknown_key,opts=nil>) (0.00s)
    --- PASS: TestAutoInit/NewApp(<env=string_unknown_key,opts=nil>) (0.00s)

```