### PR TITLE
Handling USER_NOT_FOUND errors in UpdateUser() and DeleteUser()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- [fixed] `auth.UpdateUser()` and `auth.DeleteUser()` returns the expected
-  `UserNotFound` errors when called with a non-existing uid.
+- [fixed] `auth.UpdateUser()` and `auth.DeleteUser()` return the expected
+  `UserNotFound` error when called with a non-existing uid.
 - [added] Implemented the `auth.ImportUsers()` function for importing
   users into Firebase Auth in bulk.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Unreleased
 
+- [fixed] `auth.UpdateUser()` and `auth.DeleteUser()` returns the expected
+  `UserNotFound` errors when called with a non-existing uid.
+
 # v3.0.0
 
-- All functions that make network calls now take context as an argument.
+- [changed] All functions that make network calls now take context as an argument.
 
 # v2.7.0
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -557,6 +557,7 @@ var serverError = map[string]string{
 	"INSUFFICIENT_PERMISSION": insufficientPermission,
 	"PHONE_NUMBER_EXISTS":     phoneNumberAlreadyExists,
 	"PROJECT_NOT_FOUND":       projectNotFound,
+	"USER_NOT_FOUND":          userNotFound,
 }
 
 func handleServerError(err error) error {

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -62,6 +62,33 @@ func TestUserManagement(t *testing.T) {
 	}
 }
 
+func TestGetNonExistingUser(t *testing.T) {
+	user, err := client.GetUser(context.Background(), "non.existing")
+	if user != nil || !auth.IsUserNotFound(err) {
+		t.Errorf("GetUser(non.existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+
+	user, err = client.GetUserByEmail(context.Background(), "non.existing@definitely.non.existing")
+	if user != nil || !auth.IsUserNotFound(err) {
+		t.Errorf("GetUserByEmail(non.existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+}
+
+func TestUpdateNonExistingUser(t *testing.T) {
+	update := (&auth.UserToUpdate{}).Email("test@example.com")
+	user, err := client.UpdateUser(context.Background(), "non.existing", update)
+	if user != nil || !auth.IsUserNotFound(err) {
+		t.Errorf("UpdateUser(non.existing) = (%v, %v); want = (nil, error)", user, err)
+	}
+}
+
+func TestDeleteNonExistingUser(t *testing.T) {
+	err := client.DeleteUser(context.Background(), "non.existing")
+	if !auth.IsUserNotFound(err) {
+		t.Errorf("DeleteUser(non.existing) = %v; want = error", err)
+	}
+}
+
 // N.B if the tests are failing due to inability to create existing users, manual
 // cleanup of the previus test run might be required, delete the unwanted users via:
 // https://console.firebase.google.com/u/0/project/<project-id>/authentication/users


### PR DESCRIPTION
When trying to update/delete a non-existing user, the backend server returns a `USER_NOT_FOUND` error code. This needs to mapped to the `auth.IsUserNotFound()` error handler.