### PR TITLE
Refactoring Unit Tests

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -17,7 +17,6 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -69,17 +68,6 @@ type Client struct {
 	clock     internal.Clock
 }
 
-func signerFromCreds(creds []byte) (cryptoSigner, error) {
-	var sa serviceAccount
-	if err := json.Unmarshal(creds, &sa); err != nil {
-		return nil, err
-	}
-	if sa.PrivateKey != "" && sa.ClientEmail != "" {
-		return newServiceAccountSigner(sa)
-	}
-	return nil, nil
-}
-
 // NewClient creates a new instance of the Firebase Auth Client.
 //
 // This function can only be invoked from within the SDK. Client applications should access the
@@ -93,7 +81,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 	if conf.Creds != nil && len(conf.Creds.JSON) > 0 {
 		// If the SDK was initialized with a service account, use it to sign bytes.
 		signer, err = signerFromCreds(conf.Creds.JSON)
-		if err != nil {
+		if err != nil && err != errNotAServiceAcct {
 			return nil, err
 		}
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -66,7 +66,7 @@ type Client struct {
 	projectID string
 	signer    cryptoSigner
 	version   string
-	clock     clock
+	clock     internal.Clock
 }
 
 type signer interface {
@@ -136,7 +136,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		projectID: conf.ProjectID,
 		signer:    signer,
 		version:   "Go/Admin/" + conf.Version,
-		clock:     &systemClock{},
+		clock:     internal.SystemClock,
 	}, nil
 }
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -72,7 +72,7 @@ func TestMain(m *testing.M) {
 func TestNewClientWithServiceAccountCredentials(t *testing.T) {
 	creds, err := transport.Creds(context.Background(), optsWithServiceAcct...)
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 	client, err := NewClient(context.Background(), &internal.AuthConfig{
 		Creds:     creds,
@@ -81,7 +81,7 @@ func TestNewClientWithServiceAccountCredentials(t *testing.T) {
 		Version:   "test-version",
 	})
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 
 	if _, ok := client.signer.(*serviceAccountSigner); !ok {
@@ -457,7 +457,7 @@ func TestVerifyIDTokenInvalidAlgorithm(t *testing.T) {
 	}
 	token, err := info.Token(context.Background(), testSigner)
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 
 	client := &Client{

--- a/auth/token_generator.go
+++ b/auth/token_generator.go
@@ -98,6 +98,19 @@ type serviceAccountSigner struct {
 	clientEmail string
 }
 
+var errNotAServiceAcct = errors.New("credentials json is not a service account")
+
+func signerFromCreds(creds []byte) (cryptoSigner, error) {
+	var sa serviceAccount
+	if err := json.Unmarshal(creds, &sa); err != nil {
+		return nil, err
+	}
+	if sa.PrivateKey != "" && sa.ClientEmail != "" {
+		return newServiceAccountSigner(sa)
+	}
+	return nil, errNotAServiceAcct
+}
+
 func newServiceAccountSigner(sa serviceAccount) (*serviceAccountSigner, error) {
 	block, _ := pem.Decode([]byte(sa.PrivateKey))
 	if block == nil {

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -32,6 +32,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"firebase.google.com/go/internal"
 )
 
 // keySource is used to obtain a set of public keys, which can be used to verify cryptographic
@@ -48,7 +50,7 @@ type httpKeySource struct {
 	HTTPClient *http.Client
 	CachedKeys []*publicKey
 	ExpiryTime time.Time
-	Clock      clock
+	Clock      internal.Clock
 	Mutex      *sync.Mutex
 }
 
@@ -56,7 +58,7 @@ func newHTTPKeySource(uri string, hc *http.Client) *httpKeySource {
 	return &httpKeySource{
 		KeyURI:     uri,
 		HTTPClient: hc,
-		Clock:      systemClock{},
+		Clock:      internal.SystemClock,
 		Mutex:      &sync.Mutex{},
 	}
 }
@@ -169,25 +171,6 @@ func verifySignature(parts []string, k *publicKey) error {
 type publicKey struct {
 	Kid string
 	Key *rsa.PublicKey
-}
-
-// clock is used to query the current local time.
-type clock interface {
-	Now() time.Time
-}
-
-type systemClock struct{}
-
-func (s systemClock) Now() time.Time {
-	return time.Now()
-}
-
-type mockClock struct {
-	now time.Time
-}
-
-func (m *mockClock) Now() time.Time {
-	return m.now
 }
 
 func findMaxAge(resp *http.Response) (*time.Duration, error) {

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -155,7 +155,7 @@ func TestParsePublicKeysError(t *testing.T) {
 }
 
 func TestVerifyToken(t *testing.T) {
-	if err := verifyToken(context.Background(), testIDToken, client.keySource); err != nil {
+	if err := verifyToken(context.Background(), testIDToken, testKeySource); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -163,7 +163,7 @@ func TestVerifyToken(t *testing.T) {
 func TestVerifyTokenError(t *testing.T) {
 	tokens := []string{"", "foo", "foo.bar.baz"}
 	for _, token := range tokens {
-		if err := verifyToken(context.Background(), token, client.keySource); err == nil {
+		if err := verifyToken(context.Background(), token, testKeySource); err == nil {
 			t.Errorf("verifyToken(%q) = nil; want = error", token)
 		}
 	}

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -15,6 +15,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"firebase.google.com/go/internal"
 )
 
 func TestHTTPKeySource(t *testing.T) {
@@ -60,7 +63,7 @@ func TestHTTPKeySourceWithClient(t *testing.T) {
 func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 	hc, _ := newTestHTTPClient([]byte(""))
 	ks := newHTTPKeySource("http://mock.url", hc)
-	if keys, err := ks.Keys(ctx); keys != nil || err == nil {
+	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
 }
@@ -68,7 +71,7 @@ func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 func TestHTTPKeySourceIncorrectResponse(t *testing.T) {
 	hc, _ := newTestHTTPClient([]byte("{\"foo\": 1}"))
 	ks := newHTTPKeySource("http://mock.url", hc)
-	if keys, err := ks.Keys(ctx); keys != nil || err == nil {
+	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
 }
@@ -80,7 +83,7 @@ func TestHTTPKeySourceTransportError(t *testing.T) {
 		},
 	}
 	ks := newHTTPKeySource("http://mock.url", hc)
-	if keys, err := ks.Keys(ctx); keys != nil || err == nil {
+	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
 }
@@ -152,7 +155,7 @@ func TestParsePublicKeysError(t *testing.T) {
 }
 
 func TestVerifyToken(t *testing.T) {
-	if err := verifyToken(ctx, testIDToken, client.keySource); err != nil {
+	if err := verifyToken(context.Background(), testIDToken, client.keySource); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -160,7 +163,7 @@ func TestVerifyToken(t *testing.T) {
 func TestVerifyTokenError(t *testing.T) {
 	tokens := []string{"", "foo", "foo.bar.baz"}
 	for _, token := range tokens {
-		if err := verifyToken(ctx, token, client.keySource); err == nil {
+		if err := verifyToken(context.Background(), token, client.keySource); err == nil {
 			t.Errorf("verifyToken(%q) = nil; want = error", token)
 		}
 	}
@@ -221,12 +224,12 @@ func (r *mockReadCloser) Close() error {
 }
 
 func verifyHTTPKeySource(ks *httpKeySource, rc *mockReadCloser) error {
-	mc := &mockClock{now: time.Unix(0, 0)}
+	mc := &internal.MockClock{Timestamp: time.Unix(0, 0)}
 	ks.Clock = mc
 
 	exp := time.Unix(100, 0)
 	for i := 0; i <= 100; i++ {
-		keys, err := ks.Keys(ctx)
+		keys, err := ks.Keys(context.Background())
 		if err != nil {
 			return err
 		}
@@ -237,11 +240,11 @@ func verifyHTTPKeySource(ks *httpKeySource, rc *mockReadCloser) error {
 		} else if ks.ExpiryTime != exp {
 			return fmt.Errorf("Expiry: %v; want: %v", ks.ExpiryTime, exp)
 		}
-		mc.now = mc.now.Add(time.Second)
+		mc.Timestamp = mc.Timestamp.Add(time.Second)
 	}
 
-	mc.now = time.Unix(101, 0)
-	keys, err := ks.Keys(ctx)
+	mc.Timestamp = time.Unix(101, 0)
+	keys, err := ks.Keys(context.Background())
 	if err != nil {
 		return err
 	}

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -29,10 +29,8 @@ import (
 	"time"
 
 	"firebase.google.com/go/internal"
-	"golang.org/x/oauth2"
 	"google.golang.org/api/identitytoolkit/v3"
 	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
 var testUser = &UserRecord{
@@ -1146,13 +1144,12 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 	})
 	s.Srv = httptest.NewServer(handler)
 	conf := &internal.AuthConfig{
-		Opts: []option.ClientOption{
-			option.WithTokenSource(&mockTokenSource{testToken})},
+		Opts:      optsWithTokenSource,
 		ProjectID: "mock-project-id",
 		Version:   testVersion,
 	}
 
-	authClient, err := NewClient(ctx, conf)
+	authClient, err := NewClient(context.Background(), conf)
 	authClient.keySource = &fileKeySource{FilePath: "../testdata/public_certs.json"}
 	if err != nil {
 		t.Fatal(err)
@@ -1164,12 +1161,4 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 
 func (s *mockAuthServer) Close() {
 	s.Srv.Close()
-}
-
-type mockTokenSource struct {
-	AccessToken string
-}
-
-func (m *mockTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{AccessToken: m.AccessToken}, nil
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -124,6 +124,7 @@ func TestGetUserByPhoneNumber(t *testing.T) {
 }
 
 func TestInvalidGetUser(t *testing.T) {
+	client := &Client{}
 	user, err := client.GetUser(context.Background(), "")
 	if user != nil || err == nil {
 		t.Errorf("GetUser('') = (%v, %v); want = (nil, error)", user, err)
@@ -269,6 +270,7 @@ func TestInvalidCreateUser(t *testing.T) {
 			`malformed email string: "a@a@a"`,
 		},
 	}
+	client := &Client{}
 	for i, tc := range cases {
 		user, err := client.CreateUser(context.Background(), tc.params)
 		if user != nil || err == nil {
@@ -400,6 +402,7 @@ func TestInvalidUpdateUser(t *testing.T) {
 		cases = append(cases, s)
 	}
 
+	client := &Client{}
 	for i, tc := range cases {
 		user, err := client.UpdateUser(context.Background(), "uid", tc.params)
 		if user != nil || err == nil {
@@ -413,6 +416,7 @@ func TestInvalidUpdateUser(t *testing.T) {
 
 func TestUpdateUserEmptyUID(t *testing.T) {
 	params := (&UserToUpdate{}).DisplayName("test")
+	client := &Client{}
 	user, err := client.UpdateUser(context.Background(), "", params)
 	if user != nil || err == nil {
 		t.Errorf("UpdateUser('') = (%v, %v); want = (nil, error)", user, err)
@@ -576,6 +580,7 @@ func TestInvalidSetCustomClaims(t *testing.T) {
 		cases = append(cases, s)
 	}
 
+	client := &Client{}
 	for _, tc := range cases {
 		err := client.SetCustomUserClaims(context.Background(), "uid", tc.cc)
 		if err == nil {
@@ -976,6 +981,7 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestInvalidDeleteUser(t *testing.T) {
+	client := &Client{}
 	if err := client.DeleteUser(context.Background(), ""); err == nil {
 		t.Errorf("DeleteUser('') = nil; want error")
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 
 	"firebase.google.com/go/internal"
-	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
 
@@ -38,15 +37,17 @@ const (
 	defaultMaxRetries = 1
 )
 
-var testUserAgent string
-var testAuthOverrides string
-var testOpts = []option.ClientOption{
-	option.WithTokenSource(&mockTokenSource{"mock-token"}),
-}
+var (
+	aoClient          *Client
+	client            *Client
+	testAuthOverrides string
+	testref           *Ref
+	testUserAgent     string
 
-var client *Client
-var aoClient *Client
-var testref *Ref
+	testOpts = []option.ClientOption{
+		option.WithTokenSource(&internal.MockTokenSource{AccessToken: "mock-token"}),
+	}
+)
 
 func TestMain(m *testing.M) {
 	var err error
@@ -387,14 +388,6 @@ func (s *mockServer) Start(c *Client) *httptest.Server {
 	s.srv = httptest.NewServer(handler)
 	c.url = s.srv.URL
 	return s.srv
-}
-
-type mockTokenSource struct {
-	AccessToken string
-}
-
-func (ts *mockTokenSource) Token() (*oauth2.Token, error) {
-	return &oauth2.Token{AccessToken: ts.AccessToken}, nil
 }
 
 type person struct {

--- a/iid/iid_test.go
+++ b/iid/iid_test.go
@@ -187,6 +187,8 @@ func TestDeleteInstanceIDConnectionError(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.endpoint = ts.URL
+	client.client.RetryConfig = nil
+
 	if err := client.DeleteInstanceID(ctx, "test-iid"); err == nil {
 		t.Errorf("DeleteInstanceID() = nil; want = error")
 		return

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -347,7 +347,7 @@ func (rc *RetryConfig) estimateDelayBeforeNextRetry(retries int) time.Duration {
 	return estimatedDelay
 }
 
-var retryTimeClock Clock = &SystemClock{}
+var retryTimeClock Clock = SystemClock
 
 func parseRetryAfterHeader(resp *http.Response) time.Duration {
 	if resp == nil {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -34,6 +34,9 @@ var FirebaseScopes = []string{
 	"https://www.googleapis.com/auth/userinfo.email",
 }
 
+// SystemClock is a clock that returns local time of the system.
+var SystemClock = &systemClock{}
+
 // AuthConfig represents the configuration of Firebase Auth service.
 type AuthConfig struct {
 	Opts             []option.ClientOption
@@ -127,11 +130,11 @@ type Clock interface {
 	Now() time.Time
 }
 
-// SystemClock returns the current system time.
-type SystemClock struct{}
+// systemClock returns the current system time.
+type systemClock struct{}
 
 // Now returns the current system time by calling time.Now().
-func (s SystemClock) Now() time.Time {
+func (s *systemClock) Now() time.Time {
 	return time.Now()
 }
 


### PR DESCRIPTION
I'm planning some refactoring work (especially in the auth package). In preparation for that I wanted to clean up and refactor our unit tests first.

1. Using `internal.Clock` and `internal.MockAccessTokenSource` in all packages.
2. Removing the App Engine dependencies in the auth tests (this was never properly maintained or verified).
3. Updating auth unit tests to use more local variables, and less package variables for clarity and readability. Specifically, tests no longer use a single, shared `auth.Client` instance that is set up at the package level.