### PR TITLE
Implementing the SAML provider config management API

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -41,6 +41,7 @@ var reservedClaims = []string{
 // by Firebase backend services.
 type Client struct {
 	userManagementClient
+	pcc             *providerConfigClient // TODO: Embed this to add the methods to the public API
 	idTokenVerifier *tokenVerifier
 	cookieVerifier  *tokenVerifier
 	signer          cryptoSigner
@@ -99,6 +100,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 
 	return &Client{
 		userManagementClient: *userMgt,
+		pcc:                  newProviderConfigClient(userMgt.httpClient.Client, conf),
 		idTokenVerifier:      idTokenVerifier,
 		cookieVerifier:       cookieVerifier,
 		signer:               signer,

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -1,0 +1,140 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"firebase.google.com/go/internal"
+)
+
+const providerConfigEndpoint = "https://identitytoolkit.googleapis.com/v2beta1"
+
+// SAMLProviderConfig is the SAML auth provider configuration.
+// See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html.
+type SAMLProviderConfig struct {
+	ID                    string
+	DisplayName           string
+	Enabled               bool
+	IDPEntityID           string
+	SSOURL                string
+	RequestSigningEnabled bool
+	X509Certificates      []string
+	RPEntityID            string
+	CallbackURL           string
+}
+
+type providerConfigClient struct {
+	endpoint   string
+	projectID  string
+	httpClient *internal.HTTPClient
+}
+
+func newProviderConfigClient(hc *http.Client, conf *internal.AuthConfig) *providerConfigClient {
+	client := &internal.HTTPClient{
+		Client:      hc,
+		SuccessFn:   internal.HasSuccessStatus,
+		CreateErrFn: handleHTTPError,
+		Opts: []internal.HTTPOption{
+			internal.WithHeader("X-Client-Version", fmt.Sprintf("Go/Admin/%s", conf.Version)),
+		},
+	}
+	return &providerConfigClient{
+		endpoint:   providerConfigEndpoint,
+		projectID:  conf.ProjectID,
+		httpClient: client,
+	}
+}
+
+func (c *providerConfigClient) SAMLProviderConfig(ctx context.Context, id string) (*SAMLProviderConfig, error) {
+	if err := validateSAMLConfigID(id); err != nil {
+		return nil, err
+	}
+
+	req := &internal.Request{
+		Method: http.MethodGet,
+		URL:    fmt.Sprintf("/inboundSamlConfigs/%s", id),
+	}
+	var result samlProviderConfigDAO
+	if _, err := c.makeRequest(ctx, req, &result); err != nil {
+		return nil, err
+	}
+
+	return result.toSAMLProviderConfig(), nil
+}
+
+func (c *providerConfigClient) makeRequest(ctx context.Context, req *internal.Request, v interface{}) (*internal.Response, error) {
+	if c.projectID == "" {
+		return nil, errors.New("project id not available")
+	}
+
+	req.URL = fmt.Sprintf("%s/projects/%s%s", c.endpoint, c.projectID, req.URL)
+	return c.httpClient.DoAndUnmarshal(ctx, req, v)
+}
+
+type samlProviderConfigDAO struct {
+	Name      string `json:"name"`
+	IDPConfig struct {
+		IDPEntityID     string `json:"idpEntityId"`
+		SSOURL          string `json:"ssoUrl"`
+		IDPCertificates []struct {
+			X509Certificate string `json:"x509Certificate"`
+		} `json:"idpCertificates"`
+		SignRequest bool `json:"signRequest"`
+	} `json:"idpConfig"`
+	SPConfig struct {
+		SPEntityID  string `json:"spEntityId"`
+		CallbackURI string `json:"callbackUri"`
+	} `json:"spConfig"`
+	DisplayName string `json:"displayName"`
+	Enabled     bool   `json:"enabled"`
+}
+
+func (dao *samlProviderConfigDAO) toSAMLProviderConfig() *SAMLProviderConfig {
+	var certs []string
+	for _, cert := range dao.IDPConfig.IDPCertificates {
+		certs = append(certs, cert.X509Certificate)
+	}
+
+	return &SAMLProviderConfig{
+		ID:                    extractResourceID(dao.Name),
+		DisplayName:           dao.DisplayName,
+		Enabled:               dao.Enabled,
+		IDPEntityID:           dao.IDPConfig.IDPEntityID,
+		SSOURL:                dao.IDPConfig.SSOURL,
+		RequestSigningEnabled: dao.IDPConfig.SignRequest,
+		X509Certificates:      certs,
+		RPEntityID:            dao.SPConfig.SPEntityID,
+		CallbackURL:           dao.SPConfig.CallbackURI,
+	}
+}
+
+func validateSAMLConfigID(id string) error {
+	if !strings.HasPrefix(id, "saml.") {
+		return fmt.Errorf("invalid SAML provider id: %q", id)
+	}
+
+	return nil
+}
+
+func extractResourceID(name string) string {
+	// name format: "projects/project-id/resource/resource-id"
+	segments := strings.Split(name, "/")
+	return segments[len(segments)-1]
+}

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -62,6 +62,7 @@ func newProviderConfigClient(hc *http.Client, conf *internal.AuthConfig) *provid
 	}
 }
 
+// SAMLProviderConfig returns the SAMLProviderConfig with the given ID.
 func (c *providerConfigClient) SAMLProviderConfig(ctx context.Context, id string) (*SAMLProviderConfig, error) {
 	if err := validateSAMLConfigID(id); err != nil {
 		return nil, err
@@ -77,6 +78,21 @@ func (c *providerConfigClient) SAMLProviderConfig(ctx context.Context, id string
 	}
 
 	return result.toSAMLProviderConfig(), nil
+}
+
+// DeleteSAMLProviderConfig deletes the SAMLProviderConfig with the given ID.
+func (c *providerConfigClient) DeleteSAMLProviderConfig(ctx context.Context, id string) error {
+	if err := validateSAMLConfigID(id); err != nil {
+		return err
+	}
+
+	req := &internal.Request{
+		Method: http.MethodDelete,
+		URL:    fmt.Sprintf("/inboundSamlConfigs/%s", id),
+	}
+	var result samlProviderConfigDAO
+	_, err := c.makeRequest(ctx, req, &result)
+	return err
 }
 
 func (c *providerConfigClient) makeRequest(ctx context.Context, req *internal.Request, v interface{}) (*internal.Response, error) {

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -90,8 +90,7 @@ func (c *providerConfigClient) DeleteSAMLProviderConfig(ctx context.Context, id 
 		Method: http.MethodDelete,
 		URL:    fmt.Sprintf("/inboundSamlConfigs/%s", id),
 	}
-	var result samlProviderConfigDAO
-	_, err := c.makeRequest(ctx, req, &result)
+	_, err := c.makeRequest(ctx, req, nil)
 	return err
 }
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -40,6 +40,11 @@ const samlConfigResponse = `{
     "displayName": "samlProviderName",
     "enabled": true
 }`
+const notFoundResponse = `{
+	"error": {
+		"message": "CONFIGURATION_NOT_FOUND"
+	}
+}`
 
 var samlProviderConfig = &SAMLProviderConfig{
 	ID:                    "saml.provider",
@@ -51,6 +56,12 @@ var samlProviderConfig = &SAMLProviderConfig{
 	X509Certificates:      []string{"CERT1", "CERT2"},
 	RPEntityID:            "RP_ENTITY_ID",
 	CallbackURL:           "https://projectId.firebaseapp.com/__/auth/handler",
+}
+
+var invalidSAMLConfigIDs = []string{
+	"",
+	"invalid.id",
+	"oidc.config",
 }
 
 func TestSAMLProviderConfig(t *testing.T) {
@@ -80,18 +91,69 @@ func TestSAMLProviderConfig(t *testing.T) {
 
 func TestSAMLProviderConfigInvalidID(t *testing.T) {
 	client := &providerConfigClient{}
-	invalidIDs := []string{
-		"",
-		"invalid.id",
-		"oidc.config",
-	}
 	wantErr := "invalid SAML provider id: "
 
-	for _, id := range invalidIDs {
+	for _, id := range invalidSAMLConfigIDs {
 		saml, err := client.SAMLProviderConfig(context.Background(), id)
 		if saml != nil || err == nil || !strings.HasPrefix(err.Error(), wantErr) {
 			t.Errorf("SAMLProviderConfig(%q) = (%v, %v); want = (nil, %q)", id, saml, err, wantErr)
 		}
+	}
+}
+
+func TestSAMLProviderConfigError(t *testing.T) {
+	s := echoServer([]byte(notFoundResponse), t)
+	defer s.Close()
+	s.Status = http.StatusNotFound
+
+	client := s.Client.pcc
+	saml, err := client.SAMLProviderConfig(context.Background(), "saml.provider")
+	if saml != nil || err == nil || !IsConfigurationNotFound(err) {
+		t.Errorf("SAMLProviderConfig() = (%v, %v); want = (nil, ConfigurationNotFound)", saml, err)
+	}
+}
+
+func TestDeleteSAMLProviderConfig(t *testing.T) {
+	s := echoServer([]byte("{}"), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	if err := client.DeleteSAMLProviderConfig(context.Background(), "saml.provider"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := s.Req[0]
+	if req.Method != http.MethodDelete {
+		t.Errorf("DeleteSAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodDelete)
+	}
+
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs/saml.provider"
+	if req.URL.Path != wantURL {
+		t.Errorf("DeleteSAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
+	}
+}
+
+func TestDeleteSAMLProviderConfigInvalidID(t *testing.T) {
+	client := &providerConfigClient{}
+	wantErr := "invalid SAML provider id: "
+
+	for _, id := range invalidSAMLConfigIDs {
+		err := client.DeleteSAMLProviderConfig(context.Background(), id)
+		if err == nil || !strings.HasPrefix(err.Error(), wantErr) {
+			t.Errorf("DeleteSAMLProviderConfig(%q) = %v; want = %q", id, err, wantErr)
+		}
+	}
+}
+
+func TestDeleteSAMLProviderConfigError(t *testing.T) {
+	s := echoServer([]byte(notFoundResponse), t)
+	defer s.Close()
+	s.Status = http.StatusNotFound
+
+	client := s.Client.pcc
+	err := client.DeleteSAMLProviderConfig(context.Background(), "saml.provider")
+	if err == nil || !IsConfigurationNotFound(err) {
+		t.Errorf("DeleteSAMLProviderConfig() = %v; want = ConfigurationNotFound", err)
 	}
 }
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const samlConfigResponse = `{
+    "name":"projects/mock-project-id/inboundSamlConfigs/saml.provider",
+    "idpConfig": {
+        "idpEntityId": "IDP_ENTITY_ID",
+        "ssoUrl": "https://example.com/login",
+        "signRequest": true,
+        "idpCertificates": [
+            {"x509Certificate": "CERT1"},
+            {"x509Certificate": "CERT2"}
+        ]
+    },
+    "spConfig": {
+        "spEntityId": "RP_ENTITY_ID",
+        "callbackUri": "https://projectId.firebaseapp.com/__/auth/handler"
+    },
+    "displayName": "samlProviderName",
+    "enabled": true
+}`
+
+var samlProviderConfig = &SAMLProviderConfig{
+	ID:                    "saml.provider",
+	DisplayName:           "samlProviderName",
+	Enabled:               true,
+	IDPEntityID:           "IDP_ENTITY_ID",
+	SSOURL:                "https://example.com/login",
+	RequestSigningEnabled: true,
+	X509Certificates:      []string{"CERT1", "CERT2"},
+	RPEntityID:            "RP_ENTITY_ID",
+	CallbackURL:           "https://projectId.firebaseapp.com/__/auth/handler",
+}
+
+func TestSAMLProviderConfig(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	saml, err := client.SAMLProviderConfig(context.Background(), "saml.provider")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("SAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	req := s.Req[0]
+	if req.Method != http.MethodGet {
+		t.Errorf("SAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodGet)
+	}
+
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs/saml.provider"
+	if req.URL.Path != wantURL {
+		t.Errorf("SAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
+	}
+}
+
+func TestSAMLProviderConfigInvalidID(t *testing.T) {
+	client := &providerConfigClient{}
+	invalidIDs := []string{
+		"",
+		"invalid.id",
+		"oidc.config",
+	}
+	wantErr := "invalid SAML provider id: "
+
+	for _, id := range invalidIDs {
+		saml, err := client.SAMLProviderConfig(context.Background(), id)
+		if saml != nil || err == nil || !strings.HasPrefix(err.Error(), wantErr) {
+			t.Errorf("SAMLProviderConfig(%q) = (%v, %v); want = (nil, %q)", id, saml, err, wantErr)
+		}
+	}
+}
+
+func TestSAMLProviderConfigNoProjectID(t *testing.T) {
+	client := &providerConfigClient{}
+	want := "project id not available"
+	if _, err := client.SAMLProviderConfig(context.Background(), "saml.provider"); err == nil || err.Error() != want {
+		t.Errorf("SAMLProviderConfig() = %v; want = %q", err, want)
+	}
+}

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -311,6 +311,7 @@ func marshalCustomClaims(claims map[string]interface{}) (string, error) {
 // Error handlers.
 
 const (
+	configurationNotFound    = "configuration-not-found"
 	emailAlreadyExists       = "email-already-exists"
 	idTokenRevoked           = "id-token-revoked"
 	insufficientPermission   = "insufficient-permission"
@@ -323,6 +324,11 @@ const (
 	unknown                  = "unknown-error"
 	userNotFound             = "user-not-found"
 )
+
+// IsConfigurationNotFound checks if the given error was due to a non-existing IdP configuration.
+func IsConfigurationNotFound(err error) bool {
+	return internal.HasErrorCode(err, configurationNotFound)
+}
 
 // IsEmailAlreadyExists checks if the given error was due to a duplicate email.
 func IsEmailAlreadyExists(err error) bool {
@@ -380,7 +386,7 @@ func IsUserNotFound(err error) bool {
 }
 
 var serverError = map[string]string{
-	"CONFIGURATION_NOT_FOUND":     projectNotFound,
+	"CONFIGURATION_NOT_FOUND":     configurationNotFound,
 	"DUPLICATE_EMAIL":             emailAlreadyExists,
 	"DUPLICATE_LOCAL_ID":          uidAlreadyExists,
 	"EMAIL_EXISTS":                emailAlreadyExists,

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1273,6 +1273,7 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 		t.Fatal(err)
 	}
 	authClient.baseURL = s.Srv.URL
+	authClient.pcc.endpoint = s.Srv.URL
 	s.Client = authClient
 	return &s
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1168,7 +1168,7 @@ func TestHTTPError(t *testing.T) {
 
 func TestHTTPErrorWithCode(t *testing.T) {
 	errorCodes := map[string]func(error) bool{
-		"CONFIGURATION_NOT_FOUND": IsProjectNotFound,
+		"CONFIGURATION_NOT_FOUND": IsConfigurationNotFound,
 		"DUPLICATE_EMAIL":         IsEmailAlreadyExists,
 		"DUPLICATE_LOCAL_ID":      IsUIDAlreadyExists,
 		"EMAIL_EXISTS":            IsEmailAlreadyExists,


### PR DESCRIPTION
Starting the implementation of the SAML provider config management API. This PR adds 2 new functions -- `SAMLProviderConfig()` and `DeleteSAMLProviderConfig()`. I'm keeping the functions off the public API until the implementation is complete by not exposing them on `auth.Client`. 

go/firebase-mt-go