### PR TITLE
Add header for opting into correct URL decoding

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -115,6 +115,7 @@ func (c *Client) send(
 	if c.authOverride != "" {
 		opts = append(opts, internal.WithQueryParam(authVarOverride, c.authOverride))
 	}
+	opts = append(opts, internal.WithHeader("X-Firebase-Decoding", "1"))
 	return c.hc.Do(ctx, &internal.Request{
 		Method: method,
 		URL:    fmt.Sprintf("%s%s.json", c.url, path),

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -273,6 +273,9 @@ func checkRequest(t *testing.T, got, want *testReq) {
 	if h := got.Header.Get("Authorization"); h != "Bearer mock-token" {
 		t.Errorf("Authorization = %q; want = %q", h, "Bearer mock-token")
 	}
+	if h := got.Header.Get("X-Firebase-Decoding"); h != "1" {
+		t.Errorf("X-Firebase-Decoding = %q; want = %q", h, "1")
+	}
 	if h := got.Header.Get("User-Agent"); h != testUserAgent {
 		t.Errorf("User-Agent = %q; want = %q", h, testUserAgent)
 	}


### PR DESCRIPTION
There is a long standing bug (~years) in the RTDB url decoding where we URL decode query parameters twice. Since we can't simply fix the issue without breaking users, we allow an opt-in upgrade/fix of the correct behavior via a header `X-Firebase-Decoding: 1`. We hope to make this the default (correct) behavior at some point in the near future. Which then this header will not be needed anymore.