### PR TITLE
Handling FCM canonical error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [changed] Improved error handling in FCM by mapping more server-side
+  errors to client-side error codes.
 
 # v2.5.0
 

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -41,13 +41,20 @@ var (
 	topicNamePattern = regexp.MustCompile("^(/topics/)?(private/)?[a-zA-Z0-9-_.~%]+$")
 
 	fcmErrorCodes = map[string]string{
-		"INVALID_ARGUMENT":   "request contains an invalid argument; code: invalid-argument",
-		"UNREGISTERED":       "app instance has been unregistered; code: registration-token-not-registered",
-		"SENDER_ID_MISMATCH": "sender id does not match regisration token; code: authentication-error",
-		"QUOTA_EXCEEDED":     "messaging service quota exceeded; code: message-rate-exceeded",
-		"APNS_AUTH_ERROR":    "apns certificate or auth key was invalid; code: authentication-error",
-		"UNAVAILABLE":        "backend servers are temporarily unavailable; code: server-unavailable",
+		// FCM v1 canonical error codes
+		"NOT_FOUND":          "app instance has been unregistered; code: registration-token-not-registered",
+		"PERMISSION_DENIED":  "sender id does not match regisration token; code: mismatched-credential",
+		"RESOURCE_EXHAUSTED": "messaging service quota exceeded; code: message-rate-exceeded",
+		"UNAUTHENTICATED":    "apns certificate or auth key was invalid; code: invalid-apns-credentials",
+
+		// FCM v1 new error codes
+		"APNS_AUTH_ERROR":    "apns certificate or auth key was invalid; code: invalid-apns-credentials",
 		"INTERNAL":           "back servers encountered an unknown internl error; code: internal-error",
+		"INVALID_ARGUMENT":   "request contains an invalid argument; code: invalid-argument",
+		"SENDER_ID_MISMATCH": "sender id does not match regisration token; code: mismatched-credential",
+		"QUOTA_EXCEEDED":     "messaging service quota exceeded; code: message-rate-exceeded",
+		"UNAVAILABLE":        "backend servers are temporarily unavailable; code: server-unavailable",
+		"UNREGISTERED":       "app instance has been unregistered; code: registration-token-not-registered",
 	}
 
 	iidErrorCodes = map[string]string{

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -633,6 +633,10 @@ func TestSendError(t *testing.T) {
 			want: "http error status: 500; reason: request contains an invalid argument; code: invalid-argument",
 		},
 		{
+			resp: "{\"error\": {\"status\": \"NOT_FOUND\", \"message\": \"test error\"}}",
+			want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered",
+		},
+		{
 			resp: "not json",
 			want: "http error status: 500; reason: server responded with an unknown error; response: not json",
 		},


### PR DESCRIPTION
The error codes defined in https://firebase.google.com/docs/reference/fcm/rest/v1/ErrorCode are embedded in the details section of the error response. The top-level error code (`status` field in the response) may take additional values such as `NOT_FOUND` and `UNAUTHENTICATED` (the so called canonical error codes):

```
{
  "error":{
    "code":404,
    "message":"Requested entity was not found.",
    "status":"NOT_FOUND",
    "details: [
      {
         "@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError",
         "errorCode":"UNREGISTERED"
      }
    ]
  }
}
```

This PR updates the FCM implementation to handle these additional error codes and map them to correct client-side errors.