### PR TITLE
Implemented GetUser* APIs with internal.HTTPClient

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -593,14 +593,30 @@ type userManagementClient struct {
 	httpClient *internal.HTTPClient
 }
 
-type userQuery interface {
-	name() string
-	build() map[string]interface{}
-}
-
 // GetUser gets the user data corresponding to the specified user ID.
 func (c *userManagementClient) GetUser(ctx context.Context, uid string) (*UserRecord, error) {
 	return c.getUser(ctx, uidQuery(uid))
+}
+
+// GetUserByEmail gets the user data corresponding to the specified email.
+func (c *userManagementClient) GetUserByEmail(ctx context.Context, email string) (*UserRecord, error) {
+	if err := validateEmail(email); err != nil {
+		return nil, err
+	}
+	return c.getUser(ctx, emailQuery(email))
+}
+
+// GetUserByPhoneNumber gets the user data corresponding to the specified user phone number.
+func (c *userManagementClient) GetUserByPhoneNumber(ctx context.Context, phone string) (*UserRecord, error) {
+	if err := validatePhone(phone); err != nil {
+		return nil, err
+	}
+	return c.getUser(ctx, phoneNumberQuery(phone))
+}
+
+type userQuery interface {
+	name() string
+	build() map[string]interface{}
 }
 
 type uidQuery string
@@ -615,14 +631,6 @@ func (q uidQuery) build() map[string]interface{} {
 	}
 }
 
-// GetUserByEmail gets the user data corresponding to the specified email.
-func (c *userManagementClient) GetUserByEmail(ctx context.Context, email string) (*UserRecord, error) {
-	if err := validateEmail(email); err != nil {
-		return nil, err
-	}
-	return c.getUser(ctx, emailQuery(email))
-}
-
 type emailQuery string
 
 func (q emailQuery) name() string {
@@ -633,14 +641,6 @@ func (q emailQuery) build() map[string]interface{} {
 	return map[string]interface{}{
 		"email": []string{string(q)},
 	}
-}
-
-// GetUserByPhoneNumber gets the user data corresponding to the specified user phone number.
-func (c *userManagementClient) GetUserByPhoneNumber(ctx context.Context, phone string) (*UserRecord, error) {
-	if err := validatePhone(phone); err != nil {
-		return nil, err
-	}
-	return c.getUser(ctx, phoneNumberQuery(phone))
 }
 
 type phoneNumberQuery string

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1143,6 +1143,7 @@ func TestSessionCookieLongExpiresIn(t *testing.T) {
 func TestHTTPError(t *testing.T) {
 	s := echoServer([]byte(`{"error":"test"}`), t)
 	defer s.Close()
+	s.Client.httpClient.RetryConfig = nil
 	s.Status = http.StatusInternalServerError
 
 	u, err := s.Client.GetUser(context.Background(), "some uid")
@@ -1150,7 +1151,7 @@ func TestHTTPError(t *testing.T) {
 		t.Fatalf("GetUser() = (%v, %v); want = (nil, error)", u, err)
 	}
 
-	want := `googleapi: got HTTP response code 500 with body: {"error":"test"}`
+	want := `http error status: 500; body: {"error":"test"}`
 	if err.Error() != want || !IsUnknown(err) {
 		t.Errorf("GetUser() = %v; want = %q", err, want)
 	}
@@ -1168,6 +1169,7 @@ func TestHTTPErrorWithCode(t *testing.T) {
 	}
 	s := echoServer(nil, t)
 	defer s.Close()
+	s.Client.httpClient.RetryConfig = nil
 	s.Status = http.StatusInternalServerError
 
 	for code, check := range errorCodes {
@@ -1177,7 +1179,7 @@ func TestHTTPErrorWithCode(t *testing.T) {
 			t.Fatalf("GetUser() = (%v, %v); want = (nil, error)", u, err)
 		}
 
-		want := fmt.Sprintf("googleapi: Error 500: %s", code)
+		want := fmt.Sprintf(`http error status: 500; body: {"error":{"message":"%s"}}`, code)
 		if err.Error() != want || !check(err) {
 			t.Errorf("GetUser() = %v; want = %q", err, want)
 		}


### PR DESCRIPTION
As a continuation of #220, I'm moving the `GetUser()`, `GetUserByEmail()` and `GetUserByPhoneNumber()` API implementations off the `identitytoolkit` package, and on to our homegrown `internal.HTTPClient`.