### PR TITLE
Enabling HTTP retries for FCM and IID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - [added] Implemented HTTP retries for the `db` package. This package
   now retries HTTP calls on low-level connection and socket read errors, as
   well as HTTP 500 and 503 errors.
+- [fixed] Updated `messaging.Client` and `iid.Client` to use the new
+  HTTP client API with retries support.
 
 # v3.6.0
 

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 
 	"firebase.google.com/go/internal"
-	"google.golang.org/api/transport"
 )
 
 const iidEndpoint = "https://console.firebase.google.com/v1"
@@ -117,14 +116,14 @@ func NewClient(ctx context.Context, c *internal.InstanceIDConfig) (*Client, erro
 		return nil, errors.New("project id is required to access instance id client")
 	}
 
-	hc, _, err := transport.NewHTTPClient(ctx, c.Opts...)
+	hc, _, err := internal.NewHTTPClient(ctx, c.Opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Client{
 		endpoint: iidEndpoint,
-		client:   &internal.HTTPClient{Client: hc},
+		client:   hc,
 		project:  c.ProjectID,
 	}, nil
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"firebase.google.com/go/internal"
-	"google.golang.org/api/transport"
 )
 
 const (
@@ -653,7 +652,7 @@ func NewClient(ctx context.Context, c *internal.MessagingConfig) (*Client, error
 		return nil, errors.New("project ID is required to access Firebase Cloud Messaging client")
 	}
 
-	hc, _, err := transport.NewHTTPClient(ctx, c.Opts...)
+	hc, _, err := internal.NewHTTPClient(ctx, c.Opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -661,7 +660,7 @@ func NewClient(ctx context.Context, c *internal.MessagingConfig) (*Client, error
 	return &Client{
 		fcmEndpoint: messagingEndpoint,
 		iidEndpoint: iidEndpoint,
-		client:      &internal.HTTPClient{Client: hc},
+		client:      hc,
 		project:     c.ProjectID,
 		version:     "Go/Admin/" + c.Version,
 	}, nil


### PR DESCRIPTION
Updated `messaging.Client` and `iid.Client` to use the new `internal.NewHTTPClient()` API which automatically enables retries.