### PR TITLE
Implementing HTTP Retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- [added] Implemented HTTP retries for the `db` package. This package
+  now retries HTTP calls on low-level connection and socket read errors, as
+  well as HTTP 500 and 503 errors.
+
 # v3.6.0
 
 - [added] `messaging.Aps` type now supports critical sound in its payload.

--- a/db/db.go
+++ b/db/db.go
@@ -63,7 +63,7 @@ func NewClient(ctx context.Context, c *internal.DatabaseConfig) (*Client, error)
 	opts := append([]option.ClientOption{}, c.Opts...)
 	ua := fmt.Sprintf(userAgentFormat, c.Version, runtime.Version())
 	opts = append(opts, option.WithUserAgent(ua))
-	hc, err := internal.NewHTTPClient(ctx, opts...)
+	hc, _, err := internal.NewHTTPClient(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -25,7 +25,6 @@ import (
 
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/option"
-	"google.golang.org/api/transport"
 )
 
 const userAgentFormat = "Firebase/HTTP/%s/%s/AdminGo"
@@ -44,14 +43,6 @@ type Client struct {
 // This function can only be invoked from within the SDK. Client applications should access the
 // Database service through firebase.App.
 func NewClient(ctx context.Context, c *internal.DatabaseConfig) (*Client, error) {
-	opts := append([]option.ClientOption{}, c.Opts...)
-	ua := fmt.Sprintf(userAgentFormat, c.Version, runtime.Version())
-	opts = append(opts, option.WithUserAgent(ua))
-	hc, _, err := transport.NewHTTPClient(ctx, opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	p, err := url.ParseRequestURI(c.URL)
 	if err != nil {
 		return nil, err
@@ -69,6 +60,14 @@ func NewClient(ctx context.Context, c *internal.DatabaseConfig) (*Client, error)
 		}
 	}
 
+	opts := append([]option.ClientOption{}, c.Opts...)
+	ua := fmt.Sprintf(userAgentFormat, c.Version, runtime.Version())
+	opts = append(opts, option.WithUserAgent(ua))
+	hc, err := internal.NewHTTPClient(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+
 	ep := func(b []byte) string {
 		var p struct {
 			Error string `json:"error"`
@@ -78,8 +77,10 @@ func NewClient(ctx context.Context, c *internal.DatabaseConfig) (*Client, error)
 		}
 		return p.Error
 	}
+	hc.ErrParser = ep
+
 	return &Client{
-		hc:           &internal.HTTPClient{Client: hc, ErrParser: ep},
+		hc:           hc,
 		url:          fmt.Sprintf("https://%s", p.Host),
 		authOverride: string(ao),
 	}, nil

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -56,6 +56,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalln(err)
 	}
+	// Disable retries for faster execution
+	client.hc.RetryConfig = nil
 
 	ao := map[string]interface{}{"uid": "user1"}
 	aoClient, err = NewClient(context.Background(), &internal.DatabaseConfig{

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -33,7 +33,10 @@ import (
 	"google.golang.org/api/option"
 )
 
-const testURL = "https://test-db.firebaseio.com"
+const (
+	testURL           = "https://test-db.firebaseio.com"
+	defaultMaxRetries = 1
+)
 
 var testUserAgent string
 var testAuthOverrides string
@@ -56,8 +59,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	// Disable retries for faster execution
-	client.hc.RetryConfig = nil
+	retryConfig := client.hc.RetryConfig
+	retryConfig.MaxRetries = defaultMaxRetries
+	retryConfig.ExpBackoffFactor = 0
 
 	ao := map[string]interface{}{"uid": "user1"}
 	aoClient, err = NewClient(context.Background(), &internal.DatabaseConfig{

--- a/db/ref_test.go
+++ b/db/ref_test.go
@@ -292,8 +292,9 @@ func TestWelformedHttpError(t *testing.T) {
 		})
 	}
 
-	if len(mock.Reqs) != len(testOps) {
-		t.Errorf("Requests = %d; want = %d", len(mock.Reqs), len(testOps))
+	wantReqs := len(testOps) * (1 + defaultMaxRetries)
+	if len(mock.Reqs) != wantReqs {
+		t.Errorf("Requests = %d; want = %d", len(mock.Reqs), wantReqs)
 	}
 }
 
@@ -312,8 +313,9 @@ func TestUnexpectedHttpError(t *testing.T) {
 		})
 	}
 
-	if len(mock.Reqs) != len(testOps) {
-		t.Errorf("Requests = %d; want = %d", len(mock.Reqs), len(testOps))
+	wantReqs := len(testOps) * (1 + defaultMaxRetries)
+	if len(mock.Reqs) != wantReqs {
+		t.Errorf("Requests = %d; want = %d", len(mock.Reqs), wantReqs)
 	}
 }
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -330,7 +330,7 @@ func (rc *RetryConfig) retryEligible(retries int, resp *http.Response, err error
 		return false
 	}
 	if rc.CheckForRetry == nil {
-		return err != nil || resp.StatusCode >= 400
+		return err != nil || resp.StatusCode >= 500
 	}
 	return rc.CheckForRetry(resp, err)
 }

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -393,7 +393,7 @@ func TestNoRetryOnHTTPSuccessCodes(t *testing.T) {
 }
 
 func TestRetryOnHTTPErrorCodes(t *testing.T) {
-	for i := http.StatusBadRequest; i <= http.StatusNetworkAuthenticationRequired; i++ {
+	for i := http.StatusInternalServerError; i <= http.StatusNetworkAuthenticationRequired; i++ {
 		resp := &http.Response{
 			StatusCode: i,
 		}

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -17,6 +17,7 @@ package internal // import "firebase.google.com/go/internal"
 
 import (
 	"fmt"
+	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -119,4 +120,27 @@ type MockTokenSource struct {
 // Token returns the test token associated with the TokenSource.
 func (ts *MockTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{AccessToken: ts.AccessToken}, nil
+}
+
+// Clock is used to query the current local time.
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock returns the current system time.
+type SystemClock struct{}
+
+// Now returns the current system time by calling time.Now().
+func (s SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+// MockClock can be used to mock current time during tests.
+type MockClock struct {
+	Timestamp time.Time
+}
+
+// Now returns the timestamp set in the MockClock.
+func (m *MockClock) Now() time.Time {
+	return m.Timestamp
 }


### PR DESCRIPTION
* Implementing retries support in the `internal.HTTPClient` API.
* Enabling the retries support for RTDB (will enable it for other APIs in later PRs).
* Retrying requests on all network errors and HTTP 503 and 500 errors by default.
* Support for Retry-After header and exponential backoff (similar algorithm to Python's `urllib3.util.Retry`).