### PR TITLE
Migrated the FCM impl to the new HTTPClient API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 testdata/integration_*
 .vscode/*
+*~
+

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -56,10 +56,6 @@ type CreateErrFn func(r *Response) error
 // NewHTTPClient creates a new HTTPClient using the provided client options and the default
 // RetryConfig.
 //
-// The default RetryConfig retries requests on all low-level network errors as well as on HTTP
-// InternalServerError (500) and ServiceUnavailable (503) errors. Repeatedly failing requests are
-// retried up to 4 times with exponential backoff. Retry delay is never longer than 2 minutes.
-//
 // NewHTTPClient returns the created HTTPClient along with the target endpoint URL. The endpoint
 // is obtained from the client options passed into the function.
 func NewHTTPClient(ctx context.Context, opts ...option.ClientOption) (*HTTPClient, string, error) {
@@ -68,8 +64,18 @@ func NewHTTPClient(ctx context.Context, opts ...option.ClientOption) (*HTTPClien
 		return nil, "", err
 	}
 
+	return WithDefaultRetryConfig(hc), endpoint, nil
+}
+
+// WithDefaultRetryConfig creates a new HTTPClient using the provided client and the default
+// RetryConfig.
+//
+// The default RetryConfig retries requests on all low-level network errors as well as on HTTP
+// InternalServerError (500) and ServiceUnavailable (503) errors. Repeatedly failing requests are
+// retried up to 4 times with exponential backoff. Retry delay is never longer than 2 minutes.
+func WithDefaultRetryConfig(hc *http.Client) *HTTPClient {
 	twoMinutes := time.Duration(2) * time.Minute
-	client := &HTTPClient{
+	return &HTTPClient{
 		Client: hc,
 		RetryConfig: &RetryConfig{
 			MaxRetries: 4,
@@ -81,7 +87,6 @@ func NewHTTPClient(ctx context.Context, opts ...option.ClientOption) (*HTTPClien
 			MaxDelay:         &twoMinutes,
 		},
 	}
-	return client, endpoint, nil
 }
 
 // Request contains all the parameters required to construct an outgoing HTTP request.

--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -95,7 +95,7 @@ type BatchResponse struct {
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAll indicates a total failure -- i.e. none of the messages in the array could be sent.
 // Partial failures are indicated by a `BatchResponse` return value.
-func (c *Client) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
+func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendBatch(ctx, messages, false)
 }
 
@@ -111,7 +111,7 @@ func (c *Client) SendAll(ctx context.Context, messages []*Message) (*BatchRespon
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAllDryRun indicates a total failure -- i.e. none of the messages in the array could be sent
 // for validation. Partial failures are indicated by a `BatchResponse` return value.
-func (c *Client) SendAllDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
+func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendBatch(ctx, messages, true)
 }
 
@@ -122,7 +122,7 @@ func (c *Client) SendAllDryRun(ctx context.Context, messages []*Message) (*Batch
 // responses list obtained from the return value corresponds to the order of the input tokens. An
 // error from SendMulticast indicates a total failure -- i.e. the message could not be sent to any
 // of the recipients. Partial failures are indicated by a `BatchResponse` return value.
-func (c *Client) SendMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
+func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (c *Client) SendMulticast(ctx context.Context, message *MulticastMessage) (
 // the return value corresponds to the order of the input tokens. An error from SendMulticastDryRun
 // indicates a total failure -- i.e. none of the messages were sent to FCM for validation. Partial
 // failures are indicated by a `BatchResponse` return value.
-func (c *Client) SendMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
+func (c *fcmClient) SendMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func toMessages(message *MulticastMessage) ([]*Message, error) {
 	return message.toMessages()
 }
 
-func (c *Client) sendBatch(
+func (c *fcmClient) sendBatch(
 	ctx context.Context, messages []*Message, dryRun bool) (*BatchResponse, error) {
 
 	if len(messages) == 0 {
@@ -175,7 +175,7 @@ func (c *Client) sendBatch(
 		return nil, err
 	}
 
-	resp, err := c.client.Do(ctx, request)
+	resp, err := c.httpClient.Do(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ type multipartEntity struct {
 	parts []*part
 }
 
-func (c *Client) newBatchRequest(messages []*Message, dryRun bool) (*internal.Request, error) {
+func (c *fcmClient) newBatchRequest(messages []*Message, dryRun bool) (*internal.Request, error) {
 	url := fmt.Sprintf("%s/projects/%s/messages:send", c.fcmEndpoint, c.project)
 	headers := map[string]string{
 		apiFormatVersionHeader: apiFormatVersion,

--- a/messaging/messaging_batch_test.go
+++ b/messaging/messaging_batch_test.go
@@ -335,7 +335,7 @@ func TestSendAllTotalFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.batchEndpoint = ts.URL
-	client.client.RetryConfig = nil
+	client.fcmClient.httpClient.RetryConfig = nil
 
 	for _, tc := range httpErrors {
 		resp = tc.resp

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -832,41 +831,6 @@ var invalidMessages = []struct {
 	},
 }
 
-var invalidTopicMgtArgs = []struct {
-	name   string
-	tokens []string
-	topic  string
-	want   string
-}{
-	{
-		name: "NoTokensAndTopic",
-		want: "no tokens specified",
-	},
-	{
-		name:   "NoTopic",
-		tokens: []string{"token1"},
-		want:   "topic name not specified",
-	},
-	{
-		name:   "InvalidTopicName",
-		tokens: []string{"token1"},
-		topic:  "foo*bar",
-		want:   "invalid topic name: \"foo*bar\"",
-	},
-	{
-		name:   "TooManyTokens",
-		tokens: strings.Split("a"+strings.Repeat(",a", 1000), ","),
-		topic:  "topic",
-		want:   "tokens list must not contain more than 1000 items",
-	},
-	{
-		name:   "EmptyToken",
-		tokens: []string{"foo", ""},
-		topic:  "topic",
-		want:   "tokens list must not contain empty strings",
-	},
-}
-
 func TestNoProjectID(t *testing.T) {
 	client, err := NewClient(context.Background(), &internal.MessagingConfig{})
 	if client != nil || err == nil {
@@ -1021,7 +985,7 @@ func TestSendError(t *testing.T) {
 		t.Fatal(err)
 	}
 	client.fcmEndpoint = ts.URL
-	client.client.RetryConfig = nil
+	client.fcmClient.httpClient.RetryConfig = nil
 
 	for _, tc := range httpErrors {
 		resp = tc.resp
@@ -1045,150 +1009,6 @@ func TestInvalidMessage(t *testing.T) {
 				t.Errorf("Send(%s) = (%q, %v); want = (%q, %q)", tc.name, name, err, "", tc.want)
 			}
 		})
-	}
-}
-
-func TestSubscribe(t *testing.T) {
-	var tr *http.Request
-	var b []byte
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tr = r
-		b, _ = ioutil.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("{\"results\": [{}, {\"error\": \"error_reason\"}]}"))
-	}))
-	defer ts.Close()
-
-	ctx := context.Background()
-	client, err := NewClient(ctx, testMessagingConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.iidEndpoint = ts.URL
-
-	resp, err := client.SubscribeToTopic(ctx, []string{"id1", "id2"}, "test-topic")
-	if err != nil {
-		t.Fatal(err)
-	}
-	checkIIDRequest(t, b, tr, iidSubscribe)
-	checkTopicMgtResponse(t, resp)
-}
-
-func TestInvalidSubscribe(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient(ctx, testMessagingConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, tc := range invalidTopicMgtArgs {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.SubscribeToTopic(ctx, tc.tokens, tc.topic)
-			if err == nil || err.Error() != tc.want {
-				t.Errorf(
-					"SubscribeToTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
-			}
-		})
-	}
-}
-
-func TestUnsubscribe(t *testing.T) {
-	var tr *http.Request
-	var b []byte
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		tr = r
-		b, _ = ioutil.ReadAll(r.Body)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("{\"results\": [{}, {\"error\": \"error_reason\"}]}"))
-	}))
-	defer ts.Close()
-
-	ctx := context.Background()
-	client, err := NewClient(ctx, testMessagingConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.iidEndpoint = ts.URL
-
-	resp, err := client.UnsubscribeFromTopic(ctx, []string{"id1", "id2"}, "test-topic")
-	if err != nil {
-		t.Fatal(err)
-	}
-	checkIIDRequest(t, b, tr, iidUnsubscribe)
-	checkTopicMgtResponse(t, resp)
-}
-
-func TestInvalidUnsubscribe(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClient(ctx, testMessagingConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, tc := range invalidTopicMgtArgs {
-		t.Run(tc.name, func(t *testing.T) {
-			resp, err := client.UnsubscribeFromTopic(ctx, tc.tokens, tc.topic)
-			if err == nil || err.Error() != tc.want {
-				t.Errorf(
-					"UnsubscribeFromTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
-			}
-		})
-	}
-}
-
-func TestTopicManagementError(t *testing.T) {
-	var resp string
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(resp))
-	}))
-	defer ts.Close()
-
-	ctx := context.Background()
-	client, err := NewClient(ctx, testMessagingConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
-	client.iidEndpoint = ts.URL
-	client.client.RetryConfig = nil
-
-	cases := []struct {
-		resp, want string
-		check      func(error) bool
-	}{
-		{
-			resp:  "{}",
-			want:  "http error status: 500; reason: client encountered an unknown error; response: {}",
-			check: IsUnknown,
-		},
-		{
-			resp:  "{\"error\": \"INVALID_ARGUMENT\"}",
-			want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument",
-			check: IsInvalidArgument,
-		},
-		{
-			resp:  "{\"error\": \"TOO_MANY_TOPICS\"}",
-			want:  "http error status: 500; reason: client exceeded the number of allowed topics; code: too-many-topics",
-			check: IsTooManyTopics,
-		},
-		{
-			resp:  "not json",
-			want:  "http error status: 500; reason: client encountered an unknown error; response: not json",
-			check: IsUnknown,
-		},
-	}
-	for _, tc := range cases {
-		resp = tc.resp
-		tmr, err := client.SubscribeToTopic(ctx, []string{"id1"}, "topic")
-		if err == nil || err.Error() != tc.want || !tc.check(err) {
-			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
-		}
-	}
-	for _, tc := range cases {
-		resp = tc.resp
-		tmr, err := client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
-		if err == nil || err.Error() != tc.want {
-			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
-		}
 	}
 }
 
@@ -1226,50 +1046,6 @@ func checkFCMRequest(t *testing.T, b []byte, tr *http.Request, want map[string]i
 	clientVersion := "fire-admin-go/" + testMessagingConfig.Version
 	if h := tr.Header.Get("X-FIREBASE-CLIENT"); h != clientVersion {
 		t.Errorf("X-FIREBASE-CLIENT = %q; want = %q", h, clientVersion)
-	}
-}
-
-func checkIIDRequest(t *testing.T, b []byte, tr *http.Request, op string) {
-	var parsed map[string]interface{}
-	if err := json.Unmarshal(b, &parsed); err != nil {
-		t.Fatal(err)
-	}
-	want := map[string]interface{}{
-		"to":                  "/topics/test-topic",
-		"registration_tokens": []interface{}{"id1", "id2"},
-	}
-	if !reflect.DeepEqual(parsed, want) {
-		t.Errorf("Body = %#v; want = %#v", parsed, want)
-	}
-
-	if tr.Method != http.MethodPost {
-		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
-	}
-	wantOp := "/" + op
-	if tr.URL.Path != wantOp {
-		t.Errorf("Path = %q; want = %q", tr.URL.Path, wantOp)
-	}
-	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
-		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
-	}
-}
-
-func checkTopicMgtResponse(t *testing.T, resp *TopicManagementResponse) {
-	if resp.SuccessCount != 1 {
-		t.Errorf("SuccessCount = %d; want  = %d", resp.SuccessCount, 1)
-	}
-	if resp.FailureCount != 1 {
-		t.Errorf("FailureCount = %d; want  = %d", resp.FailureCount, 1)
-	}
-	if len(resp.Errors) != 1 {
-		t.Fatalf("Errors = %d; want = %d", len(resp.Errors), 1)
-	}
-	e := resp.Errors[0]
-	if e.Index != 1 {
-		t.Errorf("ErrorInfo.Index = %d; want = %d", e.Index, 1)
-	}
-	if e.Reason != "unknown-error" {
-		t.Errorf("ErrorInfo.Reason = %s; want = %s", e.Reason, "unknown-error")
 	}
 }
 

--- a/messaging/topic_mgt.go
+++ b/messaging/topic_mgt.go
@@ -1,0 +1,190 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"firebase.google.com/go/internal"
+)
+
+const (
+	iidEndpoint    = "https://iid.googleapis.com/iid/v1"
+	iidSubscribe   = ":batchAdd"
+	iidUnsubscribe = ":batchRemove"
+)
+
+var iidErrorCodes = map[string]struct{ Code, Msg string }{
+	"INVALID_ARGUMENT": {
+		invalidArgument,
+		"request contains an invalid argument; code: " + invalidArgument,
+	},
+	"NOT_FOUND": {
+		registrationTokenNotRegistered,
+		"request contains an invalid argument; code: " + registrationTokenNotRegistered,
+	},
+	"INTERNAL": {
+		internalError,
+		"server encountered an internal error; code: " + internalError,
+	},
+	"TOO_MANY_TOPICS": {
+		tooManyTopics,
+		"client exceeded the number of allowed topics; code: " + tooManyTopics,
+	},
+}
+
+// TopicManagementResponse is the result produced by topic management operations.
+//
+// TopicManagementResponse provides an overview of how many input tokens were successfully handled,
+// and how many failed. In case of failures, the Errors list provides specific details concerning
+// each error.
+type TopicManagementResponse struct {
+	SuccessCount int
+	FailureCount int
+	Errors       []*ErrorInfo
+}
+
+func newTopicManagementResponse(resp *iidResponse) *TopicManagementResponse {
+	tmr := &TopicManagementResponse{}
+	for idx, res := range resp.Results {
+		if len(res) == 0 {
+			tmr.SuccessCount++
+		} else {
+			tmr.FailureCount++
+			code := res["error"].(string)
+			info, ok := iidErrorCodes[code]
+			var reason string
+			if ok {
+				reason = info.Msg
+			} else {
+				reason = unknownError
+			}
+			tmr.Errors = append(tmr.Errors, &ErrorInfo{
+				Index:  idx,
+				Reason: reason,
+			})
+		}
+	}
+	return tmr
+}
+
+type iidClient struct {
+	iidEndpoint string
+	httpClient  *internal.HTTPClient
+}
+
+func newIIDClient(hc *http.Client) *iidClient {
+	client := internal.WithDefaultRetryConfig(hc)
+	client.CreateErrFn = handleIIDError
+	client.SuccessFn = internal.HasSuccessStatus
+	client.Opts = []internal.HTTPOption{internal.WithHeader("access_token_auth", "true")}
+	return &iidClient{
+		iidEndpoint: iidEndpoint,
+		httpClient:  client,
+	}
+}
+
+// SubscribeToTopic subscribes a list of registration tokens to a topic.
+//
+// The tokens list must not be empty, and have at most 1000 tokens.
+func (c *iidClient) SubscribeToTopic(ctx context.Context, tokens []string, topic string) (*TopicManagementResponse, error) {
+	req := &iidRequest{
+		Topic:  topic,
+		Tokens: tokens,
+		op:     iidSubscribe,
+	}
+	return c.makeTopicManagementRequest(ctx, req)
+}
+
+// UnsubscribeFromTopic unsubscribes a list of registration tokens from a topic.
+//
+// The tokens list must not be empty, and have at most 1000 tokens.
+func (c *iidClient) UnsubscribeFromTopic(ctx context.Context, tokens []string, topic string) (*TopicManagementResponse, error) {
+	req := &iidRequest{
+		Topic:  topic,
+		Tokens: tokens,
+		op:     iidUnsubscribe,
+	}
+	return c.makeTopicManagementRequest(ctx, req)
+}
+
+type iidRequest struct {
+	Topic  string   `json:"to"`
+	Tokens []string `json:"registration_tokens"`
+	op     string
+}
+
+type iidResponse struct {
+	Results []map[string]interface{} `json:"results"`
+}
+
+type iidError struct {
+	Error string `json:"error"`
+}
+
+func (c *iidClient) makeTopicManagementRequest(ctx context.Context, req *iidRequest) (*TopicManagementResponse, error) {
+	if len(req.Tokens) == 0 {
+		return nil, fmt.Errorf("no tokens specified")
+	}
+	if len(req.Tokens) > 1000 {
+		return nil, fmt.Errorf("tokens list must not contain more than 1000 items")
+	}
+	for _, token := range req.Tokens {
+		if token == "" {
+			return nil, fmt.Errorf("tokens list must not contain empty strings")
+		}
+	}
+
+	if req.Topic == "" {
+		return nil, fmt.Errorf("topic name not specified")
+	}
+	if !topicNamePattern.MatchString(req.Topic) {
+		return nil, fmt.Errorf("invalid topic name: %q", req.Topic)
+	}
+
+	if !strings.HasPrefix(req.Topic, "/topics/") {
+		req.Topic = "/topics/" + req.Topic
+	}
+
+	request := &internal.Request{
+		Method: http.MethodPost,
+		URL:    fmt.Sprintf("%s/%s", c.iidEndpoint, req.op),
+		Body:   internal.NewJSONEntity(req),
+	}
+	var result iidResponse
+	if _, err := c.httpClient.DoAndUnmarshal(ctx, request, &result); err != nil {
+		return nil, err
+	}
+
+	return newTopicManagementResponse(&result), nil
+}
+
+func handleIIDError(resp *internal.Response) error {
+	var ie iidError
+	json.Unmarshal(resp.Body, &ie) // ignore any json parse errors at this level
+	var clientCode, msg string
+	info, ok := iidErrorCodes[ie.Error]
+	if ok {
+		clientCode, msg = info.Code, info.Msg
+	} else {
+		clientCode = unknownError
+		msg = fmt.Sprintf("client encountered an unknown error; response: %s", string(resp.Body))
+	}
+	return internal.Errorf(clientCode, "http error status: %d; reason: %s", resp.Status, msg)
+}

--- a/messaging/topic_mgt_test.go
+++ b/messaging/topic_mgt_test.go
@@ -1,0 +1,249 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package messaging
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSubscribe(t *testing.T) {
+	var tr *http.Request
+	var b []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		b, _ = ioutil.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"results\": [{}, {\"error\": \"error_reason\"}]}"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.iidEndpoint = ts.URL
+
+	resp, err := client.SubscribeToTopic(ctx, []string{"id1", "id2"}, "test-topic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkIIDRequest(t, b, tr, iidSubscribe)
+	checkTopicMgtResponse(t, resp)
+}
+
+func TestInvalidSubscribe(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range invalidTopicMgtArgs {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := client.SubscribeToTopic(ctx, tc.tokens, tc.topic)
+			if err == nil || err.Error() != tc.want {
+				t.Errorf(
+					"SubscribeToTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnsubscribe(t *testing.T) {
+	var tr *http.Request
+	var b []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tr = r
+		b, _ = ioutil.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"results\": [{}, {\"error\": \"error_reason\"}]}"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.iidEndpoint = ts.URL
+
+	resp, err := client.UnsubscribeFromTopic(ctx, []string{"id1", "id2"}, "test-topic")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkIIDRequest(t, b, tr, iidUnsubscribe)
+	checkTopicMgtResponse(t, resp)
+}
+
+func TestInvalidUnsubscribe(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range invalidTopicMgtArgs {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := client.UnsubscribeFromTopic(ctx, tc.tokens, tc.topic)
+			if err == nil || err.Error() != tc.want {
+				t.Errorf(
+					"UnsubscribeFromTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, resp, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestTopicManagementError(t *testing.T) {
+	var resp string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	client, err := NewClient(ctx, testMessagingConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.iidEndpoint = ts.URL
+	client.iidClient.httpClient.RetryConfig = nil
+
+	cases := []struct {
+		resp, want string
+		check      func(error) bool
+	}{
+		{
+			resp:  "{}",
+			want:  "http error status: 500; reason: client encountered an unknown error; response: {}",
+			check: IsUnknown,
+		},
+		{
+			resp:  "{\"error\": \"INVALID_ARGUMENT\"}",
+			want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument",
+			check: IsInvalidArgument,
+		},
+		{
+			resp:  "{\"error\": \"TOO_MANY_TOPICS\"}",
+			want:  "http error status: 500; reason: client exceeded the number of allowed topics; code: too-many-topics",
+			check: IsTooManyTopics,
+		},
+		{
+			resp:  "not json",
+			want:  "http error status: 500; reason: client encountered an unknown error; response: not json",
+			check: IsUnknown,
+		},
+	}
+	for _, tc := range cases {
+		resp = tc.resp
+		tmr, err := client.SubscribeToTopic(ctx, []string{"id1"}, "topic")
+		if err == nil || err.Error() != tc.want || !tc.check(err) {
+			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
+		}
+	}
+	for _, tc := range cases {
+		resp = tc.resp
+		tmr, err := client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
+		if err == nil || err.Error() != tc.want {
+			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
+		}
+	}
+}
+
+func checkIIDRequest(t *testing.T, b []byte, tr *http.Request, op string) {
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(b, &parsed); err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]interface{}{
+		"to":                  "/topics/test-topic",
+		"registration_tokens": []interface{}{"id1", "id2"},
+	}
+	if !reflect.DeepEqual(parsed, want) {
+		t.Errorf("Body = %#v; want = %#v", parsed, want)
+	}
+
+	if tr.Method != http.MethodPost {
+		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
+	}
+	wantOp := "/" + op
+	if tr.URL.Path != wantOp {
+		t.Errorf("Path = %q; want = %q", tr.URL.Path, wantOp)
+	}
+	if h := tr.Header.Get("Authorization"); h != "Bearer test-token" {
+		t.Errorf("Authorization = %q; want = %q", h, "Bearer test-token")
+	}
+}
+
+func checkTopicMgtResponse(t *testing.T, resp *TopicManagementResponse) {
+	if resp.SuccessCount != 1 {
+		t.Errorf("SuccessCount = %d; want  = %d", resp.SuccessCount, 1)
+	}
+	if resp.FailureCount != 1 {
+		t.Errorf("FailureCount = %d; want  = %d", resp.FailureCount, 1)
+	}
+	if len(resp.Errors) != 1 {
+		t.Fatalf("Errors = %d; want = %d", len(resp.Errors), 1)
+	}
+	e := resp.Errors[0]
+	if e.Index != 1 {
+		t.Errorf("ErrorInfo.Index = %d; want = %d", e.Index, 1)
+	}
+	if e.Reason != "unknown-error" {
+		t.Errorf("ErrorInfo.Reason = %s; want = %s", e.Reason, "unknown-error")
+	}
+}
+
+var invalidTopicMgtArgs = []struct {
+	name   string
+	tokens []string
+	topic  string
+	want   string
+}{
+	{
+		name: "NoTokensAndTopic",
+		want: "no tokens specified",
+	},
+	{
+		name:   "NoTopic",
+		tokens: []string{"token1"},
+		want:   "topic name not specified",
+	},
+	{
+		name:   "InvalidTopicName",
+		tokens: []string{"token1"},
+		topic:  "foo*bar",
+		want:   "invalid topic name: \"foo*bar\"",
+	},
+	{
+		name:   "TooManyTokens",
+		tokens: strings.Split("a"+strings.Repeat(",a", 1000), ","),
+		topic:  "topic",
+		want:   "tokens list must not contain more than 1000 items",
+	},
+	{
+		name:   "EmptyToken",
+		tokens: []string{"foo", ""},
+		topic:  "topic",
+		want:   "tokens list must not contain empty strings",
+	},
+}


### PR DESCRIPTION
* Using the new `internal.DoAndUnmarshal()` API
* Splitting FCM API call logic into two new types -- `fcmClient` and `iidClient`
* Moved `iidClient` into a new file