### PR TITLE
Reading project ID from GOOGLE_CLOUD_PROJECT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [added] The Admin SDK can now read the Firebase/GCP project ID from
+  both `GCLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT` environment
+  variables.
+
 # v3.1.0
 
 - [added] Added new functions for testing errors in the `iid` package

--- a/firebase.go
+++ b/firebase.go
@@ -151,7 +151,10 @@ func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*
 	} else if creds.ProjectID != "" {
 		pid = creds.ProjectID
 	} else {
-		pid = os.Getenv("GCLOUD_PROJECT")
+		pid = os.Getenv("GOOGLE_CLOUD_PROJECT")
+		if pid == "" {
+			pid = os.Getenv("GCLOUD_PROJECT")
+		}
 	}
 
 	ao := defaultAuthOverrides


### PR DESCRIPTION
`GCLOUD_PROJECT` is no longer supported in some managed Google runtimes. `GOOGLE_CLOUD_PROJECT` is the new recommended environment variable.