### PR TITLE
Extracting the Token Verification Logic into a New Type

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -108,7 +108,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		return nil, err
 	}
 
-	idTokenVerifier, err := newIDTokenVerifier(ctx, conf)
+	idTokenVerifier, err := newIDTokenVerifier(ctx, conf.ProjectID)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -23,16 +23,12 @@ import (
 
 	"firebase.google.com/go/internal"
 	"google.golang.org/api/identitytoolkit/v3"
-	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
 )
 
 const (
 	firebaseAudience = "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
-	idTokenCertURL   = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com"
-	issuerPrefix     = "https://securetoken.google.com/"
-	tokenExpSeconds  = 3600
-	clockSkewSeconds = 300
+	oneHourInSeconds = 3600
 )
 
 var reservedClaims = []string{
@@ -60,12 +56,11 @@ type Token struct {
 // Client facilitates generating custom JWT tokens for Firebase clients, and verifying ID tokens issued
 // by Firebase backend services.
 type Client struct {
-	is        *identitytoolkit.Service
-	keySource keySource
-	projectID string
-	signer    cryptoSigner
-	version   string
-	clock     internal.Clock
+	is              *identitytoolkit.Service
+	idTokenVerifier *tokenVerifier
+	signer          cryptoSigner
+	version         string
+	clock           internal.Clock
 }
 
 // NewClient creates a new instance of the Firebase Auth Client.
@@ -113,17 +108,16 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		return nil, err
 	}
 
-	noAuthHTTPClient, _, err := transport.NewHTTPClient(ctx, option.WithoutAuthentication())
+	idTokenVerifier, err := newIDTokenVerifier(ctx, conf)
 	if err != nil {
 		return nil, err
 	}
 	return &Client{
-		is:        is,
-		keySource: newHTTPKeySource(idTokenCertURL, noAuthHTTPClient),
-		projectID: conf.ProjectID,
-		signer:    signer,
-		version:   "Go/Admin/" + conf.Version,
-		clock:     internal.SystemClock,
+		is:              is,
+		idTokenVerifier: idTokenVerifier,
+		signer:          signer,
+		version:         "Go/Admin/" + conf.Version,
+		clock:           internal.SystemClock,
 	}, nil
 }
 
@@ -183,7 +177,7 @@ func (c *Client) CustomTokenWithClaims(ctx context.Context, uid string, devClaim
 			Aud:    firebaseAudience,
 			UID:    uid,
 			Iat:    now,
-			Exp:    now + tokenExpSeconds,
+			Exp:    now + oneHourInSeconds,
 			Claims: devClaims,
 		},
 	}
@@ -199,79 +193,7 @@ func (c *Client) CustomTokenWithClaims(ctx context.Context, uid string, devClaim
 // more details on how to obtain an ID token in a client app.
 // This does not check whether or not the token has been revoked. See `VerifyIDTokenAndCheckRevoked` below.
 func (c *Client) VerifyIDToken(ctx context.Context, idToken string) (*Token, error) {
-	if c.projectID == "" {
-		return nil, errors.New("project id not available")
-	}
-	if idToken == "" {
-		return nil, fmt.Errorf("id token must be a non-empty string")
-	}
-
-	segments := strings.Split(idToken, ".")
-
-	var (
-		header  jwtHeader
-		payload Token
-		claims  map[string]interface{}
-	)
-	if err := decode(segments[0], &header); err != nil {
-		return nil, err
-	}
-	if err := decode(segments[1], &payload); err != nil {
-		return nil, err
-	}
-	if err := decode(segments[1], &claims); err != nil {
-		return nil, err
-	}
-	// Delete standard claims from the custom claims maps.
-	for _, r := range []string{"iss", "aud", "exp", "iat", "sub", "uid"} {
-		delete(claims, r)
-	}
-	payload.Claims = claims
-
-	projectIDMsg := "make sure the ID token comes from the same Firebase project as the credential used to" +
-		" authenticate this SDK"
-	verifyTokenMsg := "see https://firebase.google.com/docs/auth/admin/verify-id-tokens for details on how to " +
-		"retrieve a valid ID token"
-	issuer := issuerPrefix + c.projectID
-
-	var err error
-	if header.KeyID == "" {
-		if payload.Audience == firebaseAudience {
-			err = fmt.Errorf("expected an ID token but got a custom token")
-		} else {
-			err = fmt.Errorf("ID token has no 'kid' header")
-		}
-	} else if header.Algorithm != "RS256" {
-		err = fmt.Errorf("ID token has invalid algorithm; expected 'RS256' but got %q; %s",
-			header.Algorithm, verifyTokenMsg)
-	} else if payload.Audience != c.projectID {
-		err = fmt.Errorf("ID token has invalid 'aud' (audience) claim; expected %q but got %q; %s; %s",
-			c.projectID, payload.Audience, projectIDMsg, verifyTokenMsg)
-	} else if payload.Issuer != issuer {
-		err = fmt.Errorf("ID token has invalid 'iss' (issuer) claim; expected %q but got %q; %s; %s",
-			issuer, payload.Issuer, projectIDMsg, verifyTokenMsg)
-	} else if (payload.IssuedAt - clockSkewSeconds) > c.clock.Now().Unix() {
-		err = fmt.Errorf("ID token issued at future timestamp: %d", payload.IssuedAt)
-	} else if (payload.Expires + clockSkewSeconds) < c.clock.Now().Unix() {
-		err = fmt.Errorf("ID token has expired at: %d", payload.Expires)
-	} else if payload.Subject == "" {
-		err = fmt.Errorf("ID token has empty 'sub' (subject) claim; %s", verifyTokenMsg)
-	} else if len(payload.Subject) > 128 {
-		err = fmt.Errorf("ID token has a 'sub' (subject) claim longer than 128 characters; %s", verifyTokenMsg)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	payload.UID = payload.Subject
-
-	// Verifying the signature requires syncronized access to a key store and
-	// potentially issues a http request. Validating the fields of the token is
-	// cheaper and invalid tokens will fail faster.
-	if err := verifyToken(ctx, idToken, c.keySource); err != nil {
-		return nil, err
-	}
-	return &payload, nil
+	return c.idTokenVerifier.VerifyToken(ctx, idToken)
 }
 
 // VerifyIDTokenAndCheckRevoked verifies the provided ID token and checks it has not been revoked.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -90,7 +90,7 @@ func TestNewClientWithServiceAccountCredentials(t *testing.T) {
 		t.Errorf("NewClient().signer = %#v; want = serviceAccountSigner", client.signer)
 	}
 	if err := checkIDTokenVerifier(client.idTokenVerifier, creds.ProjectID); err != nil {
-		t.Errorf("NewClient().idTokenVerifier = %v; want = nil", err)
+		t.Errorf("NewClient().idTokenVerifier: %v", err)
 	}
 	if client.clock != internal.SystemClock {
 		t.Errorf("NewClient().clock = %v; want = SystemClock", client.clock)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -67,6 +67,7 @@ func TestMain(m *testing.M) {
 		log.Fatalln(err)
 	}
 	testIDTokenVerifier.keySource = &fileKeySource{FilePath: "../testdata/public_certs.json"}
+	testIDTokenVerifier.clock = testClock
 
 	testGetUserResponse, err = ioutil.ReadFile("../testdata/get_user.json")
 	if err != nil {

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -54,7 +54,7 @@ type tokenVerifier struct {
 	clock             internal.Clock
 }
 
-func newIDTokenVerifier(ctx context.Context, conf *internal.AuthConfig) (*tokenVerifier, error) {
+func newIDTokenVerifier(ctx context.Context, projectID string) (*tokenVerifier, error) {
 	noAuthHTTPClient, _, err := transport.NewHTTPClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func newIDTokenVerifier(ctx context.Context, conf *internal.AuthConfig) (*tokenV
 		shortName:         "ID token",
 		articledShortName: "an ID token",
 		docURL:            "https://firebase.google.com/docs/auth/admin/verify-id-tokens",
-		projectID:         conf.ProjectID,
+		projectID:         projectID,
 		issuerPrefix:      idTokenIssuerPrefix,
 		keySource:         newHTTPKeySource(idTokenCertURL, noAuthHTTPClient),
 		clock:             internal.SystemClock,
@@ -73,9 +73,6 @@ func newIDTokenVerifier(ctx context.Context, conf *internal.AuthConfig) (*tokenV
 func (tv *tokenVerifier) VerifyToken(ctx context.Context, token string) (*Token, error) {
 	if tv.projectID == "" {
 		return nil, errors.New("project id not available")
-	}
-	if tv.issuerPrefix == "" {
-		panic("issuer prefix not available")
 	}
 	if token == "" {
 		return nil, fmt.Errorf("%s must be a non-empty string", tv.shortName)
@@ -164,9 +161,6 @@ func (tv *tokenVerifier) verifyTimestamps(payload *Token) error {
 
 func (tv *tokenVerifier) verifySignature(ctx context.Context, token string) error {
 	segments := strings.Split(token, ".")
-	if len(segments) != 3 {
-		return errors.New("incorrect number of segments")
-	}
 
 	var h jwtHeader
 	if err := decode(segments[0], &h); err != nil {

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -74,7 +74,7 @@ func newIDTokenVerifier(ctx context.Context, projectID string) (*tokenVerifier, 
 
 // VerifyToken Verifies that the given token string is a valid Firebase JWT.
 //
-// VerifyToken considers token string to be valid if all the following conditions are met:
+// VerifyToken considers a token string to be valid if all the following conditions are met:
 //   - The token string is a valid RS256 JWT.
 //   - The JWT contains a valid key ID (kid) claim.
 //   - The JWT contains valid issuer (iss) and audience (aud) claims that match the issuerPrefix
@@ -93,7 +93,7 @@ func (tv *tokenVerifier) VerifyToken(ctx context.Context, token string) (*Token,
 		return nil, fmt.Errorf("%s must be a non-empty string", tv.shortName)
 	}
 
-	// Validate the token content first. This is fast and cheaper.
+	// Validate the token content first. This is fast and cheap.
 	payload, err := tv.verifyContent(token)
 	if err != nil {
 		return nil, fmt.Errorf("%s; see %s for details on how to retrieve a valid %s",

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -27,6 +27,29 @@ import (
 	"firebase.google.com/go/internal"
 )
 
+func TestNewIDTokenVerifier(t *testing.T) {
+	tv, err := newIDTokenVerifier(context.Background(), testProjectID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tv.shortName != "ID token" {
+		t.Errorf("tokenVerifier.shortName = %q; want = %q", tv.shortName, "ID token")
+	}
+	if tv.projectID != testProjectID {
+		t.Errorf("tokenVerifier.projectID = %q; want = %q", tv.projectID, testProjectID)
+	}
+	if tv.issuerPrefix != idTokenIssuerPrefix {
+		t.Errorf("tokenVerifier.issuerPrefix = %q; want = %q", tv.issuerPrefix, idTokenIssuerPrefix)
+	}
+	ks, ok := tv.keySource.(*httpKeySource)
+	if !ok {
+		t.Fatalf("tokenVerifier.keySource = %#v; want = httpKeySource", tv.keySource)
+	}
+	if ks.KeyURI != idTokenCertURL {
+		t.Errorf("tokenVerifier.certURL = %q; want = %q", ks.KeyURI, idTokenCertURL)
+	}
+}
+
 func TestHTTPKeySource(t *testing.T) {
 	data, err := ioutil.ReadFile("../testdata/public_certs.json")
 	if err != nil {
@@ -71,6 +94,27 @@ func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 func TestHTTPKeySourceIncorrectResponse(t *testing.T) {
 	hc, _ := newTestHTTPClient([]byte("{\"foo\": 1}"))
 	ks := newHTTPKeySource("http://mock.url", hc)
+	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
+		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
+	}
+}
+
+func TestHTTPKeySourceHTTPError(t *testing.T) {
+	rc := &mockReadCloser{
+		data:       string(""),
+		closeCount: 0,
+	}
+	client := &http.Client{
+		Transport: &mockHTTPResponse{
+			Response: http.Response{
+				Status:     "503 Service Unavailable",
+				StatusCode: http.StatusServiceUnavailable,
+				Body:       rc,
+			},
+			Err: nil,
+		},
+	}
+	ks := newHTTPKeySource("http://mock.url", client)
 	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)
 	}
@@ -150,33 +194,6 @@ func TestParsePublicKeysError(t *testing.T) {
 	for _, tc := range cases {
 		if keys, err := parsePublicKeys([]byte(tc)); keys != nil || err == nil {
 			t.Errorf("parsePublicKeys(%q) = (%v, %v); want = (nil, err)", tc, keys, err)
-		}
-	}
-}
-
-func TestVerifyToken(t *testing.T) {
-	tv := &tokenVerifier{
-		keySource:    testKeySource,
-		clock:        testClock,
-		projectID:    testProjectID,
-		issuerPrefix: idTokenIssuerPrefix,
-	}
-	if _, err := tv.VerifyToken(context.Background(), testIDToken); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestVerifyTokenError(t *testing.T) {
-	tv := &tokenVerifier{
-		keySource:    testKeySource,
-		clock:        testClock,
-		projectID:    testProjectID,
-		issuerPrefix: idTokenIssuerPrefix,
-	}
-	tokens := []string{"", "foo", "foo.bar.baz"}
-	for _, token := range tokens {
-		if _, err := tv.VerifyToken(context.Background(), token); err == nil {
-			t.Errorf("verifyToken(%q) = nil; want = error", token)
 		}
 	}
 }

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -155,15 +155,27 @@ func TestParsePublicKeysError(t *testing.T) {
 }
 
 func TestVerifyToken(t *testing.T) {
-	if err := verifyToken(context.Background(), testIDToken, testKeySource); err != nil {
+	tv := &tokenVerifier{
+		keySource:    testKeySource,
+		clock:        testClock,
+		projectID:    testProjectID,
+		issuerPrefix: idTokenIssuerPrefix,
+	}
+	if _, err := tv.VerifyToken(context.Background(), testIDToken); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestVerifyTokenError(t *testing.T) {
+	tv := &tokenVerifier{
+		keySource:    testKeySource,
+		clock:        testClock,
+		projectID:    testProjectID,
+		issuerPrefix: idTokenIssuerPrefix,
+	}
 	tokens := []string{"", "foo", "foo.bar.baz"}
 	for _, token := range tokens {
-		if err := verifyToken(context.Background(), token, testKeySource); err == nil {
+		if _, err := tv.VerifyToken(context.Background(), token); err == nil {
 			t.Errorf("verifyToken(%q) = nil; want = error", token)
 		}
 	}

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -92,7 +92,7 @@ func TestHTTPKeySourceEmptyResponse(t *testing.T) {
 }
 
 func TestHTTPKeySourceIncorrectResponse(t *testing.T) {
-	hc, _ := newTestHTTPClient([]byte("{\"foo\": 1}"))
+	hc, _ := newTestHTTPClient([]byte("{\"foo\": \"bar\"}"))
 	ks := newHTTPKeySource("http://mock.url", hc)
 	if keys, err := ks.Keys(context.Background()); keys != nil || err == nil {
 		t.Errorf("Keys() = (%v, %v); want = (nil, error)", keys, err)

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1156,7 +1156,6 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 	}
 
 	authClient, err := NewClient(context.Background(), conf)
-	authClient.keySource = &fileKeySource{FilePath: "../testdata/public_certs.json"}
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We are planning to implement session cookie verification API soon. This requires the same code currently being used to verify ID tokens. In order to reuse this logic easily, I'm extracting it out and putting it in a new type named `tokenVerifier`.