### PR TITLE
Cleaning up the auth (user management) code

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -285,7 +285,7 @@ func (c *Client) VerifyIDTokenAndCheckRevoked(ctx context.Context, idToken strin
 	}
 
 	if p.IssuedAt*1000 < user.TokensValidAfterMillis {
-		return nil, internal.Error(idTokenRevoked, "id token has been revoked")
+		return nil, internal.Error(idTokenRevoked, "ID token has been revoked")
 	}
 	return p, nil
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -235,7 +235,7 @@ func TestVerifyIDTokenAndCheckRevokedInvalidated(t *testing.T) {
 	tok := getIDToken(mockIDTokenPayload{"uid": "uid", "iat": 1970}) // old token
 
 	p, err := s.Client.VerifyIDTokenAndCheckRevoked(ctx, tok)
-	we := "id token has been revoked"
+	we := "ID token has been revoked"
 	if p != nil || err == nil || err.Error() != we || !IsIDTokenRevoked(err) {
 		t.Errorf("VerifyIDTokenAndCheckRevoked(ctx, token) =(%v, %v); want = (%v, %v)",
 			p, err, nil, we)

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -97,7 +97,7 @@ type UserIterator struct {
 
 // UserToCreate is the parameter struct for the CreateUser function.
 type UserToCreate struct {
-	_req        *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest
+	createReq   *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest
 	uid         bool
 	displayName bool
 	email       bool
@@ -106,10 +106,10 @@ type UserToCreate struct {
 }
 
 func (u *UserToCreate) request() *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest {
-	if u._req == nil {
-		u._req = &identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest{}
+	if u.createReq == nil {
+		u.createReq = &identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest{}
 	}
-	return u._req
+	return u.createReq
 }
 
 func (u *UserToCreate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest, error) {
@@ -210,7 +210,7 @@ func (u *UserToCreate) UID(uid string) *UserToCreate {
 
 // UserToUpdate is the parameter struct for the UpdateUser function.
 type UserToUpdate struct {
-	_req         *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest
+	updateReq    *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest
 	claims       map[string]interface{}
 	displayName  bool
 	email        bool
@@ -220,18 +220,18 @@ type UserToUpdate struct {
 }
 
 func (u *UserToUpdate) request() *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest {
-	if u._req == nil {
-		u._req = &identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest{}
+	if u.updateReq == nil {
+		u.updateReq = &identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest{}
 	}
-	return u._req
+	return u.updateReq
 }
 
 func (u *UserToUpdate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest, error) {
-	if u._req == nil {
+	if u.updateReq == nil {
 		// update without any parameters is never allowed
 		return nil, fmt.Errorf("update parameters must not be nil or empty")
 	}
-	req := u._req
+	req := u.updateReq
 	if u.email {
 		if err := validateEmail(req.Email); err != nil {
 			return nil, err
@@ -591,7 +591,7 @@ func validatePhotoURL(val string) error {
 
 func validateEmail(email string) error {
 	if email == "" {
-		return fmt.Errorf("email must not be empty")
+		return fmt.Errorf("email must be a non-empty string")
 	}
 	if parts := strings.Split(email, "@"); len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return fmt.Errorf("malformed email string: %q", email)
@@ -608,7 +608,7 @@ func validatePassword(val string) error {
 
 func validateUID(uid string) error {
 	if uid == "" {
-		return fmt.Errorf("uid must not be empty")
+		return fmt.Errorf("uid must be a non-empty string")
 	}
 	if len(uid) > 128 {
 		return fmt.Errorf("uid string must not be longer than 128 characters")
@@ -618,7 +618,7 @@ func validateUID(uid string) error {
 
 func validatePhone(phone string) error {
 	if phone == "" {
-		return fmt.Errorf("phone number must not be empty")
+		return fmt.Errorf("phone number must be a non-empty string")
 	}
 	if !regexp.MustCompile(`\+.*[0-9A-Za-z]`).MatchString(phone) {
 		return fmt.Errorf("phone number must be a valid, E.164 compliant identifier")

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -31,20 +30,11 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-const maxReturnedResults = 1000
-const maxLenPayloadCC = 1000
-
-const defaultProviderID = "firebase"
-
-var commonValidators = map[string]func(interface{}) error{
-	"displayName": validateDisplayName,
-	"email":       validateEmail,
-	"phoneNumber": validatePhone,
-	"password":    validatePassword,
-	"photoUrl":    validatePhotoURL,
-	"localId":     validateUID,
-	"validSince":  func(interface{}) error { return nil }, // Needed for preparePayload.
-}
+const (
+	maxReturnedResults = 1000
+	maxLenPayloadCC    = 1000
+	defaultProviderID  = "firebase"
+)
 
 // Create a new interface
 type identitytoolkitCall interface {
@@ -107,83 +97,231 @@ type UserIterator struct {
 
 // UserToCreate is the parameter struct for the CreateUser function.
 type UserToCreate struct {
-	params map[string]interface{}
+	_req   *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest
+	fields struct {
+		UID, DisplayName, Email, PhotoURL, PhoneNumber bool
+	}
 }
 
-func (u *UserToCreate) set(key string, value interface{}) {
-	if u.params == nil {
-		u.params = make(map[string]interface{})
+func (u *UserToCreate) request() *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest {
+	if u._req == nil {
+		u._req = &identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest{}
 	}
-	u.params[key] = value
+	return u._req
+}
+
+func (u *UserToCreate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest, error) {
+	req := u.request() // it is allowed to create a user without any parameters
+	if u.fields.UID {
+		if err := validateUID(req.LocalId); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.DisplayName {
+		if err := validateDisplayName(req.DisplayName); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.Email {
+		if err := validateEmail(req.Email); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.PhoneNumber {
+		if err := validatePhone(req.PhoneNumber); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.PhotoURL {
+		if err := validatePhotoURL(req.PhotoUrl); err != nil {
+			return nil, err
+		}
+	}
+	if req.Password != "" {
+		if err := validatePassword(req.Password); err != nil {
+			return nil, err
+		}
+	}
+	return req, nil
 }
 
 // Disabled setter.
-func (u *UserToCreate) Disabled(d bool) *UserToCreate { u.set("disabled", d); return u }
+func (u *UserToCreate) Disabled(disabled bool) *UserToCreate {
+	req := u.request()
+	req.Disabled = disabled
+	if !disabled {
+		req.ForceSendFields = append(req.ForceSendFields, "Disabled")
+	}
+	return u
+}
 
 // DisplayName setter.
-func (u *UserToCreate) DisplayName(dn string) *UserToCreate { u.set("displayName", dn); return u }
+func (u *UserToCreate) DisplayName(name string) *UserToCreate {
+	u.request().DisplayName = name
+	u.fields.DisplayName = true
+	return u
+}
 
 // Email setter.
-func (u *UserToCreate) Email(e string) *UserToCreate { u.set("email", e); return u }
+func (u *UserToCreate) Email(email string) *UserToCreate {
+	u.request().Email = email
+	u.fields.Email = true
+	return u
+}
 
 // EmailVerified setter.
-func (u *UserToCreate) EmailVerified(ev bool) *UserToCreate { u.set("emailVerified", ev); return u }
+func (u *UserToCreate) EmailVerified(verified bool) *UserToCreate {
+	req := u.request()
+	req.EmailVerified = verified
+	if !verified {
+		req.ForceSendFields = append(req.ForceSendFields, "EmailVerified")
+	}
+	return u
+}
 
 // Password setter.
-func (u *UserToCreate) Password(pw string) *UserToCreate { u.set("password", pw); return u }
+func (u *UserToCreate) Password(pw string) *UserToCreate {
+	u.request().Password = pw
+	return u
+}
 
 // PhoneNumber setter.
-func (u *UserToCreate) PhoneNumber(phone string) *UserToCreate { u.set("phoneNumber", phone); return u }
+func (u *UserToCreate) PhoneNumber(phone string) *UserToCreate {
+	u.request().PhoneNumber = phone
+	u.fields.PhoneNumber = true
+	return u
+}
 
 // PhotoURL setter.
-func (u *UserToCreate) PhotoURL(url string) *UserToCreate { u.set("photoUrl", url); return u }
+func (u *UserToCreate) PhotoURL(url string) *UserToCreate {
+	u.request().PhotoUrl = url
+	u.fields.PhotoURL = true
+	return u
+}
 
 // UID setter.
-func (u *UserToCreate) UID(uid string) *UserToCreate { u.set("localId", uid); return u }
+func (u *UserToCreate) UID(uid string) *UserToCreate {
+	u.request().LocalId = uid
+	u.fields.UID = true
+	return u
+}
 
 // UserToUpdate is the parameter struct for the UpdateUser function.
 type UserToUpdate struct {
-	params map[string]interface{}
+	_req   *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest
+	claims map[string]interface{}
+	fields struct {
+		DisplayName, Email, PhoneNumber, PhotoURL, CustomClaims bool
+	}
 }
 
-func (u *UserToUpdate) set(key string, value interface{}) {
-	if u.params == nil {
-		u.params = make(map[string]interface{})
+func (u *UserToUpdate) request() *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest {
+	if u._req == nil {
+		u._req = &identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest{}
 	}
-	u.params[key] = value
+	return u._req
+}
+
+func (u *UserToUpdate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest, error) {
+	if u._req == nil {
+		// update without any parameters is never allowed
+		return nil, fmt.Errorf("update parameters must not be nil or empty")
+	}
+	req := u._req
+	if u.fields.Email {
+		if err := validateEmail(req.Email); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.DisplayName && req.DisplayName == "" {
+		req.DeleteAttribute = append(req.DeleteAttribute, "DISPLAY_NAME")
+	}
+	if u.fields.PhotoURL && req.PhotoUrl == "" {
+		req.DeleteAttribute = append(req.DeleteAttribute, "PHOTO_URL")
+	}
+	if u.fields.PhoneNumber {
+		if req.PhoneNumber == "" {
+			req.DeleteProvider = append(req.DeleteProvider, "phone")
+		} else if err := validatePhone(req.PhoneNumber); err != nil {
+			return nil, err
+		}
+	}
+	if u.fields.CustomClaims {
+		cc, err := marshalCustomClaims(u.claims)
+		if err != nil {
+			return nil, err
+		}
+		req.CustomAttributes = cc
+	}
+	return req, nil
 }
 
 // CustomClaims setter.
-func (u *UserToUpdate) CustomClaims(cc map[string]interface{}) *UserToUpdate {
-	u.set("customClaims", cc)
+func (u *UserToUpdate) CustomClaims(claims map[string]interface{}) *UserToUpdate {
+	u.request() // force initialization of the request for later use
+	u.claims = claims
+	u.fields.CustomClaims = true
 	return u
 }
 
 // Disabled setter.
-func (u *UserToUpdate) Disabled(d bool) *UserToUpdate { u.set("disableUser", d); return u }
+func (u *UserToUpdate) Disabled(disabled bool) *UserToUpdate {
+	req := u.request()
+	req.DisableUser = disabled
+	if !disabled {
+		req.ForceSendFields = append(req.ForceSendFields, "DisableUser")
+	}
+	return u
+}
 
 // DisplayName setter.
-func (u *UserToUpdate) DisplayName(dn string) *UserToUpdate { u.set("displayName", dn); return u }
+func (u *UserToUpdate) DisplayName(name string) *UserToUpdate {
+	u.request().DisplayName = name
+	u.fields.DisplayName = true
+	return u
+}
 
 // Email setter.
-func (u *UserToUpdate) Email(e string) *UserToUpdate { u.set("email", e); return u }
+func (u *UserToUpdate) Email(email string) *UserToUpdate {
+	u.request().Email = email
+	u.fields.Email = true
+	return u
+}
 
 // EmailVerified setter.
-func (u *UserToUpdate) EmailVerified(ev bool) *UserToUpdate { u.set("emailVerified", ev); return u }
+func (u *UserToUpdate) EmailVerified(verified bool) *UserToUpdate {
+	req := u.request()
+	req.EmailVerified = verified
+	if !verified {
+		req.ForceSendFields = append(req.ForceSendFields, "EmailVerified")
+	}
+	return u
+}
 
 // Password setter.
-func (u *UserToUpdate) Password(pw string) *UserToUpdate { u.set("password", pw); return u }
+func (u *UserToUpdate) Password(pw string) *UserToUpdate {
+	u.request().Password = pw
+	return u
+}
 
 // PhoneNumber setter.
-func (u *UserToUpdate) PhoneNumber(phone string) *UserToUpdate { u.set("phoneNumber", phone); return u }
+func (u *UserToUpdate) PhoneNumber(phone string) *UserToUpdate {
+	u.request().PhoneNumber = phone
+	u.fields.PhoneNumber = true
+	return u
+}
 
 // PhotoURL setter.
-func (u *UserToUpdate) PhotoURL(url string) *UserToUpdate { u.set("photoUrl", url); return u }
+func (u *UserToUpdate) PhotoURL(url string) *UserToUpdate {
+	u.request().PhotoUrl = url
+	u.fields.PhotoURL = true
+	return u
+}
 
 // revokeRefreshTokens revokes all refresh tokens for a user by setting the validSince property
 // to the present in epoch seconds.
 func (u *UserToUpdate) revokeRefreshTokens() *UserToUpdate {
-	u.set("validSince", time.Now().Unix())
+	u.request().ValidSince = time.Now().Unix()
 	return u
 }
 
@@ -328,49 +466,25 @@ func (c *Client) SetCustomUserClaims(ctx context.Context, uid string, customClai
 	return c.updateUser(ctx, uid, (&UserToUpdate{}).CustomClaims(customClaims))
 }
 
-func processDeletion(p map[string]interface{}, field, listKey, listVal string) {
-	if dn, ok := p[field]; ok && len(dn.(string)) == 0 {
-		addToListParam(p, listKey, listVal)
-		delete(p, field)
-	}
-}
-
-func addToListParam(p map[string]interface{}, listname, param string) {
-	if _, ok := p[listname]; ok {
-		p[listname] = append(p[listname].([]string), param)
-	} else {
-		p[listname] = []string{param}
-	}
-}
-
-func processClaims(p map[string]interface{}) error {
-	cc, ok := p["customClaims"]
-	if !ok {
-		return nil
-	}
-
-	claims := cc.(map[string]interface{})
+func marshalCustomClaims(claims map[string]interface{}) (string, error) {
 	for _, key := range reservedClaims {
 		if _, ok := claims[key]; ok {
-			return fmt.Errorf("claim %q is reserved and must not be set", key)
+			return "", fmt.Errorf("claim %q is reserved and must not be set", key)
 		}
 	}
 
 	b, err := json.Marshal(claims)
 	if err != nil {
-		return fmt.Errorf("custom claims marshaling error: %v", err)
+		return "", fmt.Errorf("custom claims marshaling error: %v", err)
 	}
 	s := string(b)
 	if s == "null" {
 		s = "{}"
 	}
 	if len(s) > maxLenPayloadCC {
-		return fmt.Errorf("serialized custom claims must not exceed %d characters", maxLenPayloadCC)
+		return "", fmt.Errorf("serialized custom claims must not exceed %d characters", maxLenPayloadCC)
 	}
-
-	p["customAttributes"] = s
-	delete(p, "customClaims")
-	return nil
+	return s, nil
 }
 
 // Error handlers.
@@ -452,22 +566,21 @@ func handleServerError(err error) error {
 
 // Validators.
 
-func validateDisplayName(val interface{}) error {
-	if len(val.(string)) == 0 {
+func validateDisplayName(val string) error {
+	if len(val) == 0 {
 		return fmt.Errorf("display name must be a non-empty string")
 	}
 	return nil
 }
 
-func validatePhotoURL(val interface{}) error {
-	if len(val.(string)) == 0 {
+func validatePhotoURL(val string) error {
+	if len(val) == 0 {
 		return fmt.Errorf("photo url must be a non-empty string")
 	}
 	return nil
 }
 
-func validateEmail(val interface{}) error {
-	email := val.(string)
+func validateEmail(email string) error {
 	if email == "" {
 		return fmt.Errorf("email must not be empty")
 	}
@@ -477,117 +590,30 @@ func validateEmail(val interface{}) error {
 	return nil
 }
 
-func validatePassword(val interface{}) error {
-	if len(val.(string)) < 6 {
+func validatePassword(val string) error {
+	if len(val) < 6 {
 		return fmt.Errorf("password must be a string at least 6 characters long")
 	}
 	return nil
 }
 
-func validateUID(val interface{}) error {
-	uid := val.(string)
+func validateUID(uid string) error {
 	if uid == "" {
 		return fmt.Errorf("uid must not be empty")
 	}
-	if len(val.(string)) > 128 {
+	if len(uid) > 128 {
 		return fmt.Errorf("uid string must not be longer than 128 characters")
 	}
 	return nil
 }
 
-func validatePhone(val interface{}) error {
-	phone := val.(string)
+func validatePhone(phone string) error {
 	if phone == "" {
 		return fmt.Errorf("phone number must not be empty")
 	}
 	if !regexp.MustCompile(`\+.*[0-9A-Za-z]`).MatchString(phone) {
 		return fmt.Errorf("phone number must be a valid, E.164 compliant identifier")
 	}
-	return nil
-}
-
-func (u *UserToCreate) preparePayload(user *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest) error {
-	params := map[string]interface{}{}
-	if u.params == nil {
-		return nil
-	}
-
-	for k, v := range u.params {
-		params[k] = v
-	}
-	for key, validate := range commonValidators {
-		if v, ok := params[key]; ok {
-			if err := validate(v); err != nil {
-				return err
-			}
-			reflect.ValueOf(user).Elem().FieldByName(strings.Title(key)).SetString(params[key].(string))
-		}
-	}
-	if params["disabled"] != nil {
-		user.Disabled = params["disabled"].(bool)
-		if !user.Disabled {
-			user.ForceSendFields = append(user.ForceSendFields, "Disabled")
-		}
-	}
-	if params["emailVerified"] != nil {
-		user.EmailVerified = params["emailVerified"].(bool)
-		if !user.EmailVerified {
-			user.ForceSendFields = append(user.ForceSendFields, "EmailVerified")
-		}
-	}
-
-	return nil
-}
-
-func (u *UserToUpdate) preparePayload(user *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest) error {
-	params := map[string]interface{}{}
-	for k, v := range u.params {
-		params[k] = v
-	}
-	processDeletion(params, "displayName", "deleteAttribute", "DISPLAY_NAME")
-	processDeletion(params, "photoUrl", "deleteAttribute", "PHOTO_URL")
-	processDeletion(params, "phoneNumber", "deleteProvider", "phone")
-
-	if err := processClaims(params); err != nil {
-		return err
-	}
-
-	if params["customAttributes"] != nil {
-		user.CustomAttributes = params["customAttributes"].(string)
-	}
-
-	for key, validate := range commonValidators {
-		if v, ok := params[key]; ok {
-			if err := validate(v); err != nil {
-				return err
-			}
-			f := reflect.ValueOf(user).Elem().FieldByName(strings.Title(key))
-			if f.Kind() == reflect.String {
-				f.SetString(params[key].(string))
-			} else if f.Kind() == reflect.Int64 {
-				f.SetInt(params[key].(int64))
-			}
-		}
-	}
-	if params["disableUser"] != nil {
-		user.DisableUser = params["disableUser"].(bool)
-		if !user.DisableUser {
-			user.ForceSendFields = append(user.ForceSendFields, "DisableUser")
-		}
-	}
-	if params["emailVerified"] != nil {
-		user.EmailVerified = params["emailVerified"].(bool)
-		if !user.EmailVerified {
-			user.ForceSendFields = append(user.ForceSendFields, "EmailVerified")
-		}
-	}
-	if params["deleteAttribute"] != nil {
-		user.DeleteAttribute = params["deleteAttribute"].([]string)
-	}
-	if params["deleteProvider"] != nil {
-		user.DeleteProvider = params["deleteProvider"].([]string)
-	}
-
 	return nil
 }
 
@@ -600,19 +626,16 @@ func (c *Client) createUser(ctx context.Context, user *UserToCreate) (string, er
 		user = &UserToCreate{}
 	}
 
-	request := &identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest{}
-
-	if err := user.preparePayload(request); err != nil {
+	request, err := user.validatedRequest()
+	if err != nil {
 		return "", err
 	}
-
 	call := c.is.Relyingparty.SignupNewUser(request)
 	c.setHeader(call)
 	resp, err := call.Context(ctx).Do()
 	if err != nil {
 		return "", handleServerError(err)
 	}
-
 	return resp.LocalId, nil
 }
 
@@ -620,17 +643,14 @@ func (c *Client) updateUser(ctx context.Context, uid string, user *UserToUpdate)
 	if err := validateUID(uid); err != nil {
 		return err
 	}
-	if user == nil || user.params == nil {
+	if user == nil {
 		return fmt.Errorf("update parameters must not be nil or empty")
 	}
-	request := &identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest{
-		LocalId: uid,
-	}
-
-	if err := user.preparePayload(request); err != nil {
+	request, err := user.validatedRequest()
+	if err != nil {
 		return err
 	}
-
+	request.LocalId = uid
 	call := c.is.Relyingparty.SetAccountInfo(request)
 	c.setHeader(call)
 	if _, err := call.Context(ctx).Do(); err != nil {

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -97,10 +97,12 @@ type UserIterator struct {
 
 // UserToCreate is the parameter struct for the CreateUser function.
 type UserToCreate struct {
-	_req   *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest
-	fields struct {
-		UID, DisplayName, Email, PhotoURL, PhoneNumber bool
-	}
+	_req        *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest
+	uid         bool
+	displayName bool
+	email       bool
+	photoURL    bool
+	phoneNumber bool
 }
 
 func (u *UserToCreate) request() *identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest {
@@ -111,28 +113,28 @@ func (u *UserToCreate) request() *identitytoolkit.IdentitytoolkitRelyingpartySig
 }
 
 func (u *UserToCreate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyingpartySignupNewUserRequest, error) {
-	req := u.request() // it is allowed to create a user without any parameters
-	if u.fields.UID {
+	req := u.request() // creating a user without any parameters is allowed
+	if u.uid {
 		if err := validateUID(req.LocalId); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.DisplayName {
+	if u.displayName {
 		if err := validateDisplayName(req.DisplayName); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.Email {
+	if u.email {
 		if err := validateEmail(req.Email); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.PhoneNumber {
+	if u.phoneNumber {
 		if err := validatePhone(req.PhoneNumber); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.PhotoURL {
+	if u.photoURL {
 		if err := validatePhotoURL(req.PhotoUrl); err != nil {
 			return nil, err
 		}
@@ -158,14 +160,14 @@ func (u *UserToCreate) Disabled(disabled bool) *UserToCreate {
 // DisplayName setter.
 func (u *UserToCreate) DisplayName(name string) *UserToCreate {
 	u.request().DisplayName = name
-	u.fields.DisplayName = true
+	u.displayName = true
 	return u
 }
 
 // Email setter.
 func (u *UserToCreate) Email(email string) *UserToCreate {
 	u.request().Email = email
-	u.fields.Email = true
+	u.email = true
 	return u
 }
 
@@ -188,31 +190,33 @@ func (u *UserToCreate) Password(pw string) *UserToCreate {
 // PhoneNumber setter.
 func (u *UserToCreate) PhoneNumber(phone string) *UserToCreate {
 	u.request().PhoneNumber = phone
-	u.fields.PhoneNumber = true
+	u.phoneNumber = true
 	return u
 }
 
 // PhotoURL setter.
 func (u *UserToCreate) PhotoURL(url string) *UserToCreate {
 	u.request().PhotoUrl = url
-	u.fields.PhotoURL = true
+	u.photoURL = true
 	return u
 }
 
 // UID setter.
 func (u *UserToCreate) UID(uid string) *UserToCreate {
 	u.request().LocalId = uid
-	u.fields.UID = true
+	u.uid = true
 	return u
 }
 
 // UserToUpdate is the parameter struct for the UpdateUser function.
 type UserToUpdate struct {
-	_req   *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest
-	claims map[string]interface{}
-	fields struct {
-		DisplayName, Email, PhoneNumber, PhotoURL, CustomClaims bool
-	}
+	_req         *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest
+	claims       map[string]interface{}
+	displayName  bool
+	email        bool
+	phoneNumber  bool
+	photoURL     bool
+	customClaims bool
 }
 
 func (u *UserToUpdate) request() *identitytoolkit.IdentitytoolkitRelyingpartySetAccountInfoRequest {
@@ -228,25 +232,25 @@ func (u *UserToUpdate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyi
 		return nil, fmt.Errorf("update parameters must not be nil or empty")
 	}
 	req := u._req
-	if u.fields.Email {
+	if u.email {
 		if err := validateEmail(req.Email); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.DisplayName && req.DisplayName == "" {
+	if u.displayName && req.DisplayName == "" {
 		req.DeleteAttribute = append(req.DeleteAttribute, "DISPLAY_NAME")
 	}
-	if u.fields.PhotoURL && req.PhotoUrl == "" {
+	if u.photoURL && req.PhotoUrl == "" {
 		req.DeleteAttribute = append(req.DeleteAttribute, "PHOTO_URL")
 	}
-	if u.fields.PhoneNumber {
+	if u.phoneNumber {
 		if req.PhoneNumber == "" {
 			req.DeleteProvider = append(req.DeleteProvider, "phone")
 		} else if err := validatePhone(req.PhoneNumber); err != nil {
 			return nil, err
 		}
 	}
-	if u.fields.CustomClaims {
+	if u.customClaims {
 		cc, err := marshalCustomClaims(u.claims)
 		if err != nil {
 			return nil, err
@@ -265,7 +269,7 @@ func (u *UserToUpdate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyi
 func (u *UserToUpdate) CustomClaims(claims map[string]interface{}) *UserToUpdate {
 	u.request() // force initialization of the request for later use
 	u.claims = claims
-	u.fields.CustomClaims = true
+	u.customClaims = true
 	return u
 }
 
@@ -282,14 +286,14 @@ func (u *UserToUpdate) Disabled(disabled bool) *UserToUpdate {
 // DisplayName setter.
 func (u *UserToUpdate) DisplayName(name string) *UserToUpdate {
 	u.request().DisplayName = name
-	u.fields.DisplayName = true
+	u.displayName = true
 	return u
 }
 
 // Email setter.
 func (u *UserToUpdate) Email(email string) *UserToUpdate {
 	u.request().Email = email
-	u.fields.Email = true
+	u.email = true
 	return u
 }
 
@@ -312,14 +316,14 @@ func (u *UserToUpdate) Password(pw string) *UserToUpdate {
 // PhoneNumber setter.
 func (u *UserToUpdate) PhoneNumber(phone string) *UserToUpdate {
 	u.request().PhoneNumber = phone
-	u.fields.PhoneNumber = true
+	u.phoneNumber = true
 	return u
 }
 
 // PhotoURL setter.
 func (u *UserToUpdate) PhotoURL(url string) *UserToUpdate {
 	u.request().PhotoUrl = url
-	u.fields.PhotoURL = true
+	u.photoURL = true
 	return u
 }
 
@@ -572,14 +576,14 @@ func handleServerError(err error) error {
 // Validators.
 
 func validateDisplayName(val string) error {
-	if len(val) == 0 {
+	if val == "" {
 		return fmt.Errorf("display name must be a non-empty string")
 	}
 	return nil
 }
 
 func validatePhotoURL(val string) error {
-	if len(val) == 0 {
+	if val == "" {
 		return fmt.Errorf("photo url must be a non-empty string")
 	}
 	return nil
@@ -589,7 +593,7 @@ func validateEmail(email string) error {
 	if email == "" {
 		return fmt.Errorf("email must not be empty")
 	}
-	if parts := strings.Split(email, "@"); len(parts) != 2 || len(parts[0]) == 0 || len(parts[1]) == 0 {
+	if parts := strings.Split(email, "@"); len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return fmt.Errorf("malformed email string: %q", email)
 	}
 	return nil

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -253,6 +253,11 @@ func (u *UserToUpdate) validatedRequest() (*identitytoolkit.IdentitytoolkitRelyi
 		}
 		req.CustomAttributes = cc
 	}
+	if req.Password != "" {
+		if err := validatePassword(req.Password); err != nil {
+			return nil, err
+		}
+	}
 	return req, nil
 }
 

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -232,7 +232,7 @@ func TestInvalidCreateUser(t *testing.T) {
 			"password must be a string at least 6 characters long",
 		}, {
 			(&UserToCreate{}).PhoneNumber(""),
-			"phone number must not be empty",
+			"phone number must be a non-empty string",
 		}, {
 			(&UserToCreate{}).PhoneNumber("1234"),
 			"phone number must be a valid, E.164 compliant identifier",
@@ -241,7 +241,7 @@ func TestInvalidCreateUser(t *testing.T) {
 			"phone number must be a valid, E.164 compliant identifier",
 		}, {
 			(&UserToCreate{}).UID(""),
-			"uid must not be empty",
+			"uid must be a non-empty string",
 		}, {
 			(&UserToCreate{}).UID(strings.Repeat("a", 129)),
 			"uid string must not be longer than 128 characters",
@@ -253,7 +253,7 @@ func TestInvalidCreateUser(t *testing.T) {
 			"photo url must be a non-empty string",
 		}, {
 			(&UserToCreate{}).Email(""),
-			"email must not be empty",
+			"email must be a non-empty string",
 		}, {
 			(&UserToCreate{}).Email("a"),
 			`malformed email string: "a"`,
@@ -372,7 +372,7 @@ func TestInvalidUpdateUser(t *testing.T) {
 			"update parameters must not be nil or empty",
 		}, {
 			(&UserToUpdate{}).Email(""),
-			"email must not be empty",
+			"email must be a non-empty string",
 		}, {
 			(&UserToUpdate{}).Email("invalid"),
 			`malformed email string: "invalid"`,
@@ -543,7 +543,7 @@ func TestRevokeRefreshTokensInvalidUID(t *testing.T) {
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
 
-	we := "uid must not be empty"
+	we := "uid must be a non-empty string"
 	if err := s.Client.RevokeRefreshTokens(context.Background(), ""); err == nil || err.Error() != we {
 		t.Errorf("RevokeRefreshTokens(); err = %s; want err = %s", err.Error(), we)
 	}

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -371,11 +371,20 @@ func TestInvalidUpdateUser(t *testing.T) {
 			&UserToUpdate{},
 			"update parameters must not be nil or empty",
 		}, {
+			(&UserToUpdate{}).Email(""),
+			"email must not be empty",
+		}, {
+			(&UserToUpdate{}).Email("invalid"),
+			`malformed email string: "invalid"`,
+		}, {
 			(&UserToUpdate{}).PhoneNumber("1"),
 			"phone number must be a valid, E.164 compliant identifier",
 		}, {
 			(&UserToUpdate{}).CustomClaims(map[string]interface{}{"a": strings.Repeat("a", 993)}),
 			"serialized custom claims must not exceed 1000 characters",
+		}, {
+			(&UserToUpdate{}).Password("short"),
+			"password must be a string at least 6 characters long",
 		},
 	}
 


### PR DESCRIPTION
Since we migrated the user management API to use the Google API client (`identitytoolkit` package), this code has become bit of a readability nightmare:

* Unnecessary indirection: We store all user parameters in maps and then "apply" those values to `identitytoolkit` types (see `UserToCreate` and `UserToUpdate` types).
* Too many small/redundant helper functions.
* Heavy use of reflection.

This PR addresses the above issues by:

* Directly applying user parameters to the corresponding `identitytoolkit` types. Intermediate maps are no longer used.
* Removing most of the redundant helpers, and performing validations explicitly where needed.
* Removing all usages of reflection (these were mostly present in the helper functions).