### PR TITLE
Using the default http client for getting public keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - [added] The Admin SDK can now read the Firebase/GCP project ID from
   both `GCLOUD_PROJECT` and `GOOGLE_CLOUD_PROJECT` environment
   variables.
+- [fixed] Using the default, unauthorized HTTP client to retrieve
+  public keys when verifying ID tokens.
 
 # v3.1.0
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -128,7 +129,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 
 	return &Client{
 		is:        is,
-		keySource: newHTTPKeySource(idTokenCertURL, hc),
+		keySource: newHTTPKeySource(idTokenCertURL, http.DefaultClient),
 		projectID: conf.ProjectID,
 		signer:    signer,
 		version:   "Go/Admin/" + conf.Version,

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -97,6 +98,9 @@ func (k *httpKeySource) refreshKeys(ctx context.Context) error {
 	contents, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("invalid response (%d) while retrieving public keys: %s", resp.StatusCode, string(contents))
 	}
 	newKeys, err := parsePublicKeys(contents)
 	if err != nil {


### PR DESCRIPTION
We have been using the same authorized HTTP client to retrieve public keys when verifying ID tokens. But since recently, the back-end server does not allow it. When called with credentials, it now returns the following error:

```
{
  "error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.DebugInfo",
        "detail": "No scopes defined for OAuth: serviceaccountcert.googleapis.com/google.iam.credentials.v1.CertificateService.ExternalListPublicCertificates"
      }
    ]
  }
}
```

This caused several of our integration tests fail. 

Fixing the issue by using the default HTTP client to retrieve public keys.