### PR TITLE
add analytics_label in FcmOptions + fix FcmOptions for WebpushFcmOptions

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -142,7 +142,7 @@ type Message struct {
 	Android      *AndroidConfig    `json:"android,omitempty"`
 	Webpush      *WebpushConfig    `json:"webpush,omitempty"`
 	APNS         *APNSConfig       `json:"apns,omitempty"`
-	FcmOptions   *FcmOptions       `json:"fcm_options,omitempty"`
+	FCMOptions   *FCMOptions       `json:"fcm_options,omitempty"`
 	Token        string            `json:"token,omitempty"`
 	Topic        string            `json:"-"`
 	Condition    string            `json:"condition,omitempty"`
@@ -193,7 +193,7 @@ type AndroidConfig struct {
 	RestrictedPackageName string               `json:"restricted_package_name,omitempty"`
 	Data                  map[string]string    `json:"data,omitempty"` // if specified, overrides the Data field on Message type
 	Notification          *AndroidNotification `json:"notification,omitempty"`
-	FcmOptions            *AndroidFcmOptions   `json:"fcm_options,omitempty"`
+	FCMOptions            *AndroidFCMOptions   `json:"fcm_options,omitempty"`
 }
 
 // MarshalJSON marshals an AndroidConfig into JSON (for internal use only).
@@ -270,8 +270,8 @@ type AndroidNotification struct {
 	ChannelID    string   `json:"channel_id,omitempty"`
 }
 
-// AndroidFcmOptions contains additional options for features provided by the FCM Android SDK.
-type AndroidFcmOptions struct {
+// AndroidFCMOptions contains additional options for features provided by the FCM Android SDK.
+type AndroidFCMOptions struct {
 	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }
 
@@ -401,7 +401,7 @@ type WebpushFcmOptions struct {
 type APNSConfig struct {
 	Headers    map[string]string `json:"headers,omitempty"`
 	Payload    *APNSPayload      `json:"payload,omitempty"`
-	FcmOptions *APNSFcmOptions   `json:"fcm_options,omitempty"`
+	FCMOptions *APNSFCMOptions   `json:"fcm_options,omitempty"`
 }
 
 // APNSPayload is the payload that can be included in an APNS message.
@@ -610,13 +610,13 @@ type ApsAlert struct {
 	LaunchImage     string   `json:"launch-image,omitempty"`
 }
 
-// APNSFcmOptions contains additional options for features provided by the FCM Aps SDK.
-type APNSFcmOptions struct {
+// APNSFCMOptions contains additional options for features provided by the FCM Aps SDK.
+type APNSFCMOptions struct {
 	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }
 
-// FcmOptions contains additional options to use across all platforms.
-type FcmOptions struct {
+// FCMOptions contains additional options to use across all platforms.
+type FCMOptions struct {
 	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }
 

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -142,6 +142,7 @@ type Message struct {
 	Android      *AndroidConfig    `json:"android,omitempty"`
 	Webpush      *WebpushConfig    `json:"webpush,omitempty"`
 	APNS         *APNSConfig       `json:"apns,omitempty"`
+	FcmOptions   *FcmOptions       `json:"fcm_options,omitempty"`
 	Token        string            `json:"token,omitempty"`
 	Topic        string            `json:"-"`
 	Condition    string            `json:"condition,omitempty"`
@@ -192,6 +193,7 @@ type AndroidConfig struct {
 	RestrictedPackageName string               `json:"restricted_package_name,omitempty"`
 	Data                  map[string]string    `json:"data,omitempty"` // if specified, overrides the Data field on Message type
 	Notification          *AndroidNotification `json:"notification,omitempty"`
+	FcmOptions            *AndroidFcmOptions   `json:"fcm_options,omitempty"`
 }
 
 // MarshalJSON marshals an AndroidConfig into JSON (for internal use only).
@@ -268,6 +270,11 @@ type AndroidNotification struct {
 	ChannelID    string   `json:"channel_id,omitempty"`
 }
 
+// AndroidFcmOptions contains additional options for features provided by the FCM Android SDK.
+type AndroidFcmOptions struct {
+	AnalyticsLabel string `json:"analytics_label,omitempty"`
+}
+
 // WebpushConfig contains messaging options specific to the WebPush protocol.
 //
 // See https://tools.ietf.org/html/rfc8030#section-5 for additional details, and supported
@@ -276,7 +283,7 @@ type WebpushConfig struct {
 	Headers      map[string]string    `json:"headers,omitempty"`
 	Data         map[string]string    `json:"data,omitempty"`
 	Notification *WebpushNotification `json:"notification,omitempty"`
-	FcmOptions   *WebpushFcmOptions   `json:"fcmOptions,omitempty"`
+	FcmOptions   *WebpushFcmOptions   `json:"fcm_options,omitempty"`
 }
 
 // WebpushNotificationAction represents an action that can be performed upon receiving a WebPush notification.
@@ -392,8 +399,9 @@ type WebpushFcmOptions struct {
 // See https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
 // for more details on supported headers and payload keys.
 type APNSConfig struct {
-	Headers map[string]string `json:"headers,omitempty"`
-	Payload *APNSPayload      `json:"payload,omitempty"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Payload    *APNSPayload      `json:"payload,omitempty"`
+	FcmOptions *APNSFcmOptions   `json:"fcm_options,omitempty"`
 }
 
 // APNSPayload is the payload that can be included in an APNS message.
@@ -600,6 +608,16 @@ type ApsAlert struct {
 	SubTitleLocArgs []string `json:"subtitle-loc-args,omitempty"`
 	ActionLocKey    string   `json:"action-loc-key,omitempty"`
 	LaunchImage     string   `json:"launch-image,omitempty"`
+}
+
+// APNSFcmOptions contains additional options for features provided by the FCM Aps SDK.
+type APNSFcmOptions struct {
+	AnalyticsLabel string `json:"analytics_label,omitempty"`
+}
+
+// FcmOptions contains additional options.
+type FcmOptions struct {
+	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }
 
 // ErrorInfo is a topic management error.

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -615,7 +615,7 @@ type APNSFcmOptions struct {
 	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }
 
-// FcmOptions contains additional options.
+// FcmOptions contains additional options to use across all platforms.
 type FcmOptions struct {
 	AnalyticsLabel string `json:"analytics_label,omitempty"`
 }

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -82,7 +82,7 @@ var validMessages = []struct {
 				"k1": "v1",
 				"k2": "v2",
 			},
-			FcmOptions: &FcmOptions{
+			FCMOptions: &FCMOptions{
 				AnalyticsLabel: "Analytics",
 			},
 			Topic: "test-topic",
@@ -159,7 +159,7 @@ var validMessages = []struct {
 					ChannelID:    "channel",
 				},
 				TTL: &ttlWithNanos,
-				FcmOptions: &AndroidFcmOptions{
+				FCMOptions: &AndroidFCMOptions{
 					AnalyticsLabel: "Analytics",
 				},
 			},
@@ -320,7 +320,7 @@ var validMessages = []struct {
 						"k2": true,
 					},
 				},
-				FcmOptions: &APNSFcmOptions{
+				FCMOptions: &APNSFCMOptions{
 					AnalyticsLabel: "Analytics",
 				},
 			},

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -82,12 +82,18 @@ var validMessages = []struct {
 				"k1": "v1",
 				"k2": "v2",
 			},
+			FcmOptions: &FcmOptions{
+				AnalyticsLabel: "Analytics",
+			},
 			Topic: "test-topic",
 		},
 		want: map[string]interface{}{
 			"data": map[string]interface{}{
 				"k1": "v1",
 				"k2": "v2",
+			},
+			"fcm_options": map[string]interface{}{
+				"analytics_label": "Analytics",
 			},
 			"topic": "test-topic",
 		},
@@ -153,6 +159,9 @@ var validMessages = []struct {
 					ChannelID:    "channel",
 				},
 				TTL: &ttlWithNanos,
+				FcmOptions: &AndroidFcmOptions{
+					AnalyticsLabel: "Analytics",
+				},
 			},
 			Topic: "test-topic",
 		},
@@ -171,6 +180,9 @@ var validMessages = []struct {
 					"channel_id":     "channel",
 				},
 				"ttl": "1.500000000s",
+				"fcm_options": map[string]interface{}{
+					"analytics_label": "Analytics",
+				},
 			},
 			"topic": "test-topic",
 		},
@@ -260,7 +272,7 @@ var validMessages = []struct {
 					"k1":                 "v1",
 					"k2":                 "v2",
 				},
-				"fcmOptions": map[string]interface{}{
+				"fcm_options": map[string]interface{}{
 					"link": "https://link.com",
 				},
 			},
@@ -308,6 +320,9 @@ var validMessages = []struct {
 						"k2": true,
 					},
 				},
+				FcmOptions: &APNSFcmOptions{
+					AnalyticsLabel: "Analytics",
+				},
 			},
 			Topic: "test-topic",
 		},
@@ -326,6 +341,9 @@ var validMessages = []struct {
 					},
 					"k1": "v1",
 					"k2": true,
+				},
+				"fcm_options": map[string]interface{}{
+					"analytics_label": "Analytics",
 				},
 			},
 			"topic": "test-topic",


### PR DESCRIPTION
- add analytics_label in FcmOptions
- fix json representation of FcmOptions for [WebpushFcmOptions](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?authuser=0#webpushfcmoptions) 
#255 