### PR TITLE
messaging: add image field to Notification 

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -189,6 +189,7 @@ func (m *Message) UnmarshalJSON(b []byte) error {
 type Notification struct {
 	Title string `json:"title,omitempty"`
 	Body  string `json:"body,omitempty"`
+	Image string `json:"image,omitempty"`
 }
 
 // AndroidConfig contains messaging options specific to the Android platform.

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -116,6 +116,25 @@ var validMessages = []struct {
 		},
 	},
 	{
+		name: "NotificationImageMessage",
+		req: &Message{
+			Notification: &Notification{
+				Title: "t",
+				Body:  "b",
+				Image: "https://example.com/image.png",
+			},
+			Topic: "test-topic",
+		},
+		want: map[string]interface{}{
+			"notification": map[string]interface{}{
+				"title": "t",
+				"body":  "b",
+				"image": "https://example.com/image.png",
+			},
+			"topic": "test-topic",
+		},
+	},
+	{
 		name: "AndroidDataMessage",
 		req: &Message{
 			Android: &AndroidConfig{


### PR DESCRIPTION
Firebase has added a new field `Image` in their `Notification` spec and it seems to be the new way to pass images to notifications https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages?authuser=0#notification

Unfortunately, `Notification` struct has not included this change yet and the old way of sending images seems to not work anymore.

 I've added the new field to Notification struct. unit tests are passing, and this change includes the image into the push notification :).

Thanks!