### PR TITLE
Implementing the messaging.SendAll() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- [added] Implemented `messaging.SendAll()` function for sending
+  up to 100 FCM messages at a time.
+
 # v3.8.1
 
 - [fixed] Fixed a test case that was failing in environments without

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -122,6 +122,9 @@ func TestSendAll(t *testing.T) {
 	if resp == nil || len(resp.Responses) != 2 {
 		t.Errorf("Not right")
 	}
+	if resp.SuccessCount != 2 {
+		t.Errorf("Success = %d", resp.SuccessCount)
+	}
 }
 
 func TestSendInvalidToken(t *testing.T) {

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -98,14 +98,14 @@ func TestSend(t *testing.T) {
 
 func TestSendAll(t *testing.T) {
 	messages := []*messaging.Message{
-		&messaging.Message{
+		{
 			Notification: &messaging.Notification{
 				Title: "Title 1",
 				Body:  "Body 1",
 			},
 			Topic: "foo-bar",
 		},
-		&messaging.Message{
+		{
 			Notification: &messaging.Notification{
 				Title: "Title 2",
 				Body:  "Body 2",

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -96,6 +96,34 @@ func TestSend(t *testing.T) {
 	}
 }
 
+func TestSendAll(t *testing.T) {
+	messages := []*messaging.Message{
+		&messaging.Message{
+			Notification: &messaging.Notification{
+				Title: "Title 1",
+				Body:  "Body 1",
+			},
+			Topic: "foo-bar",
+		},
+		&messaging.Message{
+			Notification: &messaging.Notification{
+				Title: "Title 2",
+				Body:  "Body 2",
+			},
+			Topic: "foo-bar",
+		},
+	}
+
+	resp, err := client.SendAll(context.Background(), messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil || len(resp.Responses) != 2 {
+		t.Errorf("Not right")
+	}
+}
+
 func TestSendInvalidToken(t *testing.T) {
 	msg := &messaging.Message{Token: "INVALID_TOKEN"}
 	if _, err := client.Send(context.Background(), msg); err == nil {

--- a/integration/messaging/messaging_test.go
+++ b/integration/messaging/messaging_test.go
@@ -16,7 +16,9 @@ package messaging
 
 import (
 	"context"
+	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"regexp"
@@ -32,6 +34,7 @@ import (
 const testRegistrationToken = "fGw0qy4TGgk:APA91bGtWGjuhp4WRhHXgbabIYp1jxEKI08ofj_v1bKhWAGJQ4e3a" +
 	"rRCWzeTfHaLz83mBnDh0aPWB1AykXAVUUGl2h1wT4XI6XazWpvY7RBUSYfoxtqSWGIm2nvWh2BOP1YG501SsRoE"
 
+var messageIDPattern = regexp.MustCompile("^projects/.*/messages/.*$")
 var client *messaging.Client
 
 // Enable API before testing
@@ -90,9 +93,15 @@ func TestSend(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	const pattern = "^projects/.*/messages/.*$"
-	if !regexp.MustCompile(pattern).MatchString(name) {
-		t.Errorf("Send() = %q; want = %q", name, pattern)
+	if !messageIDPattern.MatchString(name) {
+		t.Errorf("Send() = %q; want = %q", name, messageIDPattern.String())
+	}
+}
+
+func TestSendInvalidToken(t *testing.T) {
+	msg := &messaging.Message{Token: "INVALID_TOKEN"}
+	if _, err := client.Send(context.Background(), msg); err == nil || !messaging.IsInvalidArgument(err) {
+		t.Errorf("Send() = %v; want InvalidArgumentError", err)
 	}
 }
 
@@ -112,25 +121,78 @@ func TestSendAll(t *testing.T) {
 			},
 			Topic: "foo-bar",
 		},
+		{
+			Notification: &messaging.Notification{
+				Title: "Title 3",
+				Body:  "Body 3",
+			},
+			Token: "INVALID_TOKEN",
+		},
 	}
 
-	resp, err := client.SendAll(context.Background(), messages)
+	br, err := client.SendAll(context.Background(), messages)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if resp == nil || len(resp.Responses) != 2 {
-		t.Errorf("Not right")
+	if len(br.Responses) != 3 {
+		t.Errorf("len(Responses) = %d; want = 3", len(br.Responses))
 	}
-	if resp.SuccessCount != 2 {
-		t.Errorf("Success = %d", resp.SuccessCount)
+	if br.SuccessCount != 2 {
+		t.Errorf("SuccessCount = %d; want = 2", br.SuccessCount)
+	}
+	if br.FailureCount != 1 {
+		t.Errorf("FailureCount = %d; want = 1", br.FailureCount)
+	}
+
+	for i := 0; i < 2; i++ {
+		sr := br.Responses[i]
+		if err := checkSuccessfulSendResponse(sr); err != nil {
+			t.Errorf("Responses[%d]: %v", i, err)
+		}
+	}
+
+	sr := br.Responses[2]
+	if sr.Success {
+		t.Errorf("Responses[2]: Success = true; want = false")
+	}
+	if sr.MessageID != "" {
+		t.Errorf("Responses[2]: MessageID = %q; want = %q", sr.MessageID, "")
+	}
+	if sr.Error == nil || !messaging.IsInvalidArgument(sr.Error) {
+		t.Errorf("Responses[2]: Error = %v; want = InvalidArgumentError", sr.Error)
 	}
 }
 
-func TestSendInvalidToken(t *testing.T) {
-	msg := &messaging.Message{Token: "INVALID_TOKEN"}
-	if _, err := client.Send(context.Background(), msg); err == nil {
-		t.Errorf("Send() = nil; want error")
+func TestSendHundred(t *testing.T) {
+	var messages []*messaging.Message
+	for i := 0; i < 100; i++ {
+		m := &messaging.Message{
+			Topic: fmt.Sprintf("foo-bar-%d", i%10),
+		}
+		messages = append(messages, m)
+	}
+
+	br, err := client.SendAll(context.Background(), messages)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(br.Responses) != 100 {
+		t.Errorf("len(Responses) = %d; want = 100", len(br.Responses))
+	}
+	if br.SuccessCount != 100 {
+		t.Errorf("SuccessCount = %d; want = 100", br.SuccessCount)
+	}
+	if br.FailureCount != 0 {
+		t.Errorf("FailureCount = %d; want = 0", br.FailureCount)
+	}
+
+	for i := 0; i < 100; i++ {
+		sr := br.Responses[i]
+		if err := checkSuccessfulSendResponse(sr); err != nil {
+			t.Errorf("Responses[%d]: %v", i, err)
+		}
 	}
 }
 
@@ -152,4 +214,18 @@ func TestUnsubscribe(t *testing.T) {
 	if tmr.SuccessCount+tmr.FailureCount != 1 {
 		t.Errorf("UnsubscribeFromTopic() = %v; want total 1", tmr)
 	}
+}
+
+func checkSuccessfulSendResponse(sr *messaging.SendResponse) error {
+	if !sr.Success {
+		return errors.New("Success = false; want = true")
+	}
+	if !messageIDPattern.MatchString(sr.MessageID) {
+		return fmt.Errorf("MessageID = %q; want = %q", sr.MessageID, messageIDPattern.String())
+	}
+	if sr.Error != nil {
+		return fmt.Errorf("Error = %v; want = nil", sr.Error)
+	}
+
+	return nil
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -824,6 +824,10 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 		return result.Name, err
 	}
 
+	return "", c.handleFCMError(resp)
+}
+
+func (c *Client) handleFCMError(resp *internal.Response) error {
 	var fe fcmError
 	json.Unmarshal(resp.Body, &fe) // ignore any json parse errors at this level
 	var serverCode string
@@ -848,7 +852,7 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 	if fe.Error.Message != "" {
 		msg += "; details: " + fe.Error.Message
 	}
-	return "", internal.Errorf(clientCode, "http error status: %d; reason: %s", resp.Status, msg)
+	return internal.Errorf(clientCode, "http error status: %d; reason: %s", resp.Status, msg)
 }
 
 func (c *Client) makeTopicManagementRequest(ctx context.Context, req *iidRequest) (*TopicManagementResponse, error) {

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -37,6 +37,8 @@ const (
 	iidSubscribe      = "iid/v1:batchAdd"
 	iidUnsubscribe    = "iid/v1:batchRemove"
 
+	firebaseClientHeader = "X-Firebase-Client"
+
 	internalError                  = "internal-error"
 	invalidAPNSCredentials         = "invalid-apns-credentials"
 	invalidArgument                = "invalid-argument"
@@ -812,7 +814,7 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 		Body:   internal.NewJSONEntity(req),
 		Opts: []internal.HTTPOption{
 			internal.WithHeader("X-GOOG-API-FORMAT-VERSION", "2"),
-			internal.WithHeader("X-FIREBASE-CLIENT", c.version),
+			internal.WithHeader(firebaseClientHeader, c.version),
 		},
 	}
 

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -32,6 +32,7 @@ import (
 
 const (
 	messagingEndpoint = "https://fcm.googleapis.com/v1"
+	batchEndpoint     = "https://fcm.googleapis.com/batch"
 	iidEndpoint       = "https://iid.googleapis.com"
 	iidSubscribe      = "iid/v1:batchAdd"
 	iidUnsubscribe    = "iid/v1:batchRemove"
@@ -122,11 +123,12 @@ var (
 
 // Client is the interface for the Firebase Cloud Messaging (FCM) service.
 type Client struct {
-	fcmEndpoint string // to enable testing against arbitrary endpoints
-	iidEndpoint string // to enable testing against arbitrary endpoints
-	client      *internal.HTTPClient
-	project     string
-	version     string
+	fcmEndpoint   string // to enable testing against arbitrary endpoints
+	batchEndpoint string // to enable testing against arbitrary endpoints
+	iidEndpoint   string // to enable testing against arbitrary endpoints
+	client        *internal.HTTPClient
+	project       string
+	version       string
 }
 
 // Message to be sent via Firebase Cloud Messaging.
@@ -658,11 +660,12 @@ func NewClient(ctx context.Context, c *internal.MessagingConfig) (*Client, error
 	}
 
 	return &Client{
-		fcmEndpoint: messagingEndpoint,
-		iidEndpoint: iidEndpoint,
-		client:      hc,
-		project:     c.ProjectID,
-		version:     "fire-admin-go/" + c.Version,
+		fcmEndpoint:   messagingEndpoint,
+		batchEndpoint: batchEndpoint,
+		iidEndpoint:   iidEndpoint,
+		client:        hc,
+		project:       c.ProjectID,
+		version:       "fire-admin-go/" + c.Version,
 	}, nil
 }
 

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -37,7 +37,9 @@ const (
 	iidSubscribe      = "iid/v1:batchAdd"
 	iidUnsubscribe    = "iid/v1:batchRemove"
 
-	firebaseClientHeader = "X-Firebase-Client"
+	firebaseClientHeader   = "X-Firebase-Client"
+	apiFormatVersionHeader = "X-GOOG-API-FORMAT-VERSION"
+	apiFormatVersion       = "2"
 
 	internalError                  = "internal-error"
 	invalidAPNSCredentials         = "invalid-apns-credentials"
@@ -813,7 +815,7 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 		URL:    fmt.Sprintf("%s/projects/%s/messages:send", c.fcmEndpoint, c.project),
 		Body:   internal.NewJSONEntity(req),
 		Opts: []internal.HTTPOption{
-			internal.WithHeader("X-GOOG-API-FORMAT-VERSION", "2"),
+			internal.WithHeader(apiFormatVersionHeader, apiFormatVersion),
 			internal.WithHeader(firebaseClientHeader, c.version),
 		},
 	}

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -824,10 +824,10 @@ func (c *Client) makeSendRequest(ctx context.Context, req *fcmRequest) (string, 
 		return result.Name, err
 	}
 
-	return "", c.handleFCMError(resp)
+	return "", handleFCMError(resp)
 }
 
-func (c *Client) handleFCMError(resp *internal.Response) error {
+func handleFCMError(resp *internal.Response) error {
 	var fe fcmError
 	json.Unmarshal(resp.Body, &fe) // ignore any json parse errors at this level
 	var serverCode string

--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -107,8 +107,8 @@ type multipartEntity struct {
 func (c *Client) newBatchRequest(messages []*Message, dryRun bool) (*internal.Request, error) {
 	url := fmt.Sprintf("%s/projects/%s/messages:send", c.fcmEndpoint, c.project)
 	headers := map[string]string{
-		"X-GOOG-API-FORMAT-VERSION": "2",
-		firebaseClientHeader:        c.version,
+		apiFormatVersionHeader: apiFormatVersion,
+		firebaseClientHeader:   c.version,
 	}
 
 	var parts []*part

--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -1,0 +1,209 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+
+	"firebase.google.com/go/internal"
+)
+
+// SendResponse represents the status of an individual message that was sent as part of a batch request.
+type SendResponse struct {
+	Success   bool
+	MessageID string
+	Error     error
+}
+
+// BatchResponse represents the response from the `SendAll()` and `SendMulticast()` APIs.
+type BatchResponse struct {
+	SuccessCount int
+	FailureCount int
+	Responses    []*SendResponse
+}
+
+// SendAll sends all the messages in the given array via Firebase Cloud Messaging.
+//
+// Employs batching to send the entire list as a single RPC call. Compared to the `Send()` function,
+// this is a significantly more efficient way to send multiple messages. The responses
+// list obtained from the return value corresponds to the order of input messages. An error from
+// this function indicates a total failure -- i.e. none of the messages in the list could be sent.
+// Partial failures are indicated by a `BatchResponse` return value.
+func (c *Client) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
+	if len(messages) == 0 {
+		return nil, errors.New("messages must not be nil or empty")
+	}
+	if len(messages) > 100 {
+		return nil, errors.New("messages must not contain more than 100 elements")
+	}
+
+	url := fmt.Sprintf("%s/projects/%s/messages:send", c.fcmEndpoint, c.project)
+	headers := map[string]string{
+		"X-GOOG-API-FORMAT-VERSION": "2",
+		"X-FIREBASE-CLIENT":         c.version,
+	}
+
+	var reqs []*subRequest
+	for idx, m := range messages {
+		if err := validateMessage(m); err != nil {
+			return nil, fmt.Errorf("error validating message at index %d: %v", idx, err)
+		}
+
+		r := &subRequest{
+			url: url,
+			body: &fcmRequest{
+				Message: m,
+			},
+			headers: headers,
+		}
+		reqs = append(reqs, r)
+	}
+
+	request := &internal.Request{
+		Method: http.MethodPost,
+		URL:    "https://fcm.googleapis.com/batch",
+		Body:   &multipartEntity{reqs},
+		Opts: []internal.HTTPOption{
+			internal.WithHeader("X-FIREBASE-CLIENT", c.version),
+		},
+	}
+
+	resp, err := c.client.Do(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Status != http.StatusOK {
+		return nil, c.handleFCMError(resp)
+	}
+
+	_, params, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	mr := multipart.NewReader(bytes.NewBuffer(resp.Body), params["boundary"])
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+
+		b, err := ioutil.ReadAll(part)
+		if err != nil {
+			return nil, err
+		}
+		subResp, err := http.ReadResponse(bufio.NewReader(bytes.NewBuffer(b)), nil)
+		if err != nil {
+			return nil, err
+		}
+
+		sb, _ := ioutil.ReadAll(subResp.Body)
+		if subResp.StatusCode == http.StatusOK {
+			var result fcmResponse
+			json.Unmarshal(sb, &result)
+			sr := &SendResponse{
+				Success:   true,
+				MessageID: result.Name,
+			}
+			log.Println("SUCCESS", sr)
+		} else {
+
+			sr := &SendResponse{
+				Success: false,
+				Error: c.handleFCMError(&internal.Response{
+					Status: subResp.StatusCode,
+					Header: subResp.Header,
+					Body:   sb,
+				}),
+			}
+			log.Println(sr)
+		}
+
+	}
+	return nil, nil
+}
+
+type multipartEntity struct {
+	reqs []*subRequest
+}
+
+func (e *multipartEntity) Bytes() ([]byte, error) {
+	return multipartPayload(e.reqs)
+}
+
+func (e *multipartEntity) Mime() string {
+	return "multipart/mixed; boundary=__END_OF_PART__"
+}
+
+type subRequest struct {
+	url     string
+	body    interface{}
+	headers map[string]string
+}
+
+func (req *subRequest) serialize() ([]byte, error) {
+	b, err := json.Marshal(req.body)
+	if err != nil {
+		return nil, err
+	}
+
+	payload := fmt.Sprintf("POST %s HTTP/1.1\r\n", req.url)
+	payload += fmt.Sprintf("Content-Length: %d\r\n", len(b))
+	payload += "Content-Type: application/json; charset=UTF-8\r\n"
+	for key, value := range req.headers {
+		payload += fmt.Sprintf("%s: %s\r\n", key, value)
+	}
+	payload += "\r\n"
+	payload += string(b)
+	return []byte(payload), nil
+}
+
+func multipartPayload(requests []*subRequest) ([]byte, error) {
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	writer.SetBoundary("__END_OF_PART__")
+	for idx, req := range requests {
+		body, err := req.serialize()
+		if err != nil {
+			return nil, err
+		}
+
+		header := make(textproto.MIMEHeader)
+		header.Add("Content-Length", fmt.Sprintf("%d", len(body)))
+		header.Add("Content-Type", "application/http")
+		header.Add("Content-Id", fmt.Sprintf("%d", idx+1))
+		header.Add("Content-Transfer-Encoding", "binary")
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := part.Write(body); err != nil {
+			return nil, err
+		}
+	}
+	writer.Close()
+	return body.Bytes(), nil
+}

--- a/messaging/messaging_batch_test.go
+++ b/messaging/messaging_batch_test.go
@@ -1,0 +1,94 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import "testing"
+
+func TestMultipartSerializationSingle(t *testing.T) {
+	reqs := []*subRequest{
+		&subRequest{
+			url: "http://example.com",
+			body: map[string]interface{}{"key": "value"},
+		},
+	}
+
+	b, err := multipartPayload(reqs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "--__END_OF_PART__\r\n" +
+		"Content-Id: 1\r\n" +
+		"Content-Length: 118\r\n" +
+		"Content-Transfer-Encoding: binary\r\n" +
+		"Content-Type: application/http\r\n" +
+		"\r\n" +
+		"POST http://example.com HTTP/1.1\r\n" +
+		"Content-Length: 15\r\n" +
+		"Content-Type: application/json; charset=UTF-8\r\n" +
+		"\r\n" +
+		"{\"key\":\"value\"}\r\n" +
+		"--__END_OF_PART__--\r\n"
+	if string(b) != want {
+		t.Errorf("multipartPayload() = %q; want = %q", string(b), want)
+	}
+}
+
+func TestMultipartSerializationArray(t *testing.T) {
+	reqs := []*subRequest{
+		&subRequest{
+			url: "http://example1.com",
+			body: map[string]interface{}{"key1": "value"},
+		},
+		&subRequest{
+			url: "http://example2.com",
+			body: map[string]interface{}{"key2": "value"},
+			headers: map[string]string{"Custom-Header": "custom-value"},
+		},
+	}
+
+	b, err := multipartPayload(reqs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "--__END_OF_PART__\r\n" +
+		"Content-Id: 1\r\n" +
+		"Content-Length: 120\r\n" +
+		"Content-Transfer-Encoding: binary\r\n" +
+		"Content-Type: application/http\r\n" +
+		"\r\n" +
+		"POST http://example1.com HTTP/1.1\r\n" +
+		"Content-Length: 16\r\n" +
+		"Content-Type: application/json; charset=UTF-8\r\n" +
+		"\r\n" +
+		"{\"key1\":\"value\"}\r\n" +
+		"--__END_OF_PART__\r\n" +
+		"Content-Id: 2\r\n" +
+		"Content-Length: 149\r\n" +
+		"Content-Transfer-Encoding: binary\r\n" +
+		"Content-Type: application/http\r\n" +
+		"\r\n" +
+		"POST http://example2.com HTTP/1.1\r\n" +
+		"Content-Length: 16\r\n" +
+		"Content-Type: application/json; charset=UTF-8\r\n" +
+		"Custom-Header: custom-value\r\n" +
+		"\r\n" +
+		"{\"key2\":\"value\"}\r\n" +
+		"--__END_OF_PART__--\r\n"
+	if string(b) != want {
+		t.Errorf("multipartPayload() = %q; want = %q", string(b), want)
+	}
+}

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -965,70 +965,7 @@ func TestSendError(t *testing.T) {
 	client.fcmEndpoint = ts.URL
 	client.client.RetryConfig = nil
 
-	cases := []struct {
-		resp, want string
-		check      func(error) bool
-	}{
-		{
-			resp:  "{}",
-			want:  "http error status: 500; reason: server responded with an unknown error; response: {}",
-			check: IsUnknown,
-		},
-		{
-			resp:  "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
-			want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument; details: test error",
-			check: IsInvalidArgument,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"NOT_FOUND\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
-				"details: test error",
-			check: IsRegistrationTokenNotRegistered,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"QUOTA_EXCEEDED\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: messaging service quota exceeded; code: message-rate-exceeded; " +
-				"details: test error",
-			check: IsMessageRateExceeded,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"UNAVAILABLE\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: backend servers are temporarily unavailable; code: server-unavailable; " +
-				"details: test error",
-			check: IsServerUnavailable,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"INTERNAL\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: backend servers encountered an unknown internl error; code: internal-error; " +
-				"details: test error",
-			check: IsInternal,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"APNS_AUTH_ERROR\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: apns certificate or auth key was invalid; code: invalid-apns-credentials; " +
-				"details: test error",
-			check: IsInvalidAPNSCredentials,
-		},
-		{
-			resp: "{\"error\": {\"status\": \"SENDER_ID_MISMATCH\", \"message\": \"test error\"}}",
-			want: "http error status: 500; reason: sender id does not match regisration token; code: mismatched-credential; " +
-				"details: test error",
-			check: IsMismatchedCredential,
-		},
-		{
-			resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
-				`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "UNREGISTERED"}]}}`,
-			want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
-				"details: test error",
-			check: IsRegistrationTokenNotRegistered,
-		},
-		{
-			resp:  "not json",
-			want:  "http error status: 500; reason: server responded with an unknown error; response: not json",
-			check: IsUnknown,
-		},
-	}
-	for _, tc := range cases {
+	for _, tc := range httpErrors {
 		resp = tc.resp
 		name, err := client.Send(ctx, &Message{Topic: "topic"})
 		if err == nil || err.Error() != tc.want || !tc.check(err) {
@@ -1276,4 +1213,68 @@ func checkTopicMgtResponse(t *testing.T, resp *TopicManagementResponse) {
 	if e.Reason != "unknown-error" {
 		t.Errorf("ErrorInfo.Reason = %s; want = %s", e.Reason, "unknown-error")
 	}
+}
+
+var httpErrors = []struct {
+	resp, want string
+	check      func(error) bool
+}{
+	{
+		resp:  "{}",
+		want:  "http error status: 500; reason: server responded with an unknown error; response: {}",
+		check: IsUnknown,
+	},
+	{
+		resp:  "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
+		want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument; details: test error",
+		check: IsInvalidArgument,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"NOT_FOUND\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
+			"details: test error",
+		check: IsRegistrationTokenNotRegistered,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"QUOTA_EXCEEDED\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: messaging service quota exceeded; code: message-rate-exceeded; " +
+			"details: test error",
+		check: IsMessageRateExceeded,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"UNAVAILABLE\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: backend servers are temporarily unavailable; code: server-unavailable; " +
+			"details: test error",
+		check: IsServerUnavailable,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"INTERNAL\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: backend servers encountered an unknown internl error; code: internal-error; " +
+			"details: test error",
+		check: IsInternal,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"APNS_AUTH_ERROR\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: apns certificate or auth key was invalid; code: invalid-apns-credentials; " +
+			"details: test error",
+		check: IsInvalidAPNSCredentials,
+	},
+	{
+		resp: "{\"error\": {\"status\": \"SENDER_ID_MISMATCH\", \"message\": \"test error\"}}",
+		want: "http error status: 500; reason: sender id does not match regisration token; code: mismatched-credential; " +
+			"details: test error",
+		check: IsMismatchedCredential,
+	},
+	{
+		resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "UNREGISTERED"}]}}`,
+		want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
+			"details: test error",
+		check: IsRegistrationTokenNotRegistered,
+	},
+	{
+		resp:  "not json",
+		want:  "http error status: 500; reason: server responded with an unknown error; response: not json",
+		check: IsUnknown,
+	},
 }


### PR DESCRIPTION
Implemented the `SendAll()` API for sending up to 100 messages in a single RPC call. Also introducing the `SendResponse` and `BatchResponse` types.

go/fcm-multicast

Related to #213