### PR TITLE
Fix invalid endpoint URL for topic unsubscribe

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -364,7 +364,7 @@ func (c *Client) UnsubscribeFromTopic(ctx context.Context, tokens []string, topi
 	req := &iidRequest{
 		Topic:  topic,
 		Tokens: tokens,
-		op:     iidSubscribe,
+		op:     iidUnsubscribe,
 	}
 	return c.makeTopicManagementRequest(ctx, req)
 }

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -730,7 +730,7 @@ func TestUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkIIDRequest(t, b, tr, iidSubscribe)
+	checkIIDRequest(t, b, tr, iidUnsubscribe)
 	checkTopicMgtResponse(t, resp)
 }
 


### PR DESCRIPTION
#115 - Uses correct `op` when creating topic unsubscribe requests.