### PR TITLE
Fixing an error formatting bug in FCM tests

### DIFF
--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -1089,7 +1089,7 @@ func TestInvalidSubscribe(t *testing.T) {
 			resp, err := client.SubscribeToTopic(ctx, tc.tokens, tc.topic)
 			if err == nil || err.Error() != tc.want {
 				t.Errorf(
-					"SubscribeToTopic(%s) = (%#v, %v); want = (%q, %q)", tc.name, resp, err, "", tc.want)
+					"SubscribeToTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
 			}
 		})
 	}
@@ -1132,7 +1132,7 @@ func TestInvalidUnsubscribe(t *testing.T) {
 			resp, err := client.UnsubscribeFromTopic(ctx, tc.tokens, tc.topic)
 			if err == nil || err.Error() != tc.want {
 				t.Errorf(
-					"UnsubscribeFromTopic(%s) = (%#v, %v); want = (%q, %q)", tc.name, resp, err, "", tc.want)
+					"UnsubscribeFromTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
 			}
 		})
 	}
@@ -1184,14 +1184,14 @@ func TestTopicManagementError(t *testing.T) {
 		resp = tc.resp
 		tmr, err := client.SubscribeToTopic(ctx, []string{"id1"}, "topic")
 		if err == nil || err.Error() != tc.want || !tc.check(err) {
-			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (%q, %q)", tmr, err, "", tc.want)
+			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
 		}
 	}
 	for _, tc := range cases {
 		resp = tc.resp
 		tmr, err := client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
 		if err == nil || err.Error() != tc.want {
-			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (%q, %q)", tmr, err, "", tc.want)
+			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
 		}
 	}
 }

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -1086,9 +1086,10 @@ func TestInvalidSubscribe(t *testing.T) {
 	}
 	for _, tc := range invalidTopicMgtArgs {
 		t.Run(tc.name, func(t *testing.T) {
-			name, err := client.SubscribeToTopic(ctx, tc.tokens, tc.topic)
+			resp, err := client.SubscribeToTopic(ctx, tc.tokens, tc.topic)
 			if err == nil || err.Error() != tc.want {
-				t.Errorf("SubscribeToTopic(%s) = (%q, %v); want = (%q, %q)", tc.name, name, err, "", tc.want)
+				t.Errorf(
+					"SubscribeToTopic(%s) = (%#v, %v); want = (%q, %q)", tc.name, resp, err, "", tc.want)
 			}
 		})
 	}
@@ -1128,9 +1129,10 @@ func TestInvalidUnsubscribe(t *testing.T) {
 	}
 	for _, tc := range invalidTopicMgtArgs {
 		t.Run(tc.name, func(t *testing.T) {
-			name, err := client.UnsubscribeFromTopic(ctx, tc.tokens, tc.topic)
+			resp, err := client.UnsubscribeFromTopic(ctx, tc.tokens, tc.topic)
 			if err == nil || err.Error() != tc.want {
-				t.Errorf("UnsubscribeFromTopic(%s) = (%q, %v); want = (%q, %q)", tc.name, name, err, "", tc.want)
+				t.Errorf(
+					"UnsubscribeFromTopic(%s) = (%#v, %v); want = (%q, %q)", tc.name, resp, err, "", tc.want)
 			}
 		})
 	}
@@ -1182,14 +1184,14 @@ func TestTopicManagementError(t *testing.T) {
 		resp = tc.resp
 		tmr, err := client.SubscribeToTopic(ctx, []string{"id1"}, "topic")
 		if err == nil || err.Error() != tc.want || !tc.check(err) {
-			t.Errorf("SubscribeToTopic() = (%q, %v); want = (%q, %q)", tmr, err, "", tc.want)
+			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (%q, %q)", tmr, err, "", tc.want)
 		}
 	}
 	for _, tc := range cases {
 		resp = tc.resp
 		tmr, err := client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
 		if err == nil || err.Error() != tc.want {
-			t.Errorf("UnsubscribeFromTopic() = (%q, %v); want = (%q, %q)", tmr, err, "", tc.want)
+			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (%q, %q)", tmr, err, "", tc.want)
 		}
 	}
 }


### PR DESCRIPTION
New Go tools are pedantic about this:

```
# firebase.google.com/go/messaging
../../go-workspace/src/firebase.google.com/go/messaging/messaging_test.go:1091:5: Errorf format %q has arg name of wrong type *firebase.google.com/go/messaging.TopicManagementResponse
../../go-workspace/src/firebase.google.com/go/messaging/messaging_test.go:1133:5: Errorf format %q has arg name of wrong type *firebase.google.com/go/messaging.TopicManagementResponse
../../go-workspace/src/firebase.google.com/go/messaging/messaging_test.go:1185:4: Errorf format %q has arg tmr of wrong type *firebase.google.com/go/messaging.TopicManagementResponse
../../go-workspace/src/firebase.google.com/go/messaging/messaging_test.go:1192:4: Errorf format %q has arg tmr of wrong type *firebase.google.com/go/messaging.TopicManagementResponse
```