### PR TITLE
Initial commit - FR: realtime event listener for RTDB (#229)

### DIFF
--- a/cmd/listen/main.go
+++ b/cmd/listen/main.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"golang.org/x/net/context"
+	"google.golang.org/api/option"
+
+	firebase "firebase.google.com/go"
+	"firebase.google.com/go/db"
+)
+
+func main() {
+
+	// opt := option.WithCredentialsFile("c:/users/username/.firebase/firebase.json") // Windows
+	//
+	opt := option.WithCredentialsFile("/home/username/.firebase/firebase.json") // Linux, edit 1.
+
+	config := &firebase.Config{
+		DatabaseURL: "https://mydb.firebaseio.com", // edit 2.
+	}
+
+	app, err := firebase.NewApp(context.Background(), config, opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	ctx := context.Background()
+
+	// DatabaseWithURL
+	client, err := app.Database(ctx)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testpath := "user1/path1"
+	ref := client.NewRef(testpath)
+
+	args := os.Args
+	if len(args) > 1 {
+		triggerEvent(ctx, client, testpath, args[1])
+		return // exit app
+	}
+
+	// SnapshotIterator
+	iter, err := ref.Listen(ctx)
+	if err != nil {
+		fmt.Printf(" Error: failed to create Listener %v\n", err)
+		return
+	}
+
+	fmt.Printf("client app | Ref Path: %s | iter.Snapshot = %v\n", ref.Path, iter.Snapshot)
+	fmt.Printf("           | Ref Key: %s \n", ref.Key)
+
+	defer iter.Stop()
+
+	go func() {
+		for {
+			event, err := iter.Next()
+
+			if err != nil {
+				break
+			}
+
+			fmt.Printf("client app | Ref Path: %s | event.Path %s | event.Snapshot() = %v\n", ref.Path, event.Path, event.Snapshot())
+			fmt.Printf("\n")
+		}
+	}()
+
+	fmt.Printf("\n >>> edit value of any key from %s in firebase console to trigger event\n\n", testpath)
+	fmt.Printf("\n >>> press <enter> to close http connection\n\n")
+	fmt.Printf("Waiting for events...\n\n")
+
+	fmt.Scanln()
+	iter.Stop()
+
+	fmt.Printf("\n >>> press <enter> to exit app\n\n\n")
+	fmt.Scanln()
+}
+
+func triggerEvent(ctx context.Context, client *db.Client, testpath string, val string) {
+
+	ref := client.NewRef(testpath + "/key1")
+
+	if err := ref.Set(ctx, val); err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Printf("OK - Set %s to %v\n", testpath+"/key1", val)
+	}
+}

--- a/db/event.go
+++ b/db/event.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// SSE = Sever-Sent Events = ssevent
+
+// EventType ...
+type EventType uint
+
+// EventType ...
+const (
+	ChildChanged EventType = iota
+	ChildAdded             // to be implemented
+	ChildRemoved           // to be implemented
+	ValueChanged           // to be implemented
+)
+
+// Event Sever-Sent Event object
+type Event struct {
+	EventType EventType // ChildChanged, ValueChanged, ChildAdded, ChildRemoved
+
+	Data string // JSON-encoded snapshot
+	Path string // snapshot path
+}
+
+// SnapshotIterator iterator for continuous event
+type SnapshotIterator struct {
+	Snapshot    string         // initial snapshot, JSON-encoded, returned from http Respoonse, server sent event, data part
+	SSEDataChan <-chan string  // continuous event snapshot, channel receive only, directional channel
+	resp        *http.Response // http connection keep alive
+	active      bool           // false when resp is closed, used to prevent channel block, defaults to false
+}
+
+// Snapshot ssevent data, data part
+func (e *Event) Snapshot() string {
+	return e.Data // ssevent data (snapshot), snapshot only, data part of ssevent data
+}
+
+// Unmarshal current snapshot Event.Data
+func (e *Event) Unmarshal(v interface{}) error {
+
+	return json.Unmarshal([]byte(e.Data), v)
+}
+
+// Next ...
+func (i *SnapshotIterator) Next() (*Event, error) {
+
+	// prevent channel block
+	if i.active == false {
+		return nil, errors.New("SnapshotIterator is not active")
+	}
+
+	sseDataString := <-i.SSEDataChan
+
+	// todo: determine EventType
+
+	path, ss, err := splitSSEData(sseDataString)
+
+	return &Event{
+		EventType: ChildChanged,
+		Data:      ss, // snapshot
+		Path:      path,
+	}, err
+
+} // Next()
+
+// Stop ...
+func (i *SnapshotIterator) Stop() {
+	i.active = false
+	if i.resp != nil {
+		i.resp.Body.Close()
+	}
+}

--- a/db/event_ref.go
+++ b/db/event_ref.go
@@ -1,0 +1,207 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"firebase.google.com/go/internal"
+)
+
+// Listen ...
+func (r *Ref) Listen(ctx context.Context) (*SnapshotIterator, error) {
+
+	sseDataChan := make(chan string) // server-sent event data channel
+
+	var opts []internal.HTTPOption
+	opts = append(opts, internal.WithHeader("Cache-Control", "no-cache"))
+	opts = append(opts, internal.WithHeader("Accept", "text/event-stream"))
+	opts = append(opts, internal.WithHeader("Connection", "keep-alive"))
+
+	resp, err := r.sendListen(ctx, "GET", opts...)
+
+	if err != nil {
+		return &SnapshotIterator{active: false}, err
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+
+	snapshot, err := getInitialNodeSnapshot(scanner, resp)
+
+	if err != nil {
+		return &SnapshotIterator{active: false}, err
+	}
+
+	go startListening(scanner, resp, sseDataChan)
+
+	return &SnapshotIterator{
+		Snapshot:    snapshot,
+		SSEDataChan: sseDataChan,
+		resp:        resp, //*http.Response
+		active:      true,
+	}, err
+
+} // Listen()
+
+// return initial snapshot (JSON-encoded string) from Ref.Path node location
+func getInitialNodeSnapshot(scanner *bufio.Scanner, resp *http.Response) (string, error) {
+
+	var b []byte
+
+	if scanner.Scan() == true {
+
+		b = scanner.Bytes()
+
+		if "event: put" == string(b) {
+
+			if scanner.Scan() == true {
+				b = scanner.Bytes()
+				s := string(b)
+
+				// https://firebase.google.com/docs/reference/rest/database/#section-streaming
+				// JSON encoded data payload
+				// sample
+				// s = data: {"path":"/","data":{"test3":{"test4":4}}}
+
+				// sse data = path + snapshot
+				// we only want snapshot
+				// path is always root for initial json payload, so 1st 25 char/byte is conistent
+				// data: {"path":"/","data":
+				// 1234567890123456789012345
+				if s[:25] != "data: {\"path\":\"/\",\"data\":" {
+					return "", errors.New("sse data json error, 25 char/byte sequence")
+				}
+
+				if s[:5] == "data:" {
+					ss := s[6:]         // trim first 6 chars:'data: '
+					ss = ss[19:]        // trim first 19 chars:'{path":"/","data":'
+					ss = ss[:len(ss)-1] // trim last char }
+					return ss, nil      // {"test3":{"test4":4}} = snapshot
+				}
+			}
+		}
+
+	}
+
+	return "", errors.New("sse data json error, event: put")
+}
+
+// called with goroutine
+func startListening(scanner *bufio.Scanner, resp *http.Response, sseDataChan chan<- string) { // sseDataChan send only
+
+	var b []byte
+
+	for {
+		if scanner.Scan() == true {
+
+			b = scanner.Bytes()
+
+			if "event: put" == string(b) {
+
+				if scanner.Scan() == true {
+					b = scanner.Bytes()
+					s := string(b)
+
+					// sample data
+					// s = 'data: {"path":"/","data":{"test3":{"test4":4}}}'
+
+					// sse data = path + snapshot
+					if s[:5] == "data:" {
+						// trim 'data: '
+						sseDataChan <- s[6:] // {"path":"/","data":{"test3":{"test4":4}}}
+
+					}
+				}
+			}
+
+		} else {
+
+			break
+		}
+
+	} // for
+}
+
+// returns path and snapshot
+func splitSSEData(json string) (string, string, error) {
+
+	// sse data = path + snapshot
+	// expected json payload string is similar to this:
+	// {"path":"/test2","data":{"test3":{"test4":4}}}
+
+	// IMPORTANT: quote and comma are valid in path, but are escaped in json payload
+	//            so the 3 char/byte sequence used in count "," should only occur once
+
+	count := strings.Count(json, "\",\"") // unique 3 char/byte sequence in json payload
+	index := strings.Index(json, "\",\"")
+
+	if count != 1 {
+		// count must equal to 1 or json payload is incorrect
+		return "", "", errors.New("sse data json count error")
+	}
+
+	if index < 11 { // 11 comes from root path which is minimum '{"path":"/"'
+		return "", "", errors.New("sse data json index error")
+	}
+
+	if json[:8] == "{\"path\":" {
+		path := json
+		path = path[:index]
+		path = path[9:] // 9 = {"path":"
+
+		ss := json
+		ss = ss[index+9:]    // trim  '..."/","data":'
+		ss = ss[:len(ss)-1]  // trim last char }
+		return path, ss, nil // {"test3":{"test4":4}} = snapshot
+	}
+
+	return "", "", errors.New("sse data json {\"path\": not found error")
+}
+
+func (c *Client) sendListen(
+	ctx context.Context,
+	method, path string,
+	body internal.HTTPEntity,
+	opts ...internal.HTTPOption) (*http.Response, error) {
+
+	if strings.ContainsAny(path, invalidChars) {
+		return nil, fmt.Errorf("invalid path with illegal characters: %q", path)
+	}
+	if c.authOverride != "" {
+		opts = append(opts, internal.WithQueryParam(authVarOverride, c.authOverride))
+	}
+
+	resp, err := c.hc.DoListen(ctx, &internal.Request{
+		Method: method,
+		URL:    fmt.Sprintf("%s%s.json", c.url, path),
+		Body:   body,
+		Opts:   opts,
+	})
+
+	return resp, err
+}
+
+func (r *Ref) sendListen(
+	ctx context.Context,
+	method string,
+	opts ...internal.HTTPOption) (*http.Response, error) {
+
+	return r.client.sendListen(ctx, method, r.Path, nil, opts...)
+}

--- a/db/event_test.go
+++ b/db/event_test.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"testing"
+)
+
+func TestListen(t *testing.T) {
+	mock := &mockServer{}
+	srv := mock.Start(client)
+	defer srv.Close()
+
+	// mostly just a place holder, currenty test for crash only
+
+	iter, err := testref.Listen(context.Background())
+	_ = iter
+	_ = err
+
+	defer iter.Stop()
+
+	event, err := iter.Next()
+	_ = event
+	_ = err
+
+	if err == nil {
+		iter.Stop()
+	}
+
+}

--- a/internal/http_client_event.go
+++ b/internal/http_client_event.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+	"net/http"
+)
+
+// DoListen executes the given Request, and returns a Response.
+func (c *HTTPClient) DoListen(ctx context.Context, r *Request) (*http.Response, error) {
+	req, err := r.buildHTTPRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.Client.Do(req.WithContext(ctx))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Here's a pull request against ```dev```

``` see cmd/listen/main.go for working simple test client app```

To run the test app, edit main.go for credential json file location "edit 1." and db url "edit 2."
then from command line terminal, cd to cmd/listen
```go run . init```  - creates snapshot user1/path1/key1:"init"  for listener testing
```go run .``` - starts listening
 start a new command line terminal, cd to cmd/listen
```go run . hey``` - this will trigger an event and should show up from other cmd line listener 



Here's the gist of the code:
```golang
  iter, err := ref.Listen(ctx)
  
  defer iter.Stop()
  
  go func() {
    for {
      event, err := iter.Next()

      if err != nil {
        break
      }
    }
  }()
```


FR https://github.com/firebase/firebase-admin-go/issues/229



