### PR TITLE
Remove (base64) 'REDACTED' passwords from user records.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,13 @@ following credentials from the project:
    your Go workspace as
    `src/firebase.google.com/go/testdata/integration_apikey.txt`.
 
+You'll also need to grant your service account the 'Firebase Authentication Admin' role. This is
+required to ensure that exported user records contain the password hashes of the user accounts:
+1. Go to [Google Cloud Platform Console / IAM & admin](https://console.cloud.google.com/iam-admin).
+2. Find your service account in the list, and click the 'pencil' icon to edit it's permissions.
+3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
+4. Click 'SAVE'.
+
 Now you can invoke the test suite as follows:
 
 ```bash

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -16,6 +16,7 @@ package auth
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,6 +34,9 @@ const (
 	maxLenPayloadCC   = 1000
 	defaultProviderID = "firebase"
 )
+
+// 'REDACTED', encoded as a base64 string.
+var b64Redacted = base64.StdEncoding.EncodeToString([]byte("REDACTED"))
 
 // Create a new interface
 type identitytoolkitCall interface {
@@ -623,6 +627,14 @@ func (r *userQueryResponse) makeExportedUserRecord() (*ExportedUserRecord, error
 		}
 	}
 
+	// If the password hash is redacted (probably due to missing permissions)
+	// then clear it out, similar to how the salt is returned. (Otherwise, it
+	// *looks* like a b64-encoded hash is present, which is confusing.)
+	hash := r.PasswordHash
+	if hash == b64Redacted {
+		hash = ""
+	}
+
 	return &ExportedUserRecord{
 		UserRecord: &UserRecord{
 			UserInfo: &UserInfo{
@@ -643,7 +655,7 @@ func (r *userQueryResponse) makeExportedUserRecord() (*ExportedUserRecord, error
 				CreationTimestamp:  r.CreationTimestamp,
 			},
 		},
-		PasswordHash: r.PasswordHash,
+		PasswordHash: hash,
 		PasswordSalt: r.PasswordSalt,
 	}, nil
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -995,7 +995,7 @@ func TestInvalidDeleteUser(t *testing.T) {
 }
 
 func TestMakeExportedUser(t *testing.T) {
-	rur := &userQueryResponse{
+	queryResponse := &userQueryResponse{
 		UID:                "testuser",
 		Email:              "testuser@example.com",
 		PhoneNumber:        "+1234567890",
@@ -1028,7 +1028,7 @@ func TestMakeExportedUser(t *testing.T) {
 		PasswordHash: "passwordhash",
 		PasswordSalt: "salt",
 	}
-	exported, err := rur.makeExportedUserRecord()
+	exported, err := queryResponse.makeExportedUserRecord()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1042,6 +1042,21 @@ func TestMakeExportedUser(t *testing.T) {
 	}
 	if exported.PasswordSalt != want.PasswordSalt {
 		t.Errorf("PasswordSalt = %q; want = %q", exported.PasswordSalt, want.PasswordSalt)
+	}
+}
+
+func TestExportedUserRecordShouldClearRedacted(t *testing.T) {
+	queryResponse := &userQueryResponse{
+		UID:          "uid1",
+		PasswordHash: base64.StdEncoding.EncodeToString([]byte("REDACTED")),
+	}
+
+	exported, err := queryResponse.makeExportedUserRecord()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exported.PasswordHash != "" {
+		t.Errorf("PasswordHash = %q; want = ''", exported.PasswordHash)
 	}
 }
 

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -107,6 +107,9 @@ func TestDeleteNonExistingUser(t *testing.T) {
 }
 
 func TestListUsers(t *testing.T) {
+	errMsgTemplate := "Users() %s = empty; want = non-empty. A common cause would be " +
+		"forgetting to add the 'Firebase Authentication Admin' permission. See " +
+		"instructions in CONTRIBUTING.md"
 	newUsers := map[string]bool{}
 	user := newUserWithParams(t)
 	defer deleteUser(user.UID)
@@ -133,16 +136,10 @@ func TestListUsers(t *testing.T) {
 		if _, ok := newUsers[u.UID]; ok {
 			count++
 			if u.PasswordHash == "" {
-				t.Errorf(
-					"Users() PasswordHash = empty; want = non-empty. A common cause would be " +
-						"forgetting to add the 'Firebase Authentication Admin' permission. See " +
-						"instructions in CONTRIBUTING.md")
+				t.Errorf(errMsgTemplate, "PasswordHash")
 			}
 			if u.PasswordSalt == "" {
-				t.Errorf(
-					"Users() PasswordSalt = empty; want = non-empty. A common cause would be " +
-						"forgetting to add the 'Firebase Authentication Admin' permission. See " +
-						"instructions in CONTRIBUTING.md")
+				t.Errorf(errMsgTemplate, "PasswordSalt")
 			}
 		}
 	}

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -133,7 +133,16 @@ func TestListUsers(t *testing.T) {
 		if _, ok := newUsers[u.UID]; ok {
 			count++
 			if u.PasswordHash == "" {
-				t.Errorf("Users() PasswordHash = empty; want = non-empty")
+				t.Errorf(
+					"Users() PasswordHash = empty; want = non-empty. A common cause would be " +
+						"forgetting to add the 'Firebase Authentication Admin' permission. See " +
+						"instructions in CONTRIBUTING.md")
+			}
+			if u.PasswordSalt == "" {
+				t.Errorf(
+					"Users() PasswordSalt = empty; want = non-empty. A common cause would be " +
+						"forgetting to add the 'Firebase Authentication Admin' permission. See " +
+						"instructions in CONTRIBUTING.md")
 			}
 		}
 	}


### PR DESCRIPTION
These values look like passwords hashes, but aren't, leading to
potential confusion.

Additionally, added docs to CONTRIBUTING.md detailing how to add the
permission that causes password hashes to be properly returned as well
as adjusting the test failure message should the developer not add that
permission.

b/141189502