### PR TITLE
Adding golang 1.11 to the CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ install:
 
 script:
     - golint -set_exit_status $(go list ./...)
-    - ./.travis.gofmt.sh
+    - if [[ "$TRAVIS_GO_VERSION" =~ ^1\.11\.([0-9]+|x)$ ]]; then ./.travis.gofmt.sh; fi
     - go test -v -race -test.short ./...        # Run tests with the race detector.
     - go vet -v ./...                           # Run Go static analyzer.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.9.x
+  - "1.9.x"
   - "1.10.x"
+  - "1.11.x"
   - master
 
 matrix:

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -1028,7 +1028,7 @@ func checkIIDRequest(t *testing.T, b []byte, tr *http.Request, op string) {
 		t.Fatal(err)
 	}
 	want := map[string]interface{}{
-		"to": "/topics/test-topic",
+		"to":                  "/topics/test-topic",
 		"registration_tokens": []interface{}{"id1", "id2"},
 	}
 	if !reflect.DeepEqual(parsed, want) {


### PR DESCRIPTION
* Enabled go 1.11 for Travis CI
* Reformatted the code for go 1.11
* Restricting gofmt verification to go 1.11, since we cannot support it for all versions any longer