### PR TITLE
Avoid direct use of http.DefaultClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [fixed] Fixing a regression introduced in 3.2.0, where `VerifyIDToken()`
+  cannot be used in App Engine.
+
 # v3.2.0
 
 - [added] Implemented the ability to create custom tokens without

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -19,8 +19,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
+
+	"google.golang.org/api/option"
 
 	"golang.org/x/net/context"
 
@@ -127,9 +128,13 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		return nil, err
 	}
 
+	noAuthHTTPClient, _, err := transport.NewHTTPClient(ctx, option.WithoutAuthentication())
+	if err != nil {
+		return nil, err
+	}
 	return &Client{
 		is:        is,
-		keySource: newHTTPKeySource(idTokenCertURL, http.DefaultClient),
+		keySource: newHTTPKeySource(idTokenCertURL, noAuthHTTPClient),
 		projectID: conf.ProjectID,
 		signer:    signer,
 		version:   "Go/Admin/" + conf.Version,


### PR DESCRIPTION
Fixing a regression introduced in #161 

App Engine does not support `http.DefaultClient`. Therefore, we must use `transport.NewHTTPClient()`, which returns a platform-specific client.

Resolves #162 
