### PR TITLE
Add Go import comments.

### DIFF
--- a/auth/auth_std.go
+++ b/auth/auth_std.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package auth
+package auth // import "firebase.google.com/go/auth"
 
 import "golang.org/x/net/context"
 

--- a/db/query.go
+++ b/db/query.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package db
+package db // import "firebase.google.com/go/db"
 
 import (
 	"encoding/json"

--- a/firebase.go
+++ b/firebase.go
@@ -15,7 +15,7 @@
 // Package firebase is the entry point to the Firebase Admin SDK. It provides functionality for initializing App
 // instances, which serve as the central entities that provide access to various other Firebase services exposed
 // from the SDK.
-package firebase
+package firebase // import "firebase.google.com/go"
 
 import (
 	"encoding/json"

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package iid contains functions for deleting instance IDs from Firebase projects.
-package iid
+package iid // import "firebase.google.com/go/iid"
 
 import (
 	"errors"

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package internal contains functionality that is only accessible from within the Admin SDK.
-package internal
+package internal // import "firebase.google.com/go/internal"
 
 import (
 	"golang.org/x/oauth2"

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -14,7 +14,7 @@
 
 // Package messaging contains functions for sending messages and managing
 // device subscriptions with Firebase Cloud Messaging (FCM).
-package messaging
+package messaging // import "firebase.google.com/go/messaging"
 
 import (
 	"encoding/json"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // Package storage provides functions for accessing Google Cloud Storge buckets.
-package storage
+package storage // import "firebase.google.com/go/storage"
 
 import (
 	"errors"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
