### PR TITLE
Added Create and Update APIs for SAML configs

### DIFF
--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -133,20 +133,17 @@ func (config *SAMLProviderConfigToCreate) ID(id string) *SAMLProviderConfigToCre
 
 // IDPEntityID sets the IDPEntityID field of the new config.
 func (config *SAMLProviderConfigToCreate) IDPEntityID(entityID string) *SAMLProviderConfigToCreate {
-	config.set(idpEntityIDKey, entityID)
-	return config
+	return config.set(idpEntityIDKey, entityID)
 }
 
 // SSOURL sets the SSOURL field of the new config.
 func (config *SAMLProviderConfigToCreate) SSOURL(url string) *SAMLProviderConfigToCreate {
-	config.set(ssoURLKey, url)
-	return config
+	return config.set(ssoURLKey, url)
 }
 
 // RequestSigningEnabled enables or disables the request signing support.
 func (config *SAMLProviderConfigToCreate) RequestSigningEnabled(enabled bool) *SAMLProviderConfigToCreate {
-	config.set(signRequestKey, enabled)
-	return config
+	return config.set(signRequestKey, enabled)
 }
 
 // X509Certificates sets the certificates for the new config.
@@ -156,40 +153,36 @@ func (config *SAMLProviderConfigToCreate) X509Certificates(certs []string) *SAML
 		result = append(result, idpCertificate{cert})
 	}
 
-	config.set(idpCertsKey, result)
-	return config
+	return config.set(idpCertsKey, result)
 }
 
 // RPEntityID sets the RPEntityID field of the new config.
 func (config *SAMLProviderConfigToCreate) RPEntityID(entityID string) *SAMLProviderConfigToCreate {
-	config.set(spEntityIDKey, entityID)
-	return config
+	return config.set(spEntityIDKey, entityID)
 }
 
 // CallbackURL sets the CallbackURL field of the new config.
 func (config *SAMLProviderConfigToCreate) CallbackURL(url string) *SAMLProviderConfigToCreate {
-	config.set(callbackURIKey, url)
-	return config
+	return config.set(callbackURIKey, url)
 }
 
 // DisplayName sets the DisplayName field of the new config.
 func (config *SAMLProviderConfigToCreate) DisplayName(name string) *SAMLProviderConfigToCreate {
-	config.set(displayNameKey, name)
-	return config
+	return config.set(displayNameKey, name)
 }
 
 // Enabled enables or disables the new config.
 func (config *SAMLProviderConfigToCreate) Enabled(enabled bool) *SAMLProviderConfigToCreate {
-	config.set(enabledKey, enabled)
-	return config
+	return config.set(enabledKey, enabled)
 }
 
-func (config *SAMLProviderConfigToCreate) set(key string, value interface{}) {
+func (config *SAMLProviderConfigToCreate) set(key string, value interface{}) *SAMLProviderConfigToCreate {
 	if config.params == nil {
 		config.params = make(nestedMap)
 	}
 
 	config.params.Set(key, value)
+	return config
 }
 
 func (config *SAMLProviderConfigToCreate) buildRequest() (nestedMap, string, error) {

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -19,12 +19,91 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"firebase.google.com/go/internal"
 )
 
-const providerConfigEndpoint = "https://identitytoolkit.googleapis.com/v2beta1"
+const (
+	providerConfigEndpoint = "https://identitytoolkit.googleapis.com/v2beta1"
+
+	idpEntityIDKey = "idpConfig.idpEntityId"
+	ssoURLKey      = "idpConfig.ssoUrl"
+	signRequestKey = "idpConfig.signRequest"
+	idpCertsKey    = "idpConfig.idpCertificates"
+
+	spEntityIDKey  = "spConfig.spEntityId"
+	callbackURIKey = "spConfig.callbackUri"
+
+	displayNameKey = "displayName"
+	enabledKey     = "enabled"
+)
+
+type nestedMap map[string]interface{}
+
+func (nm nestedMap) Get(key string) (interface{}, bool) {
+	segments := strings.Split(key, ".")
+	curr := map[string]interface{}(nm)
+	for idx, segment := range segments {
+		val, ok := curr[segment]
+		if idx == len(segments)-1 || !ok {
+			return val, ok
+		}
+
+		curr = val.(map[string]interface{})
+	}
+
+	return nil, false
+}
+
+func (nm nestedMap) GetString(key string) (string, bool) {
+	if val, ok := nm.Get(key); ok {
+		return val.(string), true
+	}
+
+	return "", false
+}
+
+func (nm nestedMap) Set(key string, value interface{}) {
+	segments := strings.Split(key, ".")
+	curr := map[string]interface{}(nm)
+	for idx, segment := range segments {
+		if idx == len(segments)-1 {
+			curr[segment] = value
+			return
+		}
+
+		child, ok := curr[segment]
+		if ok {
+			curr = child.(map[string]interface{})
+			continue
+		}
+		newChild := make(map[string]interface{})
+		curr[segment] = newChild
+		curr = newChild
+	}
+}
+
+func (nm nestedMap) UpdateMask() ([]string, error) {
+	return buildMask(nm), nil
+}
+
+func buildMask(data map[string]interface{}) []string {
+	var mask []string
+	for k, v := range data {
+		if child, ok := v.(map[string]interface{}); ok {
+			childMask := buildMask(child)
+			for _, item := range childMask {
+				mask = append(mask, fmt.Sprintf("%s.%s", k, item))
+			}
+		} else {
+			mask = append(mask, k)
+		}
+	}
+
+	return mask
+}
 
 // SAMLProviderConfig is the SAML auth provider configuration.
 // See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html.
@@ -38,6 +117,231 @@ type SAMLProviderConfig struct {
 	X509Certificates      []string
 	RPEntityID            string
 	CallbackURL           string
+}
+
+// SAMLProviderConfigToCreate represents the options used to create a new SAMLProviderConfig.
+type SAMLProviderConfigToCreate struct {
+	id     string
+	params nestedMap
+}
+
+// ID sets the provider ID of the new config.
+func (config *SAMLProviderConfigToCreate) ID(id string) *SAMLProviderConfigToCreate {
+	config.id = id
+	return config
+}
+
+// IDPEntityID sets the IDPEntityID field of the new config.
+func (config *SAMLProviderConfigToCreate) IDPEntityID(entityID string) *SAMLProviderConfigToCreate {
+	config.set(idpEntityIDKey, entityID)
+	return config
+}
+
+// SSOURL sets the SSOURL field of the new config.
+func (config *SAMLProviderConfigToCreate) SSOURL(url string) *SAMLProviderConfigToCreate {
+	config.set(ssoURLKey, url)
+	return config
+}
+
+// RequestSigningEnabled enables or disables the request signing support.
+func (config *SAMLProviderConfigToCreate) RequestSigningEnabled(enabled bool) *SAMLProviderConfigToCreate {
+	config.set(signRequestKey, enabled)
+	return config
+}
+
+// X509Certificates sets the certificates for the new config.
+func (config *SAMLProviderConfigToCreate) X509Certificates(certs []string) *SAMLProviderConfigToCreate {
+	var result []idpCertificate
+	for _, cert := range certs {
+		result = append(result, idpCertificate{cert})
+	}
+
+	config.set(idpCertsKey, result)
+	return config
+}
+
+// RPEntityID sets the RPEntityID field of the new config.
+func (config *SAMLProviderConfigToCreate) RPEntityID(entityID string) *SAMLProviderConfigToCreate {
+	config.set(spEntityIDKey, entityID)
+	return config
+}
+
+// CallbackURL sets the CallbackURL field of the new config.
+func (config *SAMLProviderConfigToCreate) CallbackURL(url string) *SAMLProviderConfigToCreate {
+	config.set(callbackURIKey, url)
+	return config
+}
+
+// DisplayName sets the DisplayName field of the new config.
+func (config *SAMLProviderConfigToCreate) DisplayName(name string) *SAMLProviderConfigToCreate {
+	config.set(displayNameKey, name)
+	return config
+}
+
+// Enabled enables or disables the new config.
+func (config *SAMLProviderConfigToCreate) Enabled(enabled bool) *SAMLProviderConfigToCreate {
+	config.set(enabledKey, enabled)
+	return config
+}
+
+func (config *SAMLProviderConfigToCreate) set(key string, value interface{}) {
+	if config.params == nil {
+		config.params = make(nestedMap)
+	}
+
+	config.params.Set(key, value)
+}
+
+func (config *SAMLProviderConfigToCreate) buildRequest() (nestedMap, string, error) {
+	if err := validateSAMLConfigID(config.id); err != nil {
+		return nil, "", err
+	}
+
+	if len(config.params) == 0 {
+		return nil, "", errors.New("no parameters specified in the create request")
+	}
+
+	if val, ok := config.params.GetString(idpEntityIDKey); !ok || val == "" {
+		return nil, "", errors.New("IDPEntityID must not be empty")
+	}
+
+	if val, ok := config.params.GetString(ssoURLKey); !ok || val == "" {
+		return nil, "", errors.New("SSOURL must not be empty")
+	} else if _, err := url.ParseRequestURI(val); err != nil {
+		return nil, "", fmt.Errorf("failed to parse SSOURL: %v", err)
+	}
+
+	var certs interface{}
+	var ok bool
+	if certs, ok = config.params.Get(idpCertsKey); !ok || len(certs.([]idpCertificate)) == 0 {
+		return nil, "", errors.New("X509Certificates must not be empty")
+	}
+	for _, cert := range certs.([]idpCertificate) {
+		if cert.X509Certificate == "" {
+			return nil, "", errors.New("X509Certificates must not contain empty strings")
+		}
+	}
+
+	if val, ok := config.params.GetString(spEntityIDKey); !ok || val == "" {
+		return nil, "", errors.New("RPEntityID must not be empty")
+	}
+
+	if val, ok := config.params.GetString(callbackURIKey); !ok || val == "" {
+		return nil, "", errors.New("CallbackURL must not be empty")
+	} else if _, err := url.ParseRequestURI(val); err != nil {
+		return nil, "", fmt.Errorf("failed to parse CallbackURL: %v", err)
+	}
+
+	return config.params, config.id, nil
+}
+
+// SAMLProviderConfigToUpdate represents the options used to update an existing SAMLProviderConfig.
+type SAMLProviderConfigToUpdate struct {
+	params nestedMap
+}
+
+// IDPEntityID the IDPEntityID field of the config.
+func (config *SAMLProviderConfigToUpdate) IDPEntityID(entityID string) *SAMLProviderConfigToUpdate {
+	return config.set(idpEntityIDKey, entityID)
+}
+
+// SSOURL updates the SSOURL field of the config.
+func (config *SAMLProviderConfigToUpdate) SSOURL(url string) *SAMLProviderConfigToUpdate {
+	return config.set(ssoURLKey, url)
+}
+
+// RequestSigningEnabled enables or disables the request signing support.
+func (config *SAMLProviderConfigToUpdate) RequestSigningEnabled(enabled bool) *SAMLProviderConfigToUpdate {
+	return config.set(signRequestKey, enabled)
+}
+
+// X509Certificates updates the certificates of the config.
+func (config *SAMLProviderConfigToUpdate) X509Certificates(certs []string) *SAMLProviderConfigToUpdate {
+	var result []idpCertificate
+	for _, cert := range certs {
+		result = append(result, idpCertificate{cert})
+	}
+
+	return config.set(idpCertsKey, result)
+}
+
+// RPEntityID updates the RPEntityID field of the config.
+func (config *SAMLProviderConfigToUpdate) RPEntityID(entityID string) *SAMLProviderConfigToUpdate {
+	return config.set(spEntityIDKey, entityID)
+}
+
+// CallbackURL updates the CallbackURL field of the config.
+func (config *SAMLProviderConfigToUpdate) CallbackURL(url string) *SAMLProviderConfigToUpdate {
+	return config.set(callbackURIKey, url)
+}
+
+// DisplayName updates the DisplayName field of the config.
+func (config *SAMLProviderConfigToUpdate) DisplayName(name string) *SAMLProviderConfigToUpdate {
+	var nameOrNil interface{}
+	if name != "" {
+		nameOrNil = name
+	}
+
+	return config.set(displayNameKey, nameOrNil)
+}
+
+// Enabled enables or disables the new config.
+func (config *SAMLProviderConfigToUpdate) Enabled(enabled bool) *SAMLProviderConfigToUpdate {
+	return config.set(enabledKey, enabled)
+}
+
+func (config *SAMLProviderConfigToUpdate) set(key string, value interface{}) *SAMLProviderConfigToUpdate {
+	if config.params == nil {
+		config.params = make(nestedMap)
+	}
+
+	config.params.Set(key, value)
+	return config
+}
+
+func (config *SAMLProviderConfigToUpdate) buildRequest() (nestedMap, error) {
+	if len(config.params) == 0 {
+		return nil, errors.New("no parameters specified in the update request")
+	}
+
+	if val, ok := config.params.GetString(idpEntityIDKey); ok && val == "" {
+		return nil, errors.New("IDPEntityID must not be empty")
+	}
+
+	if val, ok := config.params.GetString(ssoURLKey); ok {
+		if val == "" {
+			return nil, errors.New("SSOURL must not be empty")
+		}
+		if _, err := url.ParseRequestURI(val); err != nil {
+			return nil, fmt.Errorf("failed to parse SSOURL: %v", err)
+		}
+	}
+
+	if val, ok := config.params.Get(idpCertsKey); ok {
+		if len(val.([]idpCertificate)) == 0 {
+			return nil, errors.New("X509Certificates must not be empty")
+		}
+		for _, cert := range val.([]idpCertificate) {
+			if cert.X509Certificate == "" {
+				return nil, errors.New("X509Certificates must not contain empty strings")
+			}
+		}
+	}
+
+	if val, ok := config.params.GetString(spEntityIDKey); ok && val == "" {
+		return nil, errors.New("RPEntityID must not be empty")
+	}
+
+	if val, ok := config.params.GetString(callbackURIKey); ok {
+		if val == "" {
+			return nil, errors.New("CallbackURL must not be empty")
+		}
+		if _, err := url.ParseRequestURI(val); err != nil {
+			return nil, fmt.Errorf("failed to parse CallbackURL: %v", err)
+		}
+	}
+
+	return config.params, nil
 }
 
 type providerConfigClient struct {
@@ -80,6 +384,68 @@ func (c *providerConfigClient) SAMLProviderConfig(ctx context.Context, id string
 	return result.toSAMLProviderConfig(), nil
 }
 
+// CreateSAMLProviderConfig creates a new SAML provider config from the given parameters.
+func (c *providerConfigClient) CreateSAMLProviderConfig(ctx context.Context, config *SAMLProviderConfigToCreate) (*SAMLProviderConfig, error) {
+	if config == nil {
+		return nil, errors.New("config must not be nil")
+	}
+
+	body, id, err := config.buildRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &internal.Request{
+		Method: http.MethodPost,
+		URL:    "/inboundSamlConfigs",
+		Body:   internal.NewJSONEntity(body),
+		Opts: []internal.HTTPOption{
+			internal.WithQueryParam("inboundSamlConfigId", id),
+		},
+	}
+	var result samlProviderConfigDAO
+	if _, err := c.makeRequest(ctx, req, &result); err != nil {
+		return nil, err
+	}
+
+	return result.toSAMLProviderConfig(), nil
+}
+
+// UpdateSAMLProviderConfig updates an existing SAML provider config with the given parameters.
+func (c *providerConfigClient) UpdateSAMLProviderConfig(ctx context.Context, id string, config *SAMLProviderConfigToUpdate) (*SAMLProviderConfig, error) {
+	if err := validateSAMLConfigID(id); err != nil {
+		return nil, err
+	}
+	if config == nil {
+		return nil, errors.New("config must not be nil")
+	}
+
+	body, err := config.buildRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	mask, err := body.UpdateMask()
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct update mask: %v", err)
+	}
+
+	req := &internal.Request{
+		Method: http.MethodPatch,
+		URL:    fmt.Sprintf("/inboundSamlConfigs/%s", id),
+		Body:   internal.NewJSONEntity(body),
+		Opts: []internal.HTTPOption{
+			internal.WithQueryParam("updateMask", strings.Join(mask, ",")),
+		},
+	}
+	var result samlProviderConfigDAO
+	if _, err := c.makeRequest(ctx, req, &result); err != nil {
+		return nil, err
+	}
+
+	return result.toSAMLProviderConfig(), nil
+}
+
 // DeleteSAMLProviderConfig deletes the SAMLProviderConfig with the given ID.
 func (c *providerConfigClient) DeleteSAMLProviderConfig(ctx context.Context, id string) error {
 	if err := validateSAMLConfigID(id); err != nil {
@@ -103,15 +469,17 @@ func (c *providerConfigClient) makeRequest(ctx context.Context, req *internal.Re
 	return c.httpClient.DoAndUnmarshal(ctx, req, v)
 }
 
+type idpCertificate struct {
+	X509Certificate string `json:"x509Certificate"`
+}
+
 type samlProviderConfigDAO struct {
 	Name      string `json:"name"`
 	IDPConfig struct {
-		IDPEntityID     string `json:"idpEntityId"`
-		SSOURL          string `json:"ssoUrl"`
-		IDPCertificates []struct {
-			X509Certificate string `json:"x509Certificate"`
-		} `json:"idpCertificates"`
-		SignRequest bool `json:"signRequest"`
+		IDPEntityID     string           `json:"idpEntityId"`
+		SSOURL          string           `json:"ssoUrl"`
+		IDPCertificates []idpCertificate `json:"idpCertificates"`
+		SignRequest     bool             `json:"signRequest"`
 	} `json:"idpConfig"`
 	SPConfig struct {
 		SPEntityID  string `json:"spEntityId"`

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -16,8 +16,11 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -40,11 +43,17 @@ const samlConfigResponse = `{
     "displayName": "samlProviderName",
     "enabled": true
 }`
+
 const notFoundResponse = `{
 	"error": {
 		"message": "CONFIGURATION_NOT_FOUND"
 	}
 }`
+
+var idpCertsMap = []interface{}{
+	map[string]interface{}{"x509Certificate": "CERT1"},
+	map[string]interface{}{"x509Certificate": "CERT2"},
+}
 
 var samlProviderConfig = &SAMLProviderConfig{
 	ID:                    "saml.provider",
@@ -113,6 +122,464 @@ func TestSAMLProviderConfigError(t *testing.T) {
 	}
 }
 
+func TestCreateSAMLProviderConfig(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToCreate{}).
+		ID(samlProviderConfig.ID).
+		DisplayName(samlProviderConfig.DisplayName).
+		Enabled(samlProviderConfig.Enabled).
+		IDPEntityID(samlProviderConfig.IDPEntityID).
+		SSOURL(samlProviderConfig.SSOURL).
+		RequestSigningEnabled(samlProviderConfig.RequestSigningEnabled).
+		X509Certificates(samlProviderConfig.X509Certificates).
+		RPEntityID(samlProviderConfig.RPEntityID).
+		CallbackURL(samlProviderConfig.CallbackURL)
+	saml, err := client.CreateSAMLProviderConfig(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("CreateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"displayName": samlProviderConfig.DisplayName,
+		"enabled":     samlProviderConfig.Enabled,
+		"idpConfig": map[string]interface{}{
+			"idpEntityId":     samlProviderConfig.IDPEntityID,
+			"ssoUrl":          samlProviderConfig.SSOURL,
+			"signRequest":     samlProviderConfig.RequestSigningEnabled,
+			"idpCertificates": idpCertsMap,
+		},
+		"spConfig": map[string]interface{}{
+			"spEntityId":  samlProviderConfig.RPEntityID,
+			"callbackUri": samlProviderConfig.CallbackURL,
+		},
+	}
+	if err := checkCreateRequest(s, wantBody); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateSAMLProviderConfigMinimal(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToCreate{}).
+		ID(samlProviderConfig.ID).
+		IDPEntityID(samlProviderConfig.IDPEntityID).
+		SSOURL(samlProviderConfig.SSOURL).
+		X509Certificates(samlProviderConfig.X509Certificates).
+		RPEntityID(samlProviderConfig.RPEntityID).
+		CallbackURL(samlProviderConfig.CallbackURL)
+	saml, err := client.CreateSAMLProviderConfig(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("CreateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"idpConfig": map[string]interface{}{
+			"idpEntityId":     samlProviderConfig.IDPEntityID,
+			"ssoUrl":          samlProviderConfig.SSOURL,
+			"idpCertificates": idpCertsMap,
+		},
+		"spConfig": map[string]interface{}{
+			"spEntityId":  samlProviderConfig.RPEntityID,
+			"callbackUri": samlProviderConfig.CallbackURL,
+		},
+	}
+	if err := checkCreateRequest(s, wantBody); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateSAMLProviderConfigZeroValues(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+	client := s.Client.pcc
+
+	options := (&SAMLProviderConfigToCreate{}).
+		ID(samlProviderConfig.ID).
+		DisplayName(samlProviderConfig.DisplayName).
+		Enabled(false).
+		IDPEntityID(samlProviderConfig.IDPEntityID).
+		SSOURL(samlProviderConfig.SSOURL).
+		RequestSigningEnabled(false).
+		X509Certificates(samlProviderConfig.X509Certificates).
+		RPEntityID(samlProviderConfig.RPEntityID).
+		CallbackURL(samlProviderConfig.CallbackURL)
+	saml, err := client.CreateSAMLProviderConfig(context.Background(), options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("CreateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"displayName": samlProviderConfig.DisplayName,
+		"enabled":     false,
+		"idpConfig": map[string]interface{}{
+			"idpEntityId":     samlProviderConfig.IDPEntityID,
+			"ssoUrl":          samlProviderConfig.SSOURL,
+			"signRequest":     false,
+			"idpCertificates": idpCertsMap,
+		},
+		"spConfig": map[string]interface{}{
+			"spEntityId":  samlProviderConfig.RPEntityID,
+			"callbackUri": samlProviderConfig.CallbackURL,
+		},
+	}
+	if err := checkCreateRequest(s, wantBody); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateSAMLProviderConfigError(t *testing.T) {
+	s := echoServer([]byte("{}"), t)
+	s.Status = http.StatusInternalServerError
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToCreate{}).
+		ID(samlProviderConfig.ID).
+		DisplayName(samlProviderConfig.DisplayName).
+		Enabled(samlProviderConfig.Enabled).
+		IDPEntityID(samlProviderConfig.IDPEntityID).
+		SSOURL(samlProviderConfig.SSOURL).
+		RequestSigningEnabled(samlProviderConfig.RequestSigningEnabled).
+		X509Certificates(samlProviderConfig.X509Certificates).
+		RPEntityID(samlProviderConfig.RPEntityID).
+		CallbackURL(samlProviderConfig.CallbackURL)
+	saml, err := client.CreateSAMLProviderConfig(context.Background(), options)
+	if saml != nil || !IsUnknown(err) {
+		t.Errorf("SAMLProviderConfig() = (%v, %v); want = (nil, %q)", saml, err, "unknown-error")
+	}
+}
+
+func TestCreateSAMLProviderConfigInvalidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+		conf *SAMLProviderConfigToCreate
+	}{
+		{
+			name: "NilConfig",
+			want: "config must not be nil",
+			conf: nil,
+		},
+		{
+			name: "EmptyID",
+			want: "invalid SAML provider id: ",
+			conf: &SAMLProviderConfigToCreate{},
+		},
+		{
+			name: "InvalidID",
+			want: "invalid SAML provider id: ",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("oidc.provider"),
+		},
+		{
+			name: "EmptyOptions",
+			want: "no parameters specified in the create request",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider"),
+		},
+		{
+			name: "EmptyIDPEntityID",
+			want: "IDPEntityID must not be empty",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID(""),
+		},
+		{
+			name: "EmptySSOURL",
+			want: "SSOURL must not be empty",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID"),
+		},
+		{
+			name: "InvalidSSOURL",
+			want: "failed to parse SSOURL: ",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("not a url"),
+		},
+		{
+			name: "EmptyX509Certs",
+			want: "X509Certificates must not be empty",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("https://example.com/login"),
+		},
+		{
+			name: "EmptyStringInX509Certs",
+			want: "X509Certificates must not contain empty strings",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("https://example.com/login").
+				X509Certificates([]string{""}),
+		},
+		{
+			name: "EmptyRPEntityID",
+			want: "RPEntityID must not be empty",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("https://example.com/login").
+				X509Certificates([]string{"CERT"}),
+		},
+		{
+			name: "EmptyCallbackURL",
+			want: "CallbackURL must not be empty",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("https://example.com/login").
+				X509Certificates([]string{"CERT"}).
+				RPEntityID("RP_ENTITY_ID"),
+		},
+		{
+			name: "InvalidCallbackURL",
+			want: "failed to parse CallbackURL: ",
+			conf: (&SAMLProviderConfigToCreate{}).
+				ID("saml.provider").
+				IDPEntityID("IDP_ENTITY_ID").
+				SSOURL("https://example.com/login").
+				X509Certificates([]string{"CERT"}).
+				RPEntityID("RP_ENTITY_ID").
+				CallbackURL("not a url"),
+		},
+	}
+
+	client := &providerConfigClient{}
+	for _, tc := range cases {
+		_, err := client.CreateSAMLProviderConfig(context.Background(), tc.conf)
+		if err == nil || !strings.HasPrefix(err.Error(), tc.want) {
+			t.Errorf("CreateSAMLProviderConfig(%q) = %v; want = %q", tc.name, err, tc.want)
+		}
+	}
+}
+
+func TestUpdateSAMLProviderConfig(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToUpdate{}).
+		DisplayName(samlProviderConfig.DisplayName).
+		Enabled(samlProviderConfig.Enabled).
+		IDPEntityID(samlProviderConfig.IDPEntityID).
+		SSOURL(samlProviderConfig.SSOURL).
+		RequestSigningEnabled(samlProviderConfig.RequestSigningEnabled).
+		X509Certificates(samlProviderConfig.X509Certificates).
+		RPEntityID(samlProviderConfig.RPEntityID).
+		CallbackURL(samlProviderConfig.CallbackURL)
+	saml, err := client.UpdateSAMLProviderConfig(context.Background(), "saml.provider", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("UpdateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"displayName": samlProviderConfig.DisplayName,
+		"enabled":     samlProviderConfig.Enabled,
+		"idpConfig": map[string]interface{}{
+			"idpEntityId":     samlProviderConfig.IDPEntityID,
+			"ssoUrl":          samlProviderConfig.SSOURL,
+			"signRequest":     samlProviderConfig.RequestSigningEnabled,
+			"idpCertificates": idpCertsMap,
+		},
+		"spConfig": map[string]interface{}{
+			"spEntityId":  samlProviderConfig.RPEntityID,
+			"callbackUri": samlProviderConfig.CallbackURL,
+		},
+	}
+	wantMask := []string{
+		"displayName",
+		"enabled",
+		"idpConfig.idpCertificates",
+		"idpConfig.idpEntityId",
+		"idpConfig.signRequest",
+		"idpConfig.ssoUrl",
+		"spConfig.callbackUri",
+		"spConfig.spEntityId",
+	}
+	if err := checkUpdateRequest(s, wantBody, wantMask); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateSAMLProviderConfigMinimal(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToUpdate{}).
+		DisplayName("Other name")
+	saml, err := client.UpdateSAMLProviderConfig(context.Background(), "saml.provider", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("UpdateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"displayName": "Other name",
+	}
+	wantMask := []string{
+		"displayName",
+	}
+	if err := checkUpdateRequest(s, wantBody, wantMask); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateSAMLProviderConfigZeroValues(t *testing.T) {
+	s := echoServer([]byte(samlConfigResponse), t)
+	defer s.Close()
+
+	client := s.Client.pcc
+	options := (&SAMLProviderConfigToUpdate{}).
+		DisplayName("").
+		Enabled(false).
+		RequestSigningEnabled(false)
+	saml, err := client.UpdateSAMLProviderConfig(context.Background(), "saml.provider", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(saml, samlProviderConfig) {
+		t.Errorf("UpdateSAMLProviderConfig() = %#v; want = %#v", saml, samlProviderConfig)
+	}
+
+	wantBody := map[string]interface{}{
+		"displayName": nil,
+		"enabled":     false,
+		"idpConfig": map[string]interface{}{
+			"signRequest": false,
+		},
+	}
+	wantMask := []string{
+		"displayName",
+		"enabled",
+		"idpConfig.signRequest",
+	}
+	if err := checkUpdateRequest(s, wantBody, wantMask); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUpdateSAMLProviderConfigInvalidID(t *testing.T) {
+	cases := []string{"", "oidc.config"}
+	client := &providerConfigClient{}
+	options := (&SAMLProviderConfigToUpdate{}).
+		DisplayName("").
+		Enabled(false).
+		RequestSigningEnabled(false)
+	want := "invalid SAML provider id: "
+	for _, tc := range cases {
+		_, err := client.UpdateSAMLProviderConfig(context.Background(), tc, options)
+		if err == nil || !strings.HasPrefix(err.Error(), want) {
+			t.Errorf("UpdateSAMLProviderConfig(%q) = %v; want = %q", tc, err, "foo")
+		}
+	}
+}
+
+func TestUpdateSAMLProviderConfigInvalidInput(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+		conf *SAMLProviderConfigToUpdate
+	}{
+		{
+			name: "NilConfig",
+			want: "config must not be nil",
+			conf: nil,
+		},
+		{
+			name: "Empty",
+			want: "no parameters specified in the update request",
+			conf: &SAMLProviderConfigToUpdate{},
+		},
+		{
+			name: "EmptyIDPEntityID",
+			want: "IDPEntityID must not be empty",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				IDPEntityID(""),
+		},
+		{
+			name: "EmptySSOURL",
+			want: "SSOURL must not be empty",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				SSOURL(""),
+		},
+		{
+			name: "InvalidSSOURL",
+			want: "failed to parse SSOURL: ",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				SSOURL("not a url"),
+		},
+		{
+			name: "EmptyX509Certs",
+			want: "X509Certificates must not be empty",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				X509Certificates(nil),
+		},
+		{
+			name: "EmptyStringInX509Certs",
+			want: "X509Certificates must not contain empty strings",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				X509Certificates([]string{""}),
+		},
+		{
+			name: "EmptyRPEntityID",
+			want: "RPEntityID must not be empty",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				RPEntityID(""),
+		},
+		{
+			name: "EmptyCallbackURL",
+			want: "CallbackURL must not be empty",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				CallbackURL(""),
+		},
+		{
+			name: "InvalidCallbackURL",
+			want: "failed to parse CallbackURL: ",
+			conf: (&SAMLProviderConfigToUpdate{}).
+				CallbackURL("not a url"),
+		},
+	}
+
+	client := &providerConfigClient{}
+	for _, tc := range cases {
+		_, err := client.UpdateSAMLProviderConfig(context.Background(), "saml.provider", tc.conf)
+		if err == nil || !strings.HasPrefix(err.Error(), tc.want) {
+			t.Errorf("UpdateSAMLProviderConfig(%q) = %v; want = %q", tc.name, err, tc.want)
+		}
+	}
+}
+
 func TestDeleteSAMLProviderConfig(t *testing.T) {
 	s := echoServer([]byte("{}"), t)
 	defer s.Close()
@@ -163,4 +630,62 @@ func TestSAMLProviderConfigNoProjectID(t *testing.T) {
 	if _, err := client.SAMLProviderConfig(context.Background(), "saml.provider"); err == nil || err.Error() != want {
 		t.Errorf("SAMLProviderConfig() = %v; want = %q", err, want)
 	}
+}
+
+func checkCreateRequest(s *mockAuthServer, wantBody interface{}) error {
+	req := s.Req[0]
+	if req.Method != http.MethodPost {
+		return fmt.Errorf("CreateSAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodPost)
+	}
+
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs"
+	if req.URL.Path != wantURL {
+		return fmt.Errorf("CreateSAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
+	}
+
+	wantQuery := "inboundSamlConfigId=saml.provider"
+	if req.URL.RawQuery != wantQuery {
+		return fmt.Errorf("CreateSAMLProviderConfig() Query = %q; want = %q", req.URL.RawQuery, wantQuery)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(s.Rbody, &body); err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(body, wantBody) {
+		return fmt.Errorf("CreateSAMLProviderConfig() Body = %#v; want = %#v", body, wantBody)
+	}
+
+	return nil
+}
+
+func checkUpdateRequest(s *mockAuthServer, wantBody interface{}, wantMask []string) error {
+	req := s.Req[0]
+	if req.Method != http.MethodPatch {
+		return fmt.Errorf("UpdateSAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodPatch)
+	}
+
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs/saml.provider"
+	if req.URL.Path != wantURL {
+		return fmt.Errorf("UpdateSAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
+	}
+
+	queryParam := req.URL.Query().Get("updateMask")
+	mask := strings.Split(queryParam, ",")
+	sort.Strings(mask)
+	if !reflect.DeepEqual(mask, wantMask) {
+		return fmt.Errorf("UpdateSAMLProviderConfig() Query = %#v; want = %#v", mask, wantMask)
+	}
+
+	var body map[string]interface{}
+	if err := json.Unmarshal(s.Rbody, &body); err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(body, wantBody) {
+		return fmt.Errorf("UpdateSAMLProviderConfig() Body = %#v; want = %#v", body, wantBody)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Added `CreateSAMLProviderConfig()` and `UpdateSAMLProviderConfig()` functions.

Also introducing a `nestedMap` helper type that makes it easier to model the create/update parameters as a nested map and build update masks.