### PR TITLE
remove support go 1.6

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -23,7 +23,7 @@ import (
 
 	"google.golang.org/api/option"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/identitytoolkit/v3"

--- a/auth/auth_appengine.go
+++ b/auth/auth_appengine.go
@@ -17,8 +17,9 @@
 package auth
 
 import (
+	"context"
+
 	"firebase.google.com/go/internal"
-	"golang.org/x/net/context"
 
 	"google.golang.org/appengine"
 )

--- a/auth/auth_std.go
+++ b/auth/auth_std.go
@@ -17,8 +17,9 @@
 package auth // import "firebase.google.com/go/auth"
 
 import (
+	"context"
+
 	"firebase.google.com/go/internal"
-	"golang.org/x/net/context"
 )
 
 func newCryptoSigner(ctx context.Context, conf *internal.AuthConfig) (cryptoSigner, error) {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"golang.org/x/oauth2/google"
 

--- a/auth/token_generator.go
+++ b/auth/token_generator.go
@@ -32,7 +32,7 @@ import (
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/transport"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type jwtHeader struct {

--- a/auth/token_generator_test.go
+++ b/auth/token_generator_test.go
@@ -28,7 +28,7 @@ import (
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/option"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestEncodeToken(t *testing.T) {

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -32,8 +32,7 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-	"golang.org/x/net/context/ctxhttp"
+	"context"
 )
 
 // keySource is used to obtain a set of public keys, which can be used to verify cryptographic
@@ -89,7 +88,7 @@ func (k *httpKeySource) refreshKeys(ctx context.Context) error {
 		return err
 	}
 
-	resp, err := ctxhttp.Do(ctx, k.HTTPClient, req)
+	resp, err := k.HTTPClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return err
 	}

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"firebase.google.com/go/internal"
-	"golang.org/x/net/context"
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/identitytoolkit/v3"

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/internal"
 

--- a/db/auth_override_test.go
+++ b/db/auth_override_test.go
@@ -17,7 +17,7 @@ package db
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestAuthOverrideGet(t *testing.T) {

--- a/db/db.go
+++ b/db/db.go
@@ -25,7 +25,8 @@ import (
 
 	"net/url"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
 )

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -23,7 +23,8 @@ import (
 	"runtime"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/oauth2"
 
 	"encoding/json"

--- a/db/query.go
+++ b/db/query.go
@@ -24,7 +24,7 @@ import (
 
 	"firebase.google.com/go/internal"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // QueryNode represents a data node retrieved from an ordered query.

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var sortableKeysResp = map[string]interface{}{

--- a/db/ref.go
+++ b/db/ref.go
@@ -22,7 +22,7 @@ import (
 
 	"firebase.google.com/go/internal"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // txnRetires is the maximum number of times a transaction is retried before giving up. Transaction

--- a/db/ref_test.go
+++ b/db/ref_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 type refOp func(r *Ref) error

--- a/firebase.go
+++ b/firebase.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"cloud.google.com/go/firestore"
 

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"golang.org/x/oauth2/google"
 

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/api/transport"
 

--- a/iid/iid_test.go
+++ b/iid/iid_test.go
@@ -20,7 +20,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/api/option"
 

--- a/integration/auth/auth_test.go
+++ b/integration/auth/auth_test.go
@@ -31,7 +31,7 @@ import (
 
 	"golang.org/x/oauth2/google"
 
-	"golang.org/x/net/context"
+	"context"
 
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/auth"

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/api/iterator"
 

--- a/integration/db/db_test.go
+++ b/integration/db/db_test.go
@@ -27,7 +27,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go"
 	"firebase.google.com/go/db"

--- a/integration/db/query_test.go
+++ b/integration/db/query_test.go
@@ -21,7 +21,7 @@ import (
 
 	"reflect"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var heightSorted = []string{

--- a/integration/firestore/firestore_test.go
+++ b/integration/firestore/firestore_test.go
@@ -19,7 +19,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/integration/internal"
 )

--- a/integration/iid/iid_test.go
+++ b/integration/iid/iid_test.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/iid"
 	"firebase.google.com/go/integration/internal"

--- a/integration/internal/internal.go
+++ b/integration/internal/internal.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"golang.org/x/net/context"
+	"context"
 
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/internal"

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/integration/internal"
 	"firebase.google.com/go/messaging"

--- a/integration/storage/storage_test.go
+++ b/integration/storage/storage_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go"
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -22,9 +22,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"golang.org/x/net/context/ctxhttp"
-
-	"golang.org/x/net/context"
+	"context"
 )
 
 // HTTPClient is a convenient API to make HTTP calls.
@@ -46,7 +44,7 @@ func (c *HTTPClient) Do(ctx context.Context, r *Request) (*Response, error) {
 		return nil, err
 	}
 
-	resp, err := ctxhttp.Do(ctx, c.Client, req)
+	resp, err := c.Client.Do(req.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var cases = []struct {

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -25,8 +25,9 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"firebase.google.com/go/internal"
-	"golang.org/x/net/context"
 
 	"google.golang.org/api/transport"
 )

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/option"

--- a/snippets/auth.go
+++ b/snippets/auth.go
@@ -18,7 +18,7 @@ import (
 	"encoding/base64"
 	"log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/auth"

--- a/snippets/db.go
+++ b/snippets/db.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go/db"
 

--- a/snippets/init.go
+++ b/snippets/init.go
@@ -18,7 +18,7 @@ package snippets
 import (
 	"log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	firebase "firebase.google.com/go"
 	"firebase.google.com/go/auth"

--- a/snippets/messaging.go
+++ b/snippets/messaging.go
@@ -19,7 +19,7 @@ import (
 	"log"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"firebase.google.com/go"
 	"firebase.google.com/go/messaging"

--- a/snippets/storage.go
+++ b/snippets/storage.go
@@ -17,7 +17,7 @@ package snippets
 import (
 	"log"
 
-	"golang.org/x/net/context"
+	"context"
 
 	firebase "firebase.google.com/go"
 	"google.golang.org/api/option"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,7 +18,7 @@ package storage // import "firebase.google.com/go/storage"
 import (
 	"errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"cloud.google.com/go/storage"
 	"firebase.google.com/go/internal"

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -17,7 +17,7 @@ package storage
 import (
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"google.golang.org/api/option"
 


### PR DESCRIPTION
cloud.google.com/go has stopped supporting go 1.8 and earlier. We can now use context.