### PR TITLE
Accepting prefixed topic names

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -81,8 +81,21 @@ type Message struct {
 	Webpush      *WebpushConfig    `json:"webpush,omitempty"`
 	APNS         *APNSConfig       `json:"apns,omitempty"`
 	Token        string            `json:"token,omitempty"`
-	Topic        string            `json:"topic,omitempty"`
+	Topic        string            `json:"-"`
 	Condition    string            `json:"condition,omitempty"`
+}
+
+// MarshalJSON marshals a Message into JSON (for internal use only).
+func (m *Message) MarshalJSON() ([]byte, error) {
+	type messageInternal Message
+	s := &struct {
+		BareTopic string `json:"topic,omitempty"`
+		*messageInternal
+	}{
+		BareTopic:       strings.TrimPrefix(m.Topic, "/topics/"),
+		messageInternal: (*messageInternal)(m),
+	}
+	return json.Marshal(s)
 }
 
 // Notification is the basic notification template to use across all platforms.

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -87,6 +87,7 @@ type Message struct {
 
 // MarshalJSON marshals a Message into JSON (for internal use only).
 func (m *Message) MarshalJSON() ([]byte, error) {
+	// Create a new type to prevent infinite recursion.
 	type messageInternal Message
 	s := &struct {
 		BareTopic string `json:"topic,omitempty"`

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -64,6 +64,11 @@ var validMessages = []struct {
 		want: map[string]interface{}{"topic": "test-topic"},
 	},
 	{
+		name: "PrefixedTopicOnly",
+		req:  &Message{Topic: "/topics/test-topic"},
+		want: map[string]interface{}{"topic": "test-topic"},
+	},
+	{
 		name: "ConditionOnly",
 		req:  &Message{Condition: "test-condition"},
 		want: map[string]interface{}{"condition": "test-condition"},
@@ -370,11 +375,11 @@ var invalidMessages = []struct {
 		want: "exactly one of token, topic or condition must be specified",
 	},
 	{
-		name: "InvalidTopicPrefix",
+		name: "InvalidPrefixedTopicName",
 		req: &Message{
-			Topic: "/topics/foo",
+			Topic: "/topics/",
 		},
-		want: "topic name must not contain the /topics/ prefix",
+		want: "malformed topic name",
 	},
 	{
 		name: "InvalidTopicName",

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -37,10 +37,8 @@ func validateMessage(message *Message) error {
 
 	// validate topic
 	if message.Topic != "" {
-		if strings.HasPrefix(message.Topic, "/topics/") {
-			return fmt.Errorf("topic name must not contain the /topics/ prefix")
-		}
-		if !bareTopicNamePattern.MatchString(message.Topic) {
+		bt := strings.TrimPrefix(message.Topic, "/topics/")
+		if !bareTopicNamePattern.MatchString(bt) {
 			return fmt.Errorf("malformed topic name")
 		}
 	}


### PR DESCRIPTION
The new FCM API does not accept topic names prefixed with `/topics/`. But we can easily check for this in the SDK and remove it. This results in a better and consistent dev experience since the other methods in this API accepts prefixed topic names.

