### PR TITLE
Firebase Cloud Messaging API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
-- 
+
+- [feature] Added the `messaging` package for sending Firebase notifications
+  and managing topic subscriptions.
 
 # v2.4.0
 

--- a/firebase.go
+++ b/firebase.go
@@ -28,6 +28,7 @@ import (
 	"firebase.google.com/go/auth"
 	"firebase.google.com/go/iid"
 	"firebase.google.com/go/internal"
+	"firebase.google.com/go/messaging"
 	"firebase.google.com/go/storage"
 
 	"golang.org/x/net/context"
@@ -43,6 +44,7 @@ var firebaseScopes = []string{
 	"https://www.googleapis.com/auth/firebase",
 	"https://www.googleapis.com/auth/identitytoolkit",
 	"https://www.googleapis.com/auth/userinfo.email",
+	"https://www.googleapis.com/auth/firebase.messaging",
 }
 
 // Version of the Firebase Go Admin SDK.
@@ -101,6 +103,16 @@ func (a *App) InstanceID(ctx context.Context) (*iid.Client, error) {
 		Opts:      a.opts,
 	}
 	return iid.NewClient(ctx, conf)
+}
+
+// Messaging returns an instance of messaging.Client.
+func (a *App) Messaging(ctx context.Context) (*messaging.Client, error) {
+	conf := &internal.MessagingConfig{
+		ProjectID: a.projectID,
+		Opts:      a.opts,
+		Version:   Version,
+	}
+	return messaging.NewClient(ctx, conf)
 }
 
 // NewApp creates a new App from the provided config and client options.

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -304,6 +304,18 @@ func TestInstanceID(t *testing.T) {
 	}
 }
 
+func TestMessaging(t *testing.T) {
+	ctx := context.Background()
+	app, err := NewApp(ctx, nil, option.WithCredentialsFile("testdata/service_account.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c, err := app.Messaging(ctx); c == nil || err != nil {
+		t.Errorf("Messaging() = (%v, %v); want (iid, nil)", c, err)
+	}
+}
+
 func TestCustomTokenSource(t *testing.T) {
 	ctx := context.Background()
 	ts := &testTokenSource{AccessToken: "mock-token-from-custom"}

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"regexp"
 	"testing"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -34,15 +33,7 @@ import (
 const testRegistrationToken = "fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKhWAGJQ4e3a" +
 	"rRCWzeTfHaLz83mBnDh0aPWB1AykXAVUUGl2h1wT4XI6XazWpvY7RBUSYfoxtqSWGIm2nvWh2BOP1YG501SsRoE"
 
-var (
-	client       *messaging.Client
-	testFixtures = struct {
-		token     string
-		topic     string
-		condition string
-	}{}
-	ttl = time.Duration(3) * time.Second
-)
+var client *messaging.Client
 
 // Enable API before testing
 // https://console.developers.google.com/apis/library/fcm.googleapis.com

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"firebase.google.com/go/integration/internal"
 	"firebase.google.com/go/messaging"
@@ -21,6 +22,8 @@ var testFixtures = struct {
 	topic     string
 	condition string
 }{}
+
+var ttl = time.Duration(3) * time.Second
 
 // Enable API before testing
 // https://console.developers.google.com/apis/library/fcm.googleapis.com/?project=
@@ -188,7 +191,7 @@ func TestSendData(t *testing.T) {
 	ctx := context.Background()
 	msg := &messaging.Message{
 		Token: testFixtures.token,
-		Data: map[string]interface{}{
+		Data: map[string]string{
 			"private_key":  "foo",
 			"client_email": "bar@test.com",
 		},
@@ -215,7 +218,7 @@ func TestSendAndroidNotification(t *testing.T) {
 		Android: &messaging.AndroidConfig{
 			CollapseKey: "Collapse",
 			Priority:    "HIGH",
-			TTL:         "3.5s",
+			TTL:         &ttl,
 			Notification: &messaging.AndroidNotification{
 				Title: "Android Title",
 				Body:  "Android body",
@@ -244,7 +247,7 @@ func TestSendAndroidData(t *testing.T) {
 		Android: &messaging.AndroidConfig{
 			CollapseKey: "Collapse",
 			Priority:    "HIGH",
-			TTL:         "3.5s",
+			TTL:         &ttl,
 			Data: map[string]string{
 				"private_key":  "foo",
 				"client_email": "bar@test.com",
@@ -271,9 +274,13 @@ func TestSendAPNSNotification(t *testing.T) {
 			Body:  "This is a Notification",
 		},
 		APNS: &messaging.APNSConfig{
-			Payload: map[string]string{
-				"title": "APNS Title ",
-				"body":  "APNS bodym",
+			Payload: &messaging.APNSPayload{
+				Aps: &messaging.Aps{
+					Alert: &messaging.ApsAlert{
+						Title: "APNS title",
+						Body:  "APNS body",
+					},
+				},
 			},
 		},
 	}

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -28,25 +28,28 @@ import (
 	"firebase.google.com/go/messaging"
 )
 
-const testRegistrationToken = "fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKhWAGJQ4e3arRCWzeTfHaLz83mBnDh0a" +
-	"PWB1AykXAVUUGl2h1wT4XI6XazWpvY7RBUSYfoxtqSWGIm2nvWh2BOP1YG501SsRoE"
+// The registration token has the proper format, but is not valid (i.e. expired). The intention of
+// these integration tests is to verify that the endpoints return the proper payload, but it is
+// hard to ensure this token remains valid. The tests below should still pass regardless.
+const testRegistrationToken = "fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKhWAGJQ4e3a" +
+	"rRCWzeTfHaLz83mBnDh0aPWB1AykXAVUUGl2h1wT4XI6XazWpvY7RBUSYfoxtqSWGIm2nvWh2BOP1YG501SsRoE"
 
-var client *messaging.Client
-
-var testFixtures = struct {
-	token     string
-	topic     string
-	condition string
-}{}
-
-var ttl = time.Duration(3) * time.Second
+var (
+	client       *messaging.Client
+	testFixtures = struct {
+		token     string
+		topic     string
+		condition string
+	}{}
+	ttl = time.Duration(3) * time.Second
+)
 
 // Enable API before testing
-// https://console.developers.google.com/apis/library/fcm.googleapis.com/?project=
+// https://console.developers.google.com/apis/library/fcm.googleapis.com
 func TestMain(m *testing.M) {
 	flag.Parse()
 	if testing.Short() {
-		log.Println("skipping Messaging integration tests in short mode.")
+		log.Println("Skipping messaging integration tests in short mode.")
 		return
 	}
 
@@ -95,7 +98,7 @@ func TestSend(t *testing.T) {
 	}
 	name, err := client.SendDryRun(context.Background(), msg)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalln(err)
 	}
 	const pattern = "^projects/.*/messages/.*$"
 	if !regexp.MustCompile(pattern).MatchString(name) {
@@ -105,8 +108,7 @@ func TestSend(t *testing.T) {
 
 func TestSendInvalidToken(t *testing.T) {
 	msg := &messaging.Message{Token: "INVALID_TOKEN"}
-	_, err := client.Send(context.Background(), msg)
-	if err == nil {
+	if _, err := client.Send(context.Background(), msg); err == nil {
 		t.Errorf("Send() = nil; want error")
 	}
 }

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -1,0 +1,315 @@
+package messaging
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"firebase.google.com/go/integration/internal"
+	"firebase.google.com/go/messaging"
+)
+
+var projectID string
+var client *messaging.Client
+
+var testFixtures = struct {
+	token     string
+	topic     string
+	condition string
+}{}
+
+// Enable API before testing
+// https://console.developers.google.com/apis/library/fcm.googleapis.com/?project=
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		log.Println("skipping Messaging integration tests in short mode.")
+		return
+	}
+
+	token, err := ioutil.ReadFile(internal.Resource("integration_token.txt"))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	testFixtures.token = string(token)
+
+	topic, err := ioutil.ReadFile(internal.Resource("integration_topic.txt"))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	testFixtures.topic = string(topic)
+
+	condition, err := ioutil.ReadFile(internal.Resource("integration_condition.txt"))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	testFixtures.condition = string(condition)
+
+	ctx := context.Background()
+	app, err := internal.NewTestApp(ctx)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	projectID, err = internal.ProjectID()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	client, err = app.Messaging(ctx)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestSendInvalidToken(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: "INVALID_TOKEN",
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	_, err := client.Send(ctx, msg)
+
+	if err == nil {
+		log.Fatal(err)
+	}
+}
+
+func TestSendDryRun(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	name, err := client.SendDryRun(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name != fmt.Sprintf("projects/%s/messages/fake_message_id", projectID) {
+		t.Errorf("Name : %s; want : projects/%s/messages/fake_message_id", name, projectID)
+	}
+}
+
+func TestSendToToken(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendToTopic(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Topic: testFixtures.topic,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendToCondition(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Condition: testFixtures.condition,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendNotification(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendData(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Data: map[string]interface{}{
+			"private_key":  "foo",
+			"client_email": "bar@test.com",
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendAndroidNotification(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+		Android: &messaging.AndroidConfig{
+			CollapseKey: "Collapse",
+			Priority:    "HIGH",
+			TTL:         "3.5s",
+			Notification: &messaging.AndroidNotification{
+				Title: "Android Title",
+				Body:  "Android body",
+			},
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendAndroidData(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+		Android: &messaging.AndroidConfig{
+			CollapseKey: "Collapse",
+			Priority:    "HIGH",
+			TTL:         "3.5s",
+			Data: map[string]string{
+				"private_key":  "foo",
+				"client_email": "bar@test.com",
+			},
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendAPNSNotification(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+		APNS: &messaging.APNSConfig{
+			Payload: map[string]string{
+				"title": "APNS Title ",
+				"body":  "APNS bodym",
+			},
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}
+
+func TestSendAPNSData(t *testing.T) {
+	ctx := context.Background()
+	msg := &messaging.Message{
+		Token: testFixtures.token,
+		Notification: &messaging.Notification{
+			Title: "My Title",
+			Body:  "This is a Notification",
+		},
+		APNS: &messaging.APNSConfig{
+			Headers: map[string]string{
+				"private_key":  "foo",
+				"client_email": "bar@test.com",
+			},
+		},
+	}
+	name, err := client.Send(ctx, msg)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if name == "" {
+		t.Errorf("Name : %s; want : projects/%s/messages/#id#", name, projectID)
+	}
+}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -46,6 +46,13 @@ type MockTokenSource struct {
 	AccessToken string
 }
 
+// MessagingConfig represents the configuration of Firebase Cloud Messaging service.
+type MessagingConfig struct {
+	Opts      []option.ClientOption
+	ProjectID string
+	Version   string
+}
+
 // Token returns the test token associated with the TokenSource.
 func (ts *MockTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: ts.AccessToken}, nil

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -43,11 +43,12 @@ var (
 
 	fcmErrorCodes = map[string]string{
 		"INVALID_ARGUMENT":   "request contains an invalid argument; code: invalid-argument",
-		"NOT_FOUND":          "request contains an invalid argument; code: registration-token-not-registered",
-		"PERMISSION_DENIED":  "client does not have permission to perform the requested operation; code: authentication-error",
-		"RESOURCE_EXHAUSTED": "messaging service quota exceeded; code: message-rate-exceeded",
-		"UNAUTHENTICATED":    "client failed to authenticate; code: authentication-error",
+		"UNREGISTERED":       "app instance has been unregistered; code: registration-token-not-registered",
+		"SENDER_ID_MISMATCH": "sender id does not match regisration token; code: authentication-error",
+		"QUOTA_EXCEEDED":     "messaging service quota exceeded; code: message-rate-exceeded",
+		"APNS_AUTH_ERROR":    "apns certificate or auth key was invalid; code: authentication-error",
 		"UNAVAILABLE":        "backend servers are temporarily unavailable; code: server-unavailable",
+		"INTERNAL":           "back servers encountered an unknown internl error; code: internal-error",
 	}
 
 	iidErrorCodes = map[string]string{
@@ -416,7 +417,7 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 	json.Unmarshal(resp.Body, &fe) // ignore any json parse errors at this level
 	msg := fcmErrorCodes[fe.Error.Status]
 	if msg == "" {
-		msg = fmt.Sprintf("client encountered an unknown error; response: %s", string(resp.Body))
+		msg = fmt.Sprintf("server responded with an unknown error; response: %s", string(resp.Body))
 	}
 	return "", fmt.Errorf("http error status: %d; reason: %s", resp.Status, msg)
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -81,8 +81,22 @@ type Message struct {
 	Webpush      *WebpushConfig    `json:"webpush,omitempty"`
 	APNS         *APNSConfig       `json:"apns,omitempty"`
 	Token        string            `json:"token,omitempty"`
-	Topic        string            `json:"topic,omitempty"`
+	Topic        string            `json:"-"`
 	Condition    string            `json:"condition,omitempty"`
+}
+
+// MarshalJSON marshals a Message into JSON (for internal use only).
+func (m *Message) MarshalJSON() ([]byte, error) {
+	// Create a new type to prevent infinite recursion.
+	type messageInternal Message
+	s := &struct {
+		BareTopic string `json:"topic,omitempty"`
+		*messageInternal
+	}{
+		BareTopic:       strings.TrimPrefix(m.Topic, "/topics/"),
+		messageInternal: (*messageInternal)(m),
+	}
+	return json.Marshal(s)
 }
 
 // Notification is the basic notification template to use across all platforms.

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -408,7 +408,7 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 }
 
 func (c *Client) makeTopicManagementRequest(ctx context.Context, req *iidRequest) (*TopicManagementResponse, error) {
-	if req.Tokens == nil {
+	if len(req.Tokens) == 0 {
 		return nil, fmt.Errorf("no tokens specified")
 	}
 	if len(req.Tokens) > 1000 {

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -194,7 +194,7 @@ func (p *APNSPayload) MarshalJSON() ([]byte, error) {
 type Aps struct {
 	AlertString      string    `json:"-"`
 	Alert            *ApsAlert `json:"-"`
-	Badge            int       `json:"badge,omitempty"`
+	Badge            *int      `json:"badge,omitempty"`
 	Sound            string    `json:"sound,omitempty"`
 	ContentAvailable bool      `json:"-"`
 	Category         string    `json:"category,omitempty"`
@@ -214,7 +214,7 @@ func (a *Aps) MarshalJSON() ([]byte, error) {
 
 	if a.Alert != nil {
 		s.Alert = a.Alert
-	} else {
+	} else if a.AlertString != "" {
 		s.Alert = a.AlertString
 	}
 	if a.ContentAvailable {

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -1,0 +1,291 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package messaging contains functions for sending messages and managing
+// device subscriptions with Firebase Cloud Messaging.
+package messaging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"firebase.google.com/go/internal"
+	"google.golang.org/api/transport"
+)
+
+const messagingEndpoint = "https://fcm.googleapis.com/v1"
+
+var errorCodes = map[int]string{
+	http.StatusBadRequest:          "malformed argument",
+	http.StatusUnauthorized:        "request not authorized",
+	http.StatusForbidden:           "project does not match or the client does not have sufficient privileges",
+	http.StatusNotFound:            "failed to find the ...",
+	http.StatusConflict:            "already deleted",
+	http.StatusTooManyRequests:     "request throttled out by the backend server",
+	http.StatusInternalServerError: "internal server error",
+	http.StatusServiceUnavailable:  "backend servers are over capacity",
+}
+
+// Client is the interface for the Firebase Messaging service.
+type Client struct {
+	// To enable testing against arbitrary endpoints.
+	endpoint string
+	client   *internal.HTTPClient
+	project  string
+	version  string
+}
+
+// RequestMessage is the request body message to send by Firebase Cloud Messaging Service.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send
+type requestMessage struct {
+	ValidateOnly bool     `json:"validate_only,omitempty"`
+	Message      *Message `json:"message,omitempty"`
+}
+
+// responseMessage is the identifier of the message sent.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages
+type responseMessage struct {
+	Name string `json:"name"`
+}
+
+// Message is the message to send by Firebase Cloud Messaging Service.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Message
+type Message struct {
+	Name         string                 `json:"name,omitempty"`
+	Data         map[string]interface{} `json:"data,omitempty"`
+	Notification *Notification          `json:"notification,omitempty"`
+	Android      *AndroidConfig         `json:"android,omitempty"`
+	Webpush      *WebpushConfig         `json:"webpush,omitempty"`
+	APNS         *APNSConfig            `json:"apns,omitempty"`
+	Token        string                 `json:"token,omitempty"`
+	Topic        string                 `json:"topic,omitempty"`
+	Condition    string                 `json:"condition,omitempty"`
+}
+
+// Notification is the Basic notification template to use across all platforms.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Notification
+type Notification struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+}
+
+// AndroidConfig is Android specific options for messages.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidConfig
+type AndroidConfig struct {
+	CollapseKey           string               `json:"collapse_key,omitempty"`
+	Priority              string               `json:"priority,omitempty"`
+	TTL                   string               `json:"ttl,omitempty"`
+	RestrictedPackageName string               `json:"restricted_package_name,omitempty"`
+	Data                  map[string]string    `json:"data,omitempty"`
+	Notification          *AndroidNotification `json:"notification,omitempty"`
+}
+
+// AndroidNotification is notification to send to android devices.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#AndroidNotification
+type AndroidNotification struct {
+	Title        string   `json:"title,omitempty"`
+	Body         string   `json:"body,omitempty"`
+	Icon         string   `json:"icon,omitempty"`
+	Color        string   `json:"color,omitempty"`
+	Sound        string   `json:"sound,omitempty"`
+	Tag          string   `json:"tag,omitempty"`
+	ClickAction  string   `json:"click_action,omitempty"`
+	BodyLocKey   string   `json:"body_loc_key,omitempty"`
+	BodyLocArgs  []string `json:"body_loc_args,omitempty"`
+	TitleLocKey  string   `json:"title_loc_key,omitempty"`
+	TitleLocArgs []string `json:"title_loc_args,omitempty"`
+}
+
+// WebpushConfig is Webpush protocol options.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#WebpushConfig
+type WebpushConfig struct {
+	Headers      map[string]string    `json:"headers,omitempty"`
+	Data         map[string]string    `json:"data,omitempty"`
+	Notification *WebpushNotification `json:"notification,omitempty"`
+}
+
+// WebpushNotification is Web notification to send via webpush protocol.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#WebpushNotification
+type WebpushNotification struct {
+	Title string `json:"title,omitempty"`
+	Body  string `json:"body,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+}
+
+// APNSConfig is Apple Push Notification Service specific options.
+// See https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#apnsconfig
+type APNSConfig struct {
+	Headers map[string]string `json:"headers,omitempty"`
+	Payload map[string]string `json:"payload,omitempty"`
+}
+
+// NewClient creates a new instance of the Firebase Cloud Messaging Client.
+//
+// This function can only be invoked from within the SDK. Client applications should access the
+// the Messaging service through firebase.App.
+func NewClient(ctx context.Context, c *internal.MessagingConfig) (*Client, error) {
+	if c.ProjectID == "" {
+		return nil, errors.New("project id is required to access firebase cloud messaging client")
+	}
+
+	hc, _, err := transport.NewHTTPClient(ctx, c.Opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		endpoint: messagingEndpoint,
+		client:   &internal.HTTPClient{Client: hc},
+		project:  c.ProjectID,
+		version:  "Go/Admin/" + c.Version,
+	}, nil
+}
+
+// Send sends a Message to Firebase Cloud Messaging.
+//
+// Send a message to specified target (a registration token, topic or condition).
+// https://firebase.google.com/docs/cloud-messaging/send-message
+func (c *Client) Send(ctx context.Context, message *Message) (string, error) {
+	if err := validateMessage(message); err != nil {
+		return "", err
+	}
+	payload := &requestMessage{
+		Message: message,
+	}
+	return c.sendRequestMessage(ctx, payload)
+}
+
+// SendDryRun sends a dryRun Message to Firebase Cloud Messaging.
+//
+// Send a message to specified target (a registration token, topic or condition).
+// https://firebase.google.com/docs/cloud-messaging/send-message
+func (c *Client) SendDryRun(ctx context.Context, message *Message) (string, error) {
+	if err := validateMessage(message); err != nil {
+		return "", err
+	}
+	payload := &requestMessage{
+		ValidateOnly: true,
+		Message:      message,
+	}
+	return c.sendRequestMessage(ctx, payload)
+}
+
+func (c *Client) sendRequestMessage(ctx context.Context, payload *requestMessage) (string, error) {
+	versionHeader := internal.WithHeader("X-Client-Version", c.version)
+
+	request := &internal.Request{
+		Method: http.MethodPost,
+		URL:    fmt.Sprintf("%s/projects/%s/messages:send", c.endpoint, c.project),
+		Body:   internal.NewJSONEntity(payload),
+		Opts:   []internal.HTTPOption{versionHeader},
+	}
+	resp, err := c.client.Do(ctx, request)
+	if err != nil {
+		return "", err
+	}
+
+	if _, ok := errorCodes[resp.Status]; ok {
+		return "", fmt.Errorf("unexpected http status code : %d, reason: %v", resp.Status, string(resp.Body))
+	}
+
+	result := &responseMessage{}
+	err = resp.Unmarshal(http.StatusOK, result)
+
+	return result.Name, err
+}
+
+// validateMessage
+func validateMessage(message *Message) error {
+	if message == nil {
+		return fmt.Errorf("message is empty")
+	}
+
+	target := bool2int(message.Token != "") + bool2int(message.Condition != "") + bool2int(message.Topic != "")
+	if target != 1 {
+		return fmt.Errorf("Exactly one of token, topic or condition must be specified")
+	}
+
+	// Validate target
+	if message.Topic != "" {
+		if strings.HasPrefix(message.Topic, "/topics/") {
+			return fmt.Errorf("Topic name must not contain the /topics/ prefix")
+		}
+		if !regexp.MustCompile("[a-zA-Z0-9-_.~%]+").MatchString(message.Topic) {
+			return fmt.Errorf("Malformed topic name")
+		}
+	}
+
+	// validate AndroidConfig
+	if message.Android != nil {
+		if err := validateAndroidConfig(message.Android); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateAndroidConfig(config *AndroidConfig) error {
+	if config.TTL != "" && !strings.HasSuffix(config.TTL, "s") {
+		return fmt.Errorf("ttl must end with 's'")
+	}
+
+	if _, err := time.ParseDuration(config.TTL); err != nil {
+		return fmt.Errorf("invalid TTL")
+	}
+
+	if config.Priority != "" {
+		if config.Priority != "normal" && config.Priority != "high" {
+			return fmt.Errorf("priority must be 'normal' or 'high'")
+		}
+	}
+	// validate AndroidNotification
+	if config.Notification != nil {
+		if err := validateAndroidNotification(config.Notification); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAndroidNotification(notification *AndroidNotification) error {
+	if notification.Color != "" {
+		if !regexp.MustCompile("^#[0-9a-fA-F]{6}$").MatchString(notification.Color) {
+			return fmt.Errorf("color must be in the form #RRGGBB")
+		}
+	}
+	if len(notification.TitleLocArgs) > 0 {
+		if notification.TitleLocKey == "" {
+			return fmt.Errorf("titleLocKey is required when specifying titleLocArgs")
+		}
+	}
+	if len(notification.BodyLocArgs) > 0 {
+		if notification.BodyLocKey == "" {
+			return fmt.Errorf("bodyLocKey is required when specifying bodyLocArgs")
+		}
+	}
+	return nil
+}
+
+func bool2int(b bool) int8 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -1,0 +1,117 @@
+package messaging
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"google.golang.org/api/option"
+
+	"firebase.google.com/go/internal"
+)
+
+var testMessagingConfig = &internal.MessagingConfig{
+	ProjectID: "test-project",
+	Opts: []option.ClientOption{
+		option.WithTokenSource(&internal.MockTokenSource{AccessToken: "test-token"}),
+	},
+}
+
+func TestNoProjectID(t *testing.T) {
+	client, err := NewClient(context.Background(), &internal.MessagingConfig{})
+	if client != nil || err == nil {
+		t.Errorf("NewClient() = (%v, %v); want = (nil, error)", client, err)
+	}
+}
+
+func TestEmptyTarget(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = client.Send(ctx, &Message{})
+	if err == nil {
+		t.Errorf("SendMessage(Message{empty}) = nil; want error")
+	}
+}
+
+func TestSend(t *testing.T) {
+	var tr *http.Request
+	msgName := "projects/test-project/messages/0:1500415314455276%31bd1c9631bd1c96"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{ \"Name\":\"" + msgName + "\" }"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.endpoint = ts.URL
+	name, err := client.Send(ctx, &Message{Topic: "my-topic"})
+	if err != nil {
+		t.Errorf("SendMessage() = %v; want nil", err)
+	}
+
+	if name != msgName {
+		t.Errorf("response Name = %q; want = %q", name, msgName)
+	}
+
+	if tr.Body == nil {
+		t.Fatalf("Request = nil; want non-nil")
+	}
+	if tr.Method != http.MethodPost {
+		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
+	}
+	if tr.URL.Path != "/projects/test-project/messages:send" {
+		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/projects/test-project/messages:send")
+	}
+	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+	}
+}
+
+func TestSendDryRun(t *testing.T) {
+	var tr *http.Request
+	msgName := "projects/test-project/messages/0:1500415314455276%31bd1c9631bd1c96"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{ \"Name\":\"" + msgName + "\" }"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.endpoint = ts.URL
+	name, err := client.SendDryRun(ctx, &Message{Topic: "my-topic"})
+	if err != nil {
+		t.Errorf("SendMessage() = %v; want nil", err)
+	}
+
+	if name != msgName {
+		t.Errorf("response Name = %q; want = %q", name, msgName)
+	}
+
+	if tr.Body == nil {
+		t.Fatalf("Request = nil; want non-nil")
+	}
+	if tr.Method != http.MethodPost {
+		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
+	}
+	if tr.URL.Path != "/projects/test-project/messages:send" {
+		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/projects/test-project/messages:send")
+	}
+	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+	}
+}

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -627,7 +627,7 @@ func TestSendError(t *testing.T) {
 	}{
 		{
 			resp: "{}",
-			want: "http error status: 500; reason: client encountered an unknown error; response: {}",
+			want: "http error status: 500; reason: server responded with an unknown error; response: {}",
 		},
 		{
 			resp: "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
@@ -635,7 +635,7 @@ func TestSendError(t *testing.T) {
 		},
 		{
 			resp: "not json",
-			want: "http error status: 500; reason: client encountered an unknown error; response: not json",
+			want: "http error status: 500; reason: server responded with an unknown error; response: not json",
 		},
 	}
 	for _, tc := range cases {

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -532,15 +532,15 @@ func TestSendError(t *testing.T) {
 	}{
 		{
 			resp: "{}",
-			want: "http error status: 500; body: {}; code: unknown-error",
+			want: "http error status: 500; reason: client encounterd an unknown error; response: {}",
 		},
 		{
 			resp: "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
-			want: "test error; code: invalid-argument",
+			want: "http error status: 500; reason: request contains an invalid argument; code: invalid-argument",
 		},
 		{
 			resp: "not json",
-			want: "http error status: 500; body: not json; code: unknown-error",
+			want: "http error status: 500; reason: client encounterd an unknown error; response: not json",
 		},
 	}
 	for _, tc := range cases {

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -206,6 +206,24 @@ var validMessages = []struct {
 		},
 	},
 	{
+		name: "APNSHeadersOnly",
+		req: &Message{
+			APNS: &APNSConfig{
+				Headers: map[string]string{
+					"h1": "v1",
+					"h2": "v2",
+				},
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"apns": map[string]interface{}{
+				"headers": map[string]interface{}{"h1": "v1", "h2": "v2"},
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
 		name: "APNSAlertString",
 		req: &Message{
 			APNS: &APNSConfig{

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -2,9 +2,13 @@ package messaging
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
+	"time"
 
 	"google.golang.org/api/option"
 
@@ -15,6 +19,144 @@ var testMessagingConfig = &internal.MessagingConfig{
 	ProjectID: "test-project",
 	Opts: []option.ClientOption{
 		option.WithTokenSource(&internal.MockTokenSource{AccessToken: "test-token"}),
+	},
+}
+
+var ttlWithNanos = time.Duration(1500) * time.Millisecond
+var ttl = time.Duration(10) * time.Second
+
+var validMessages = []struct {
+	name string
+	req  *Message
+	want map[string]interface{}
+}{
+	{
+		name: "token only",
+		req:  &Message{Token: "test-token"},
+		want: map[string]interface{}{"token": "test-token"},
+	},
+	{
+		name: "topic only",
+		req:  &Message{Topic: "test-topic"},
+		want: map[string]interface{}{"topic": "test-topic"},
+	},
+	{
+		name: "condition only",
+		req:  &Message{Condition: "test-condition"},
+		want: map[string]interface{}{"condition": "test-condition"},
+	},
+	{
+		name: "data message",
+		req: &Message{
+			Data: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"data": map[string]interface{}{
+				"k1": "v1",
+				"k2": "v2",
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
+		name: "notification message",
+		req: &Message{
+			Notification: &Notification{
+				Title: "t",
+				Body:  "b",
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"notification": map[string]interface{}{
+				"title": "t",
+				"body":  "b",
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
+		name: "android 1",
+		req: &Message{
+			Android: &AndroidConfig{
+				CollapseKey: "ck",
+				Data: map[string]string{
+					"k1": "v1",
+					"k2": "v2",
+				},
+				Priority: "normal",
+				TTL:      &ttl,
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"android": map[string]interface{}{
+				"collapse_key": "ck",
+				"data": map[string]interface{}{
+					"k1": "v1",
+					"k2": "v2",
+				},
+				"priority": "normal",
+				"ttl":      "10s",
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
+		name: "android 2",
+		req: &Message{
+			Android: &AndroidConfig{
+				RestrictedPackageName: "rpn",
+				Notification: &AndroidNotification{
+					Title:        "t",
+					Body:         "b",
+					Color:        "#112233",
+					Sound:        "s",
+					TitleLocKey:  "tlk",
+					TitleLocArgs: []string{"t1", "t2"},
+					BodyLocKey:   "blk",
+					BodyLocArgs:  []string{"b1", "b2"},
+				},
+				TTL: &ttlWithNanos,
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"android": map[string]interface{}{
+				"restricted_package_name": "rpn",
+				"notification": map[string]interface{}{
+					"title":          "t",
+					"body":           "b",
+					"color":          "#112233",
+					"sound":          "s",
+					"title_loc_key":  "tlk",
+					"title_loc_args": []interface{}{"t1", "t2"},
+					"body_loc_key":   "blk",
+					"body_loc_args":  []interface{}{"b1", "b2"},
+				},
+				"ttl": "1.500000000s",
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
+		name: "android 3",
+		req: &Message{
+			Android: &AndroidConfig{
+				Priority: "high",
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"android": map[string]interface{}{
+				"priority": "high",
+			},
+			"topic": "test-topic",
+		},
 	},
 }
 
@@ -40,11 +182,13 @@ func TestEmptyTarget(t *testing.T) {
 
 func TestSend(t *testing.T) {
 	var tr *http.Request
-	msgName := "projects/test-project/messages/0:1500415314455276%31bd1c9631bd1c96"
+	var b []byte
+	msgName := "projects/test-project/messages/msg_id"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tr = r
+		b, _ = ioutil.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("{ \"Name\":\"" + msgName + "\" }"))
+		w.Write([]byte("{ \"name\":\"" + msgName + "\" }"))
 	}))
 	defer ts.Close()
 
@@ -54,26 +198,33 @@ func TestSend(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.endpoint = ts.URL
-	name, err := client.Send(ctx, &Message{Topic: "my-topic"})
-	if err != nil {
-		t.Errorf("SendMessage() = %v; want nil", err)
-	}
 
-	if name != msgName {
-		t.Errorf("response Name = %q; want = %q", name, msgName)
-	}
+	for _, tc := range validMessages {
+		name, err := client.Send(ctx, tc.req)
+		if err != nil {
+			t.Errorf("[%s] Send() = %v; want nil", tc.name, err)
+		}
+		if name != msgName {
+			t.Errorf("[%s] Response = %q; want = %q", tc.name, name, msgName)
+		}
 
-	if tr.Body == nil {
-		t.Fatalf("Request = nil; want non-nil")
-	}
-	if tr.Method != http.MethodPost {
-		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
-	}
-	if tr.URL.Path != "/projects/test-project/messages:send" {
-		t.Errorf("Path = %q; want = %q", tr.URL.Path, "/projects/test-project/messages:send")
-	}
-	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
-		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+		var parsed map[string]interface{}
+		if err := json.Unmarshal(b, &parsed); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(parsed["message"], tc.want) {
+			t.Errorf("[%s] Body = %v; want = %v", tc.name, parsed["message"], tc.want)
+		}
+
+		if tr.Method != http.MethodPost {
+			t.Errorf("[%s] Method = %q; want = %q", tc.name, tr.Method, http.MethodPost)
+		}
+		if tr.URL.Path != "/projects/test-project/messages:send" {
+			t.Errorf("[%s] Path = %q; want = %q", tc.name, tr.URL.Path, "/projects/test-project/messages:send")
+		}
+		if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+			t.Errorf("[%s] Authorization = %q; want = %q", tc.name, h, "Bearer test-token")
+		}
 	}
 }
 

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -64,6 +64,11 @@ var validMessages = []struct {
 		want: map[string]interface{}{"topic": "test-topic"},
 	},
 	{
+		name: "PrefixedTopicOnly",
+		req:  &Message{Topic: "/topics/test-topic"},
+		want: map[string]interface{}{"topic": "test-topic"},
+	},
+	{
 		name: "ConditionOnly",
 		req:  &Message{Condition: "test-condition"},
 		want: map[string]interface{}{"condition": "test-condition"},
@@ -370,11 +375,11 @@ var invalidMessages = []struct {
 		want: "exactly one of token, topic or condition must be specified",
 	},
 	{
-		name: "InvalidTopicPrefix",
+		name: "InvalidPrefixedTopicName",
 		req: &Message{
-			Topic: "/topics/foo",
+			Topic: "/topics/",
 		},
-		want: "topic name must not contain the /topics/ prefix",
+		want: "malformed topic name",
 	},
 	{
 		name: "InvalidTopicName",

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -586,7 +586,7 @@ func TestSendError(t *testing.T) {
 	}{
 		{
 			resp: "{}",
-			want: "http error status: 500; reason: client encounterd an unknown error; response: {}",
+			want: "http error status: 500; reason: client encountered an unknown error; response: {}",
 		},
 		{
 			resp: "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
@@ -594,7 +594,7 @@ func TestSendError(t *testing.T) {
 		},
 		{
 			resp: "not json",
-			want: "http error status: 500; reason: client encounterd an unknown error; response: not json",
+			want: "http error status: 500; reason: client encountered an unknown error; response: not json",
 		},
 	}
 	for _, tc := range cases {
@@ -728,7 +728,7 @@ func TestTopicManagementError(t *testing.T) {
 	}{
 		{
 			resp: "{}",
-			want: "http error status: 500; reason: client encounterd an unknown error; response: {}",
+			want: "http error status: 500; reason: client encountered an unknown error; response: {}",
 		},
 		{
 			resp: "{\"error\": \"INVALID_ARGUMENT\"}",
@@ -736,7 +736,7 @@ func TestTopicManagementError(t *testing.T) {
 		},
 		{
 			resp: "not json",
-			want: "http error status: 500; reason: client encounterd an unknown error; response: not json",
+			want: "http error status: 500; reason: client encountered an unknown error; response: not json",
 		},
 	}
 	for _, tc := range cases {

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -1,0 +1,126 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func validateMessage(message *Message) error {
+	if message == nil {
+		return fmt.Errorf("message must not be nil")
+	}
+
+	target := bool2int(message.Token != "") + bool2int(message.Condition != "") + bool2int(message.Topic != "")
+	if target != 1 {
+		return fmt.Errorf("exactly one of token, topic or condition must be specified")
+	}
+
+	// validate topic
+	if message.Topic != "" {
+		if strings.HasPrefix(message.Topic, "/topics/") {
+			return fmt.Errorf("topic name must not contain the /topics/ prefix")
+		}
+		if !regexp.MustCompile("^[a-zA-Z0-9-_.~%]+$").MatchString(message.Topic) {
+			return fmt.Errorf("malformed topic name")
+		}
+	}
+
+	// validate AndroidConfig
+	if err := validateAndroidConfig(message.Android); err != nil {
+		return err
+	}
+
+	// validate APNSConfig
+	return validateAPNSConfig(message.APNS)
+}
+
+func validateAndroidConfig(config *AndroidConfig) error {
+	if config == nil {
+		return nil
+	}
+
+	if config.TTL != nil && config.TTL.Seconds() < 0 {
+		return fmt.Errorf("ttl duration must not be negative")
+	}
+	if config.Priority != "" && config.Priority != "normal" && config.Priority != "high" {
+		return fmt.Errorf("priority must be 'normal' or 'high'")
+	}
+	// validate AndroidNotification
+	return validateAndroidNotification(config.Notification)
+}
+
+func validateAndroidNotification(notification *AndroidNotification) error {
+	if notification == nil {
+		return nil
+	}
+	const colorPattern = "^#[0-9a-fA-F]{6}$"
+	if notification.Color != "" && !regexp.MustCompile(colorPattern).MatchString(notification.Color) {
+		return fmt.Errorf("color must be in the #RRGGBB form")
+	}
+	if len(notification.TitleLocArgs) > 0 && notification.TitleLocKey == "" {
+		return fmt.Errorf("titleLocKey is required when specifying titleLocArgs")
+	}
+	if len(notification.BodyLocArgs) > 0 && notification.BodyLocKey == "" {
+		return fmt.Errorf("bodyLocKey is required when specifying bodyLocArgs")
+	}
+	return nil
+}
+
+func validateAPNSConfig(config *APNSConfig) error {
+	if config != nil {
+		return validateAPNSPayload(config.Payload)
+	}
+	return nil
+}
+
+func validateAPNSPayload(payload *APNSPayload) error {
+	if payload != nil {
+		return validateAps(payload.Aps)
+	}
+	return nil
+}
+
+func validateAps(aps *Aps) error {
+	if aps != nil {
+		if aps.Alert != nil && aps.AlertString != "" {
+			return fmt.Errorf("multiple alert specifications")
+		}
+		return validateApsAlert(aps.Alert)
+	}
+	return nil
+}
+
+func validateApsAlert(alert *ApsAlert) error {
+	if alert == nil {
+		return nil
+	}
+	if len(alert.TitleLocArgs) > 0 && alert.TitleLocKey == "" {
+		return fmt.Errorf("titleLocKey is required when specifying titleLocArgs")
+	}
+	if len(alert.LocArgs) > 0 && alert.LocKey == "" {
+		return fmt.Errorf("locKey is required when specifying locArgs")
+	}
+	return nil
+}
+
+func bool2int(b bool) int8 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -30,8 +30,8 @@ func validateMessage(message *Message) error {
 		return fmt.Errorf("message must not be nil")
 	}
 
-	target := bool2int(message.Token != "") + bool2int(message.Condition != "") + bool2int(message.Topic != "")
-	if target != 1 {
+	targets := countNonEmpty(message.Token, message.Condition, message.Topic)
+	if targets != 1 {
 		return fmt.Errorf("exactly one of token, topic or condition must be specified")
 	}
 
@@ -122,9 +122,12 @@ func validateApsAlert(alert *ApsAlert) error {
 	return nil
 }
 
-func bool2int(b bool) int8 {
-	if b {
-		return 1
+func countNonEmpty(strings ...string) int {
+	count := 0
+	for _, s := range strings {
+		if s != "" {
+			count++
+		}
 	}
-	return 0
+	return count
 }

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -37,10 +37,8 @@ func validateMessage(message *Message) error {
 
 	// validate topic
 	if message.Topic != "" {
-		if strings.HasPrefix(message.Topic, "/topics/") {
-			return fmt.Errorf("topic name must not contain the /topics/ prefix")
-		}
-		if !bareTopicNamePattern.MatchString(message.Topic) {
+		bt := strings.TrimPrefix(message.Topic, "/topics/")
+		if !bareTopicNamePattern.MatchString(bt) {
 			return fmt.Errorf("malformed topic name")
 		}
 	}

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -20,6 +20,11 @@ import (
 	"strings"
 )
 
+var (
+	bareTopicNamePattern = regexp.MustCompile("^[a-zA-Z0-9-_.~%]+$")
+	colorPattern         = regexp.MustCompile("^#[0-9a-fA-F]{6}$")
+)
+
 func validateMessage(message *Message) error {
 	if message == nil {
 		return fmt.Errorf("message must not be nil")
@@ -35,7 +40,7 @@ func validateMessage(message *Message) error {
 		if strings.HasPrefix(message.Topic, "/topics/") {
 			return fmt.Errorf("topic name must not contain the /topics/ prefix")
 		}
-		if !regexp.MustCompile("^[a-zA-Z0-9-_.~%]+$").MatchString(message.Topic) {
+		if !bareTopicNamePattern.MatchString(message.Topic) {
 			return fmt.Errorf("malformed topic name")
 		}
 	}
@@ -68,8 +73,7 @@ func validateAndroidNotification(notification *AndroidNotification) error {
 	if notification == nil {
 		return nil
 	}
-	const colorPattern = "^#[0-9a-fA-F]{6}$"
-	if notification.Color != "" && !regexp.MustCompile(colorPattern).MatchString(notification.Color) {
+	if notification.Color != "" && !colorPattern.MatchString(notification.Color) {
 		return fmt.Errorf("color must be in the #RRGGBB form")
 	}
 	if len(notification.TitleLocArgs) > 0 && notification.TitleLocKey == "" {


### PR DESCRIPTION
This PR builds on the work by @chemidy at #62. Implements the following public API calls in the new `messaging` package:

```
Send(ctx context.Context, m *Message) (string, error)
SubscribeToTopic(ctx context.Context, tokens []string, topic string) (*TopicManagementResponse, error)
UnsubscribeFromTopic(ctx context.Context, tokens []string, topic string) (*TopicManagementResponse, error)
```

go/firebase-admin-fcm-api