### PR TITLE
Implement UnmarshalJSON for FCM Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - [added] `messaging.Aps` type now supports critical sound in its payload.
+- [fixed] Public types in the `messaging` package now support correct
+  JSON marshalling and unmarshalling.
 
 # v3.5.0
 

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -797,6 +797,60 @@ func TestNoProjectID(t *testing.T) {
 	}
 }
 
+func TestJSONSerialization(t *testing.T) {
+	cases := []struct {
+		value  interface{}
+		target interface{}
+	}{
+		{
+			value: &Aps{
+				AlertString:      "alertString",
+				Sound:            "soundString",
+				Badge:            &badge,
+				ContentAvailable: true,
+				MutableContent:   true,
+				Category:         "categoryString",
+				ThreadID:         "threadId",
+			},
+			target: &Aps{},
+		},
+		{
+			value: &Aps{
+				Alert: &ApsAlert{
+					Title:    "t",
+					SubTitle: "st",
+				},
+				CriticalSound: &CriticalSound{
+					Critical: true,
+					Name:     "fileName",
+					Volume:   0.5,
+				},
+				Badge:            &badge,
+				ContentAvailable: true,
+				MutableContent:   true,
+				Category:         "categoryString",
+				ThreadID:         "threadId",
+				CustomData: map[string]interface{}{
+					"key": "value",
+				},
+			},
+			target: &Aps{},
+		},
+	}
+	for idx, tc := range cases {
+		b, err := json.Marshal(tc.value)
+		if err != nil {
+			t.Errorf("Marshal(%d) = %v; want = nil", idx, err)
+		}
+		if err := json.Unmarshal(b, tc.target); err != nil {
+			t.Errorf("Unmarshal(%d) = %v; want = nil", idx, err)
+		}
+		if !reflect.DeepEqual(tc.value, tc.target) {
+			t.Errorf("[%d] Unmarshal result = %#v; want = %#v", idx, tc.target, tc.value)
+		}
+	}
+}
+
 func TestSend(t *testing.T) {
 	var tr *http.Request
 	var b []byte
@@ -1138,7 +1192,7 @@ func checkIIDRequest(t *testing.T, b []byte, tr *http.Request, op string) {
 		t.Fatal(err)
 	}
 	want := map[string]interface{}{
-		"to":                  "/topics/test-topic",
+		"to": "/topics/test-topic",
 		"registration_tokens": []interface{}{"id1", "id2"},
 	}
 	if !reflect.DeepEqual(parsed, want) {

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -803,6 +803,57 @@ func TestJSONSerialization(t *testing.T) {
 		target interface{}
 	}{
 		{
+			value: &Message{
+				Topic: "test-topic",
+				Notification: &Notification{
+					Title: "t",
+					Body:  "b",
+				},
+			},
+			target: &Message{},
+		},
+		{
+			value: &WebpushNotification{
+				Title: "title",
+				Body:  "body",
+				Icon:  "icon",
+				Actions: []*WebpushNotificationAction{
+					{
+						Action: "a1",
+						Title:  "a1-title",
+					},
+					{
+						Action: "a2",
+						Title:  "a2-title",
+						Icon:   "a2-icon",
+					},
+				},
+				Badge:              "badge",
+				Data:               "data",
+				Image:              "image",
+				Language:           "lang",
+				Renotify:           true,
+				RequireInteraction: true,
+				Silent:             true,
+				Tag:                "tag",
+				TimestampMillis:    &timestampMillis,
+				Vibrate:            []int{100, 200, 100},
+				CustomData:         map[string]interface{}{"k1": "v1", "k2": "v2"},
+			},
+			target: &WebpushNotification{},
+		},
+		{
+			value: &APNSPayload{
+				Aps: &Aps{
+					AlertString: "alertString",
+				},
+				CustomData: map[string]interface{}{
+					"key": "value",
+				},
+			},
+			target: &APNSPayload{},
+		},
+		{
 			value: &Aps{
 				AlertString:      "alertString",
 				Sound:            "soundString",

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -575,6 +575,23 @@ var invalidMessages = []struct {
 		want: "bodyLocKey is required when specifying bodyLocArgs",
 	},
 	{
+		name: "APNSMultipleAps",
+		req: &Message{
+			APNS: &APNSConfig{
+				Payload: &APNSPayload{
+					Aps: &Aps{
+						AlertString: "alert",
+					},
+					CustomData: map[string]interface{}{
+						"aps": map[string]interface{}{"key": "value"},
+					},
+				},
+			},
+			Topic: "topic",
+		},
+		want: `multiple specifications for the key "aps"`,
+	},
+	{
 		name: "APNSMultipleAlerts",
 		req: &Message{
 			APNS: &APNSConfig{
@@ -867,7 +884,7 @@ func TestInvalidJSONUnmarshal(t *testing.T) {
 			t.Errorf("Marshal(%s) = %v; want = nil", tc.name, err)
 		}
 		if err := json.Unmarshal(b, tc.target); err == nil {
-			t.Errorf("Unmarshal(%s) = %v; want =error", tc.name, err)
+			t.Errorf("Unmarshal(%s) = %v; want = error", tc.name, err)
 		}
 	}
 }

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -98,6 +98,9 @@ func validateAPNSConfig(config *APNSConfig) error {
 
 func validateAPNSPayload(payload *APNSPayload) error {
 	if payload != nil {
+		if _, ok := payload.CustomData["aps"]; ok {
+			return fmt.Errorf("multiple aps specifications")
+		}
 		return validateAps(payload.Aps)
 	}
 	return nil

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -98,8 +98,11 @@ func validateAPNSConfig(config *APNSConfig) error {
 
 func validateAPNSPayload(payload *APNSPayload) error {
 	if payload != nil {
-		if _, ok := payload.CustomData["aps"]; ok {
-			return fmt.Errorf("multiple aps specifications")
+		m := payload.standardFields()
+		for k := range payload.CustomData {
+			if _, contains := m[k]; contains {
+				return fmt.Errorf("multiple specifications for the key %q", k)
+			}
 		}
 		return validateAps(payload.Aps)
 	}


### PR DESCRIPTION
Currently a number of FCM types implement custom marshallers, but not unmarshallers. This results in unexpected behaviors when developers do something like this:

```
aps1 := &messaging.Aps{...}
b, err := json.Marshal(aps1)
SaveToDatabaseForLaterUse(b)

// Sometime later
b := ReadFromDatabase()
var aps2 messaging.Aps
json.Unmarshal(b, &aps2)

// aps1 and aps2 won't be equivalent
```

To resolve this we need to implement proper unmarshallers for each of the types with a custom marshaller. 

Resolves #207 
Resolves #208 