### PR TITLE
Added IdP config management APIs to TenantClient

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -101,15 +101,17 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 	}
 
 	umc := newUserManagementClient(hc, conf)
+	pcc := newProviderConfigClient(hc, conf)
 	return &Client{
 		userManagementClient: umc,
-		providerConfigClient: newProviderConfigClient(hc, conf),
+		providerConfigClient: pcc,
 		idTokenVerifier:      idTokenVerifier,
 		cookieVerifier:       cookieVerifier,
 		signer:               signer,
 		clock:                internal.SystemClock,
 		TenantManager: &TenantManager{
 			userManagementClient: umc,
+			providerConfigClient: pcc,
 		},
 	}, nil
 }

--- a/auth/email_action_links_test.go
+++ b/auth/email_action_links_test.go
@@ -101,7 +101,7 @@ func TestEmailVerificationLink(t *testing.T) {
 		"returnOobLink": true,
 	}
 	if err := checkActionLinkRequest(want, s); err != nil {
-		t.Fatal(err)
+		t.Fatalf("EmailVerificationLink() %v", err)
 	}
 }
 
@@ -126,7 +126,7 @@ func TestEmailVerificationLinkWithSettings(t *testing.T) {
 		want[k] = v
 	}
 	if err := checkActionLinkRequest(want, s); err != nil {
-		t.Fatal(err)
+		t.Fatalf("EmailVerificationLinkWithSettings() %v", err)
 	}
 }
 
@@ -148,7 +148,7 @@ func TestPasswordResetLink(t *testing.T) {
 		"returnOobLink": true,
 	}
 	if err := checkActionLinkRequest(want, s); err != nil {
-		t.Fatal(err)
+		t.Fatalf("PasswordResetLink() %v", err)
 	}
 }
 
@@ -173,7 +173,7 @@ func TestPasswordResetLinkWithSettings(t *testing.T) {
 		want[k] = v
 	}
 	if err := checkActionLinkRequest(want, s); err != nil {
-		t.Fatal(err)
+		t.Fatalf("PasswordResetLinkWithSettings() %v", err)
 	}
 }
 
@@ -198,7 +198,7 @@ func TestEmailSignInLink(t *testing.T) {
 		want[k] = v
 	}
 	if err := checkActionLinkRequest(want, s); err != nil {
-		t.Fatal(err)
+		t.Fatalf("EmailSignInLink() %v", err)
 	}
 }
 
@@ -279,12 +279,26 @@ func TestEmailVerificationLinkError(t *testing.T) {
 }
 
 func checkActionLinkRequest(want map[string]interface{}, s *mockAuthServer) error {
+	wantURL := "/projects/mock-project-id/accounts:sendOobCode"
+	return checkActionLinkRequestWithURL(want, wantURL, s)
+}
+
+func checkActionLinkRequestWithURL(want map[string]interface{}, wantURL string, s *mockAuthServer) error {
+	req := s.Req[0]
+	if req.Method != http.MethodPost {
+		return fmt.Errorf("Method = %q; want = %q", req.Method, http.MethodPatch)
+	}
+
+	if req.URL.Path != wantURL {
+		return fmt.Errorf("URL = %q; want = %q", req.URL.Path, wantURL)
+	}
+
 	var got map[string]interface{}
 	if err := json.Unmarshal(s.Rbody, &got); err != nil {
 		return err
 	}
 	if !reflect.DeepEqual(got, want) {
-		return fmt.Errorf("EmailVerificationLink() request = %#v; want = %#v", got, want)
+		return fmt.Errorf("Body = %#v; want = %#v", got, want)
 	}
 	return nil
 }

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -1225,12 +1225,16 @@ func TestSAMLProviderConfigNoProjectID(t *testing.T) {
 }
 
 func checkCreateOIDCConfigRequest(s *mockAuthServer, wantBody interface{}) error {
+	wantURL := "/projects/mock-project-id/oauthIdpConfigs"
+	return checkCreateOIDCConfigRequestWithURL(s, wantBody, wantURL)
+}
+
+func checkCreateOIDCConfigRequestWithURL(s *mockAuthServer, wantBody interface{}, wantURL string) error {
 	req := s.Req[0]
 	if req.Method != http.MethodPost {
 		return fmt.Errorf("CreateOIDCProviderConfig() Method = %q; want = %q", req.Method, http.MethodPost)
 	}
 
-	wantURL := "/projects/mock-project-id/oauthIdpConfigs"
 	if req.URL.Path != wantURL {
 		return fmt.Errorf("CreateOIDCProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
 	}
@@ -1253,12 +1257,16 @@ func checkCreateOIDCConfigRequest(s *mockAuthServer, wantBody interface{}) error
 }
 
 func checkCreateSAMLConfigRequest(s *mockAuthServer, wantBody interface{}) error {
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs"
+	return checkCreateSAMLConfigRequestWithURL(s, wantBody, wantURL)
+}
+
+func checkCreateSAMLConfigRequestWithURL(s *mockAuthServer, wantBody interface{}, wantURL string) error {
 	req := s.Req[0]
 	if req.Method != http.MethodPost {
 		return fmt.Errorf("CreateSAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodPost)
 	}
 
-	wantURL := "/projects/mock-project-id/inboundSamlConfigs"
 	if req.URL.Path != wantURL {
 		return fmt.Errorf("CreateSAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
 	}
@@ -1281,12 +1289,16 @@ func checkCreateSAMLConfigRequest(s *mockAuthServer, wantBody interface{}) error
 }
 
 func checkUpdateOIDCConfigRequest(s *mockAuthServer, wantBody interface{}, wantMask []string) error {
+	wantURL := "/projects/mock-project-id/oauthIdpConfigs/oidc.provider"
+	return checkUpdateOIDCConfigRequestWithURL(s, wantBody, wantMask, wantURL)
+}
+
+func checkUpdateOIDCConfigRequestWithURL(s *mockAuthServer, wantBody interface{}, wantMask []string, wantURL string) error {
 	req := s.Req[0]
 	if req.Method != http.MethodPatch {
 		return fmt.Errorf("UpdateOIDCProviderConfig() Method = %q; want = %q", req.Method, http.MethodPatch)
 	}
 
-	wantURL := "/projects/mock-project-id/oauthIdpConfigs/oidc.provider"
 	if req.URL.Path != wantURL {
 		return fmt.Errorf("UpdateOIDCProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
 	}
@@ -1311,12 +1323,16 @@ func checkUpdateOIDCConfigRequest(s *mockAuthServer, wantBody interface{}, wantM
 }
 
 func checkUpdateSAMLConfigRequest(s *mockAuthServer, wantBody interface{}, wantMask []string) error {
+	wantURL := "/projects/mock-project-id/inboundSamlConfigs/saml.provider"
+	return checkUpdateSAMLConfigRequestWithURL(s, wantBody, wantMask, wantURL)
+}
+
+func checkUpdateSAMLConfigRequestWithURL(s *mockAuthServer, wantBody interface{}, wantMask []string, wantURL string) error {
 	req := s.Req[0]
 	if req.Method != http.MethodPatch {
 		return fmt.Errorf("UpdateSAMLProviderConfig() Method = %q; want = %q", req.Method, http.MethodPatch)
 	}
 
-	wantURL := "/projects/mock-project-id/inboundSamlConfigs/saml.provider"
 	if req.URL.Path != wantURL {
 		return fmt.Errorf("UpdateSAMLProviderConfig() URL = %q; want = %q", req.URL.Path, wantURL)
 	}

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -54,6 +54,7 @@ type Tenant struct {
 type TenantClient struct {
 	tenantID string
 	*userManagementClient
+	*providerConfigClient
 }
 
 // TenantID returns the ID of the tenant to which this TenantClient instance belongs.
@@ -67,6 +68,7 @@ func (tc *TenantClient) TenantID() string {
 // supports creating new TenantClient instances scoped to specific tenant IDs.
 type TenantManager struct {
 	userManagementClient *userManagementClient
+	providerConfigClient *providerConfigClient
 }
 
 // AuthForTenant creates a new TenantClient scoped to a given tenantID.
@@ -78,5 +80,6 @@ func (tm *TenantManager) AuthForTenant(tenantID string) (*TenantClient, error) {
 	return &TenantClient{
 		tenantID:             tenantID,
 		userManagementClient: tm.userManagementClient.withTenantID(tenantID),
+		providerConfigClient: tm.providerConfigClient.withTenantID(tenantID),
 	}, nil
 }


### PR DESCRIPTION
Added SAML/OIDC provider management APIs to `TenantClient`. Unit tests largely copied from the existing `provider_config_test.go`.