### PR TITLE
Added baseClient type

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -319,7 +319,9 @@ func TestCustomTokenInvalidCredential(t *testing.T) {
 
 func TestVerifyIDToken(t *testing.T) {
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
 	}
 
 	ft, err := client.VerifyIDToken(context.Background(), testIDToken)
@@ -348,7 +350,9 @@ func TestVerifyIDTokenClockSkew(t *testing.T) {
 	}
 
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -368,7 +372,9 @@ func TestVerifyIDTokenClockSkew(t *testing.T) {
 
 func TestVerifyIDTokenInvalidSignature(t *testing.T) {
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
 	}
 	parts := strings.Split(testIDToken, ".")
 	token := fmt.Sprintf("%s:%s:invalidsignature", parts[0], parts[1])
@@ -462,7 +468,9 @@ func TestVerifyIDTokenError(t *testing.T) {
 	}
 
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -494,7 +502,9 @@ func TestVerifyIDTokenInvalidAlgorithm(t *testing.T) {
 	}
 
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
 	}
 	if _, err := client.VerifyIDToken(context.Background(), token); err == nil {
 		t.Errorf("VerifyIDToken(InvalidAlgorithm) = nil; want error")
@@ -518,9 +528,11 @@ func TestVerifyIDTokenWithNoProjectID(t *testing.T) {
 
 func TestCustomTokenVerification(t *testing.T) {
 	client := &Client{
-		idTokenVerifier: testIDTokenVerifier,
-		signer:          testSigner,
-		clock:           testClock,
+		baseClient: &baseClient{
+			idTokenVerifier: testIDTokenVerifier,
+		},
+		signer: testSigner,
+		clock:  testClock,
 	}
 	token, err := client.CustomToken(context.Background(), "user1")
 	if err != nil {
@@ -539,7 +551,9 @@ func TestCertificateRequestError(t *testing.T) {
 	}
 	tv.keySource = &mockKeySource{nil, errors.New("mock error")}
 	client := &Client{
-		idTokenVerifier: tv,
+		baseClient: &baseClient{
+			idTokenVerifier: tv,
+		},
 	}
 	if _, err := client.VerifyIDToken(context.Background(), testIDToken); err == nil {
 		t.Error("VeridyIDToken() = nil; want error")
@@ -627,7 +641,9 @@ func TestIDTokenRevocationCheckUserMgtError(t *testing.T) {
 
 func TestVerifySessionCookie(t *testing.T) {
 	client := &Client{
-		cookieVerifier: testCookieVerifier,
+		baseClient: &baseClient{
+			cookieVerifier: testCookieVerifier,
+		},
 	}
 
 	ft, err := client.VerifySessionCookie(context.Background(), testSessionCookie)
@@ -716,7 +732,9 @@ func TestVerifySessionCookieError(t *testing.T) {
 	}
 
 	client := &Client{
-		cookieVerifier: testCookieVerifier,
+		baseClient: &baseClient{
+			cookieVerifier: testCookieVerifier,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/auth/email_action_links_test.go
+++ b/auth/email_action_links_test.go
@@ -203,7 +203,9 @@ func TestEmailSignInLink(t *testing.T) {
 }
 
 func TestEmailActionLinkNoEmail(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	_, err := client.EmailVerificationLink(context.Background(), "")
 	if err == nil {
 		t.Errorf("EmailVerificationLink('') = nil; want error")
@@ -221,7 +223,9 @@ func TestEmailActionLinkNoEmail(t *testing.T) {
 }
 
 func TestEmailVerificationLinkInvalidSettings(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for _, tc := range invalidActionCodeSettings {
 		_, err := client.EmailVerificationLinkWithSettings(context.Background(), testEmail, tc.settings)
 		if err == nil || err.Error() != tc.want {
@@ -231,7 +235,9 @@ func TestEmailVerificationLinkInvalidSettings(t *testing.T) {
 }
 
 func TestPasswordResetLinkInvalidSettings(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for _, tc := range invalidActionCodeSettings {
 		_, err := client.PasswordResetLinkWithSettings(context.Background(), testEmail, tc.settings)
 		if err == nil || err.Error() != tc.want {
@@ -241,7 +247,9 @@ func TestPasswordResetLinkInvalidSettings(t *testing.T) {
 }
 
 func TestEmailSignInLinkInvalidSettings(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for _, tc := range invalidActionCodeSettings {
 		_, err := client.EmailSignInLink(context.Background(), testEmail, tc.settings)
 		if err == nil || err.Error() != tc.want {
@@ -251,7 +259,9 @@ func TestEmailSignInLinkInvalidSettings(t *testing.T) {
 }
 
 func TestEmailSignInLinkNoSettings(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	_, err := client.EmailSignInLink(context.Background(), testEmail, nil)
 	if err == nil {
 		t.Errorf("EmailSignInLink(nil) = %v; want = error", err)

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -52,9 +52,7 @@ type Tenant struct {
 // TenantClient instances for a specific tenantID can be instantiated by calling
 // [TenantManager.AuthForTenant(tenantID)].
 type TenantClient struct {
-	tenantID string
-	*userManagementClient
-	*providerConfigClient
+	*baseClient
 }
 
 // TenantID returns the ID of the tenant to which this TenantClient instance belongs.
@@ -67,8 +65,7 @@ func (tc *TenantClient) TenantID() string {
 // This supports creating, updating, listing, deleting the tenants of a Firebase project. It also
 // supports creating new TenantClient instances scoped to specific tenant IDs.
 type TenantManager struct {
-	userManagementClient *userManagementClient
-	providerConfigClient *providerConfigClient
+	base *baseClient
 }
 
 // AuthForTenant creates a new TenantClient scoped to a given tenantID.
@@ -78,8 +75,6 @@ func (tm *TenantManager) AuthForTenant(tenantID string) (*TenantClient, error) {
 	}
 
 	return &TenantClient{
-		tenantID:             tenantID,
-		userManagementClient: tm.userManagementClient.withTenantID(tenantID),
-		providerConfigClient: tm.providerConfigClient.withTenantID(tenantID),
+		baseClient: tm.base.withTenantID(tenantID),
 	}, nil
 }

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -47,9 +47,18 @@ func TestTenantID(t *testing.T) {
 		t.Fatalf("AuthForTenant() = %v", err)
 	}
 
+	const want = "tenantID"
 	tenantID := client.TenantID()
-	if tenantID != "tenantID" {
-		t.Errorf("TenantID() = %q; want = %q", tenantID, "tenantID")
+	if tenantID != want {
+		t.Errorf("TenantID() = %q; want = %q", tenantID, want)
+	}
+
+	if client.userManagementClient.tenantID != want {
+		t.Errorf("userManagementClient.tenantID = %q; want = %q", client.userManagementClient.tenantID, want)
+	}
+
+	if client.providerConfigClient.tenantID != want {
+		t.Errorf("providerConfigClient.tenantID = %q; want = %q", client.providerConfigClient.tenantID, want)
 	}
 }
 

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -140,7 +140,9 @@ func TestGetUserByPhoneNumber(t *testing.T) {
 
 func TestInvalidGetUser(t *testing.T) {
 	client := &Client{
-		userManagementClient: &userManagementClient{},
+		baseClient: &baseClient{
+			userManagementClient: &userManagementClient{},
+		},
 	}
 	user, err := client.GetUser(context.Background(), "")
 	if user != nil || err == nil {
@@ -293,7 +295,9 @@ func TestInvalidCreateUser(t *testing.T) {
 			`malformed email string: "a@a@a"`,
 		},
 	}
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for i, tc := range cases {
 		user, err := client.CreateUser(context.Background(), tc.params)
 		if user != nil || err == nil {
@@ -433,7 +437,9 @@ func TestInvalidUpdateUser(t *testing.T) {
 		cases = append(cases, s)
 	}
 
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for i, tc := range cases {
 		user, err := client.UpdateUser(context.Background(), "uid", tc.params)
 		if user != nil || err == nil {
@@ -447,7 +453,9 @@ func TestInvalidUpdateUser(t *testing.T) {
 
 func TestUpdateUserEmptyUID(t *testing.T) {
 	params := (&UserToUpdate{}).DisplayName("test")
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	user, err := client.UpdateUser(context.Background(), "", params)
 	if user != nil || err == nil {
 		t.Errorf("UpdateUser('') = (%v, %v); want = (nil, error)", user, err)
@@ -633,7 +641,9 @@ func TestInvalidSetCustomClaims(t *testing.T) {
 		cases = append(cases, s)
 	}
 
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	for _, tc := range cases {
 		err := client.SetCustomUserClaims(context.Background(), "uid", tc.cc)
 		if err == nil {
@@ -1062,7 +1072,9 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestInvalidDeleteUser(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	if err := client.DeleteUser(context.Background(), ""); err == nil {
 		t.Errorf("DeleteUser('') = nil; want error")
 	}
@@ -1203,7 +1215,9 @@ func TestSessionCookieError(t *testing.T) {
 
 func TestSessionCookieWithoutProjectID(t *testing.T) {
 	client := &Client{
-		userManagementClient: &userManagementClient{},
+		baseClient: &baseClient{
+			userManagementClient: &userManagementClient{},
+		},
 	}
 	_, err := client.SessionCookie(context.Background(), "idToken", 10*time.Minute)
 	want := "project id not available"
@@ -1213,7 +1227,9 @@ func TestSessionCookieWithoutProjectID(t *testing.T) {
 }
 
 func TestSessionCookieWithoutIDToken(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	_, err := client.SessionCookie(context.Background(), "", 10*time.Minute)
 	if err == nil {
 		t.Errorf("CreateSessionCookie('') = nil; want error")
@@ -1221,7 +1237,9 @@ func TestSessionCookieWithoutIDToken(t *testing.T) {
 }
 
 func TestSessionCookieShortExpiresIn(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	lessThanFiveMins := 5*time.Minute - time.Second
 	_, err := client.SessionCookie(context.Background(), "idToken", lessThanFiveMins)
 	if err == nil {
@@ -1230,7 +1248,9 @@ func TestSessionCookieShortExpiresIn(t *testing.T) {
 }
 
 func TestSessionCookieLongExpiresIn(t *testing.T) {
-	client := &Client{}
+	client := &Client{
+		baseClient: &baseClient{},
+	}
 	moreThanTwoWeeks := 14*24*time.Hour + time.Second
 	_, err := client.SessionCookie(context.Background(), "idToken", moreThanTwoWeeks)
 	if err == nil {


### PR DESCRIPTION
Introducing a `baseClient` type that can be easily embedded in both `auth.Client` and `auth.TenantClient`. This type exposes the functions that are common to both `auth.Client` and `auth.TenantClient`.

This PR just adds the `baseClient` and updates the affected tests. Future PRs will further modify how APIs like the `VerifyIDToken()` works when called via `auth.Client` and `auth.TenantClient`.