### PR TITLE
Removing golint checks from 1.6.x build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ matrix:
 go_import_path: firebase.google.com/go
 
 before_install:
-    - go get github.com/golang/lint/golint # Golint requires Go 1.6 or later.
+    - if ! [[ "$TRAVIS_GO_VERSION" =~ ^1\.6\.[0-9]+$ ]]; then go get github.com/golang/lint/golint; fi # Golint requires Go 1.7 or later.
 
 install:
     # Prior to golang 1.8, this can trigger an error for packages containing only tests.
     - go get -t -v $(go list ./... | grep -v integration)
 
 script:
-    - golint -set_exit_status $(go list ./...)
+    - if ! [[ "$TRAVIS_GO_VERSION" =~ ^1\.6\.[0-9]+$ ]]; then golint -set_exit_status $(go list ./...); fi
     - ./.travis.gofmt.sh
     - go test -v -race -test.short ./...        # Run tests with the race detector.
     - go vet -v ./...                           # Run Go static analyzer.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ matrix:
 go_import_path: firebase.google.com/go
 
 before_install:
-    - if ! [[ "$TRAVIS_GO_VERSION" =~ ^1\.6\.[0-9]+$ ]]; then go get github.com/golang/lint/golint; fi # Golint requires Go 1.7 or later.
+    # Golint requires Go 1.7 or later.
+    - if ! [[ "$TRAVIS_GO_VERSION" =~ ^1\.6\.[0-9]+$ ]]; then go get github.com/golang/lint/golint; fi
 
 install:
     # Prior to golang 1.8, this can trigger an error for packages containing only tests.


### PR DESCRIPTION
As per https://github.com/golang/lint/issues/400, Golang 1.6.x is no longer supported by golint.