### PR TITLE
Introducing the QueryNode interface to handle ordered query results

### DIFF
--- a/integration/db/query_test.go
+++ b/integration/db/query_test.go
@@ -17,6 +17,10 @@ package db
 import (
 	"testing"
 
+	"firebase.google.com/go/db"
+
+	"reflect"
+
 	"golang.org/x/net/context"
 )
 
@@ -25,190 +29,171 @@ var heightSorted = []string{
 	"triceratops", "stegosaurus", "bruhathkayosaurus",
 }
 
-func min(i, j int) int {
-	if i < j {
-		return i
-	}
-	return j
-}
-
 func TestLimitToFirst(t *testing.T) {
 	for _, tc := range []int{2, 10} {
-		var d []Dinosaur
-		if err := dinos.OrderByChild("height").
-			LimitToFirst(tc).
-			GetOrdered(context.Background(), &d); err != nil {
+		results, err := dinos.OrderByChild("height").LimitToFirst(tc).GetOrdered(context.Background())
+		if err != nil {
 			t.Fatal(err)
 		}
 
 		wl := min(tc, len(heightSorted))
 		want := heightSorted[:wl]
-		if len(d) != wl {
-			t.Errorf("LimitToFirst() = %d; want = %d", len(d), wl)
+		if len(results) != wl {
+			t.Errorf("LimitToFirst() = %d; want = %d", len(results), wl)
 		}
-		for i, w := range want {
-			if d[i] != parsedTestData[w] {
-				t.Errorf("[%d] LimitToFirst() = %v; want = %v", i, d[i], parsedTestData[w])
-			}
+		got := getNames(results)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("LimitToLast() = %v; want = %v", got, want)
 		}
+		compareValues(t, results)
 	}
 }
 
 func TestLimitToLast(t *testing.T) {
 	for _, tc := range []int{2, 10} {
-		var d []Dinosaur
-		if err := dinos.OrderByChild("height").
-			LimitToLast(tc).
-			GetOrdered(context.Background(), &d); err != nil {
+		results, err := dinos.OrderByChild("height").LimitToLast(tc).GetOrdered(context.Background())
+		if err != nil {
 			t.Fatal(err)
 		}
 
 		wl := min(tc, len(heightSorted))
 		want := heightSorted[len(heightSorted)-wl:]
-		if len(d) != wl {
-			t.Errorf("LimitToLast() = %d; want = %d", len(d), wl)
+		if len(results) != wl {
+			t.Errorf("LimitToLast() = %d; want = %d", len(results), wl)
 		}
-		for i, w := range want {
-			if d[i] != parsedTestData[w] {
-				t.Errorf("[%d] LimitToLast() = %v; want = %v", i, d[i], parsedTestData[w])
-			}
+		got := getNames(results)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("LimitToLast() = %v; want = %v", got, want)
 		}
+		compareValues(t, results)
 	}
 }
 
 func TestStartAt(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByChild("height").
-		StartAt(3.5).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByChild("height").StartAt(3.5).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := heightSorted[len(heightSorted)-2:]
-	if len(d) != len(want) {
-		t.Errorf("StartAt() = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("StartAt() = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] StartAt() = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestEndAt(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByChild("height").
-		EndAt(3.5).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByChild("height").EndAt(3.5).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := heightSorted[:4]
-	if len(d) != len(want) {
-		t.Errorf("StartAt() = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("StartAt() = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] EndAt() = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestStartAndEndAt(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByChild("height").
-		StartAt(2.5).
-		EndAt(5).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByChild("height").StartAt(2.5).EndAt(5).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := heightSorted[len(heightSorted)-3 : len(heightSorted)-1]
-	if len(d) != len(want) {
-		t.Errorf("StartAt(), EndAt() = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("StartAt(), EndAt() = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] StartAt(), EndAt() = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestEqualTo(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByChild("height").
-		EqualTo(0.6).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByChild("height").EqualTo(0.6).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := heightSorted[:2]
-	if len(d) != len(want) {
-		t.Errorf("EqualTo() = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("EqualTo() = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] EqualTo() = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestOrderByNestedChild(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByChild("ratings/pos").
-		StartAt(4).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByChild("ratings/pos").StartAt(4).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := []string{"pterodactyl", "stegosaurus", "triceratops"}
-	if len(d) != len(want) {
-		t.Errorf("OrderByChild(ratings/pos) = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("OrderByChild(ratings/pos) = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] OrderByChild(ratings/pos) = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestOrderByKey(t *testing.T) {
-	var d []Dinosaur
-	if err := dinos.OrderByKey().
-		LimitToFirst(2).
-		GetOrdered(context.Background(), &d); err != nil {
+	results, err := dinos.OrderByKey().LimitToFirst(2).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := []string{"bruhathkayosaurus", "lambeosaurus"}
-	if len(d) != len(want) {
-		t.Errorf("OrderByKey() = %d; want = %d", len(d), len(want))
+	if len(results) != len(want) {
+		t.Errorf("OrderByKey() = %d; want = %d", len(results), len(want))
 	}
-	for i, w := range want {
-		if d[i] != parsedTestData[w] {
-			t.Errorf("[%d] OrderByKey() = %v; want = %v", i, d[i], parsedTestData[w])
-		}
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
 	}
+	compareValues(t, results)
 }
 
 func TestOrderByValue(t *testing.T) {
 	scores := ref.Child("scores")
-	var s []int
-	if err := scores.OrderByValue().
-		LimitToLast(2).
-		GetOrdered(context.Background(), &s); err != nil {
+	results, err := scores.OrderByValue().LimitToLast(2).GetOrdered(context.Background())
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	want := []string{"linhenykus", "pterodactyl"}
-	if len(s) != len(want) {
-		t.Errorf("OrderByValue() = %d; want = %d", len(s), len(want))
+	if len(results) != len(want) {
+		t.Errorf("OrderByValue() = %d; want = %d", len(results), len(want))
 	}
-	scoresData := testData["scores"].(map[string]interface{})
-	for i, w := range want {
-		ws := int(scoresData[w].(float64))
-		if s[i] != ws {
-			t.Errorf("[%d] OrderByValue() = %d; want = %d", i, s[i], ws)
+	got := getNames(results)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("LimitToLast() = %v; want = %v", got, want)
+	}
+	wantScores := []int{80, 93}
+	for i, r := range results {
+		var val int
+		if err := r.Unmarshal(&val); err != nil {
+			t.Fatalf("queryNode.Unmarshal() = %v", err)
+		}
+		if val != wantScores[i] {
+			t.Errorf("queryNode.Unmarshal() = %d; want = %d", val, wantScores[i])
 		}
 	}
 }
@@ -249,6 +234,33 @@ func TestUnorderedQuery(t *testing.T) {
 	for i, w := range want {
 		if _, ok := m[w]; !ok {
 			t.Errorf("[%d] result[%q] not present", i, w)
+		}
+	}
+}
+
+func min(i, j int) int {
+	if i < j {
+		return i
+	}
+	return j
+}
+
+func getNames(results []db.QueryNode) []string {
+	s := make([]string, len(results))
+	for i, v := range results {
+		s[i] = v.Key()
+	}
+	return s
+}
+
+func compareValues(t *testing.T, results []db.QueryNode) {
+	for _, r := range results {
+		var d Dinosaur
+		if err := r.Unmarshal(&d); err != nil {
+			t.Fatalf("queryNode.Unmarshal(%q) = %v", r.Key(), err)
+		}
+		if !reflect.DeepEqual(d, parsedTestData[r.Key()]) {
+			t.Errorf("queryNode.Unmarshal(%q) = %v; want = %v", r.Key(), d, parsedTestData[r.Key()])
 		}
 	}
 }


### PR DESCRIPTION
`GetOrdered()` to return a slice of `QueryNode` instances. `QueryNode` provides access to unmarshalled json value as well as the key. Integer keys (coming from array indices) are mapped to their string representation.

Example usage:

```
results, err := query.GetOrdered(ctx)
if err != nil {
  // handle error
}
for _, r := range results {
  k := r.Key()
  var v MyType
  if err := r.Unmarshal(&v); err != nil {
     // handle error
  }
  fmt.Printf("%s => %v\n", k, v)
}
```