### PR TITLE
Fixing how CriticalSound type is serialized for APNs

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -400,9 +400,24 @@ func (a *Aps) MarshalJSON() ([]byte, error) {
 
 // CriticalSound is the sound payload that can be included in an Aps.
 type CriticalSound struct {
-	Critical bool    `json:"critical,omitempty"`
-	Name     string  `json:"name,omitempty"`
-	Volume   float64 `json:"volume,omitempty"`
+	Critical bool
+	Name     string
+	Volume   float64
+}
+
+// MarshalJSON marshals a CriticalSound into JSON (for internal use only).
+func (cs *CriticalSound) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	if cs.Critical {
+		m["critical"] = 1
+	}
+	if cs.Name != "" {
+		m["name"] = cs.Name
+	}
+	if cs.Volume != 0 {
+		m["volume"] = cs.Volume
+	}
+	return json.Marshal(m)
 }
 
 // ApsAlert is the alert payload that can be included in an Aps.

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -652,6 +652,57 @@ var invalidMessages = []struct {
 		want: "locKey is required when specifying locArgs",
 	},
 	{
+		name: "MultipleSoundSpecifications",
+		req: &Message{
+			APNS: &APNSConfig{
+				Payload: &APNSPayload{
+					Aps: &Aps{
+						Sound: "s",
+						CriticalSound: &CriticalSound{
+							Name: "s",
+						},
+					},
+				},
+			},
+			Topic: "topic",
+		},
+		want: "multiple sound specifications",
+	},
+	{
+		name: "VolumeTooLow",
+		req: &Message{
+			APNS: &APNSConfig{
+				Payload: &APNSPayload{
+					Aps: &Aps{
+						CriticalSound: &CriticalSound{
+							Name:   "s",
+							Volume: -0.1,
+						},
+					},
+				},
+			},
+			Topic: "topic",
+		},
+		want: "critical sound volume must be in the interval [0, 1]",
+	},
+	{
+		name: "VolumeTooHigh",
+		req: &Message{
+			APNS: &APNSConfig{
+				Payload: &APNSPayload{
+					Aps: &Aps{
+						CriticalSound: &CriticalSound{
+							Name:   "s",
+							Volume: 1.1,
+						},
+					},
+				},
+			},
+			Topic: "topic",
+		},
+		want: "critical sound volume must be in the interval [0, 1]",
+	},
+	{
 		name: "InvalidWebpushNotificationDirection",
 		req: &Message{
 			Webpush: &WebpushConfig{

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -368,7 +368,7 @@ var validMessages = []struct {
 						"badge":    float64(badge),
 						"category": "c",
 						"sound": map[string]interface{}{
-							"critical": true,
+							"critical": float64(1),
 							"name":     "n",
 							"volume":   float64(0.7),
 						},

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -108,8 +108,13 @@ func validateAps(aps *Aps) error {
 		if aps.Alert != nil && aps.AlertString != "" {
 			return fmt.Errorf("multiple alert specifications")
 		}
-		if aps.CriticalSound != nil && aps.Sound != "" {
-			return fmt.Errorf("multiple sound specifications")
+		if aps.CriticalSound != nil {
+			if aps.Sound != "" {
+				return fmt.Errorf("multiple sound specifications")
+			}
+			if aps.CriticalSound.Volume < 0 || aps.CriticalSound.Volume > 1 {
+				return fmt.Errorf("critical sound volume must be in the interval [0, 1]")
+			}
 		}
 		m := aps.standardFields()
 		for k := range aps.CustomData {


### PR DESCRIPTION
The Critical field should be serialized as a number according to APNs documentation: https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2990112

Also volume should be between 0 and 1.