### PR TITLE
More integration tests for tenant management support

### DIFF
--- a/integration/auth/auth_test.go
+++ b/integration/auth/auth_test.go
@@ -198,7 +198,10 @@ func verifyCustomToken(t *testing.T, ct, uid string) *auth.Token {
 		t.Fatal(err)
 	}
 	if vt.UID != uid {
-		t.Fatalf("UID = %q; want UID = %q", vt.UID, uid)
+		t.Errorf("UID = %q; want UID = %q", vt.UID, uid)
+	}
+	if vt.Firebase.Tenant != "" {
+		t.Errorf("Tenant = %q; want = %q", vt.Firebase.Tenant, "")
 	}
 	return vt
 }

--- a/integration/auth/provider_config_test.go
+++ b/integration/auth/provider_config_test.go
@@ -31,6 +31,18 @@ var x509Certs = []string{
 }
 
 func TestOIDCProviderConfig(t *testing.T) {
+	testOIDCProviderConfig(t, client)
+}
+
+type oidcProviderClient interface {
+	OIDCProviderConfig(ctx context.Context, id string) (*auth.OIDCProviderConfig, error)
+	OIDCProviderConfigs(ctx context.Context, nextPageToken string) *auth.OIDCProviderConfigIterator
+	CreateOIDCProviderConfig(ctx context.Context, config *auth.OIDCProviderConfigToCreate) (*auth.OIDCProviderConfig, error)
+	UpdateOIDCProviderConfig(ctx context.Context, id string, config *auth.OIDCProviderConfigToUpdate) (*auth.OIDCProviderConfig, error)
+	DeleteOIDCProviderConfig(ctx context.Context, id string) error
+}
+
+func testOIDCProviderConfig(t *testing.T, client oidcProviderClient) {
 	id := randomOIDCProviderID()
 	want := &auth.OIDCProviderConfig{
 		ID:          id,
@@ -140,6 +152,18 @@ func TestOIDCProviderConfig(t *testing.T) {
 }
 
 func TestSAMLProviderConfig(t *testing.T) {
+	testSAMLProviderConfig(t, client)
+}
+
+type samlProviderClient interface {
+	SAMLProviderConfig(ctx context.Context, id string) (*auth.SAMLProviderConfig, error)
+	SAMLProviderConfigs(ctx context.Context, nextPageToken string) *auth.SAMLProviderConfigIterator
+	CreateSAMLProviderConfig(ctx context.Context, config *auth.SAMLProviderConfigToCreate) (*auth.SAMLProviderConfig, error)
+	UpdateSAMLProviderConfig(ctx context.Context, id string, config *auth.SAMLProviderConfigToUpdate) (*auth.SAMLProviderConfig, error)
+	DeleteSAMLProviderConfig(ctx context.Context, id string) error
+}
+
+func testSAMLProviderConfig(t *testing.T, client samlProviderClient) {
 	id := randomSAMLProviderID()
 	want := &auth.SAMLProviderConfig{
 		ID:          id,

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -17,8 +17,10 @@ package auth
 import (
 	"context"
 	"log"
+	"net/url"
 	"reflect"
 	"testing"
+	"time"
 
 	"firebase.google.com/go/auth"
 	"google.golang.org/api/iterator"
@@ -95,6 +97,10 @@ func TestTenantManager(t *testing.T) {
 		}
 	})
 
+	t.Run("UserManagement", func(t *testing.T) {
+		testTenantAwareUserManagement(t, id)
+	})
+
 	t.Run("UpdateTenant()", func(t *testing.T) {
 		want = &auth.Tenant{
 			ID:                    id,
@@ -114,10 +120,6 @@ func TestTenantManager(t *testing.T) {
 		if !reflect.DeepEqual(tenant, want) {
 			t.Errorf("UpdateTenant() = %#v; want = %#v", tenant, want)
 		}
-	})
-
-	t.Run("UserManagement", func(t *testing.T) {
-		testTenantAwareUserManagement(t, id)
 	})
 
 	t.Run("DeleteTenant()", func(t *testing.T) {
@@ -190,6 +192,119 @@ func testTenantAwareUserManagement(t *testing.T, id string) {
 		}
 	})
 
+	t.Run("Users()", func(t *testing.T) {
+		iter := tenantClient.Users(context.Background(), "")
+		var target *auth.ExportedUserRecord
+		for {
+			got, err := iter.Next()
+			if err == iterator.Done {
+				break
+			} else if err != nil {
+				t.Fatalf("Users() = %v", err)
+			}
+
+			if got.UID == user.UID {
+				target = got
+				break
+			}
+		}
+
+		if target == nil {
+			t.Fatalf("Users() did not return required user: %q", user.UID)
+		}
+
+		if !reflect.DeepEqual(*target.UserInfo, want) {
+			t.Errorf("Users() = %v; want = %v", *target.UserInfo, want)
+		}
+	})
+
+	t.Run("SetCustomUserClaims()", func(t *testing.T) {
+		claims := map[string]interface{}{
+			"premium": true,
+			"role":    "customer",
+		}
+		if err := tenantClient.SetCustomUserClaims(context.Background(), user.UID, claims); err != nil {
+			t.Fatalf("SetCustomUserClaims() = %v", err)
+		}
+
+		got, err := tenantClient.GetUser(context.Background(), user.UID)
+		if err != nil {
+			t.Fatalf("GetUser() = %v", err)
+		}
+
+		if !reflect.DeepEqual(got.CustomClaims, claims) {
+			t.Errorf("CustomClaims = %v; want = %v", got.CustomClaims, claims)
+		}
+	})
+
+	t.Run("EmailVerificationLink()", func(t *testing.T) {
+		link, err := tenantClient.EmailVerificationLink(context.Background(), want.Email)
+		if err != nil {
+			t.Fatalf("EmailVerificationLink() = %v", err)
+		}
+
+		tenant, err := extractTenantID(link)
+		if err != nil {
+			t.Fatalf("EmailVerificationLink() = %v", err)
+		}
+
+		if id != tenant {
+			t.Fatalf("EmailVerificationLink() TenantID = %q; want = %q", tenant, id)
+		}
+	})
+
+	t.Run("PasswordResetLink()", func(t *testing.T) {
+		link, err := tenantClient.PasswordResetLink(context.Background(), want.Email)
+		if err != nil {
+			t.Fatalf("PasswordResetLink() = %v", err)
+		}
+
+		tenant, err := extractTenantID(link)
+		if err != nil {
+			t.Fatalf("PasswordResetLink() = %v", err)
+		}
+
+		if id != tenant {
+			t.Fatalf("PasswordResetLink() TenantID = %q; want = %q", tenant, id)
+		}
+	})
+
+	t.Run("EmailSignInLink()", func(t *testing.T) {
+		link, err := tenantClient.EmailSignInLink(context.Background(), want.Email, &auth.ActionCodeSettings{
+			URL:             continueURL,
+			HandleCodeInApp: false,
+		})
+		if err != nil {
+			t.Fatalf("EmailSignInLink() = %v", err)
+		}
+
+		tenant, err := extractTenantID(link)
+		if err != nil {
+			t.Fatalf("EmailSignInLink() = %v", err)
+		}
+
+		if id != tenant {
+			t.Fatalf("EmailSignInLink() TenantID = %q; want = %q", tenant, id)
+		}
+	})
+
+	t.Run("RevokeRefreshTokens()", func(t *testing.T) {
+		validSinceMillis := time.Now().Unix() * 1000
+		time.Sleep(1 * time.Second)
+		if err := tenantClient.RevokeRefreshTokens(context.Background(), user.UID); err != nil {
+			t.Fatalf("RevokeRefreshTokens() = %v", err)
+		}
+
+		got, err := tenantClient.GetUser(context.Background(), user.UID)
+		if err != nil {
+			t.Fatalf("GetUser() = %v", err)
+		}
+
+		if got.TokensValidAfterMillis < validSinceMillis {
+			t.Fatalf("RevokeRefreshTokens() TokensValidAfterMillis (%d) < Now (%d)", got.TokensValidAfterMillis, validSinceMillis)
+		}
+	})
+
 	t.Run("DeleteUser()", func(t *testing.T) {
 		if err := tenantClient.DeleteUser(context.Background(), user.UID); err != nil {
 			t.Fatalf("DeleteUser() = %v", err)
@@ -199,6 +314,15 @@ func testTenantAwareUserManagement(t *testing.T, id string) {
 		if err == nil || !auth.IsUserNotFound(err) {
 			t.Errorf("Tenant() = %v; want = UserNotFound", err)
 		}
-
 	})
+}
+
+func extractTenantID(actionLink string) (string, error) {
+	u, err := url.Parse(actionLink)
+	if err != nil {
+		return "", err
+	}
+
+	q := u.Query()
+	return q.Get("tenantId"), nil
 }

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -101,6 +101,24 @@ func TestTenantManager(t *testing.T) {
 		testTenantAwareUserManagement(t, id)
 	})
 
+	t.Run("OIDCProviderConfig", func(t *testing.T) {
+		tenantClient, err := client.TenantManager.AuthForTenant(id)
+		if err != nil {
+			t.Fatalf("AuthForTenant() = %v", err)
+		}
+
+		testOIDCProviderConfig(t, tenantClient)
+	})
+
+	t.Run("SAMLProviderConfig", func(t *testing.T) {
+		tenantClient, err := client.TenantManager.AuthForTenant(id)
+		if err != nil {
+			t.Fatalf("AuthForTenant() = %v", err)
+		}
+
+		testSAMLProviderConfig(t, tenantClient)
+	})
+
 	t.Run("UpdateTenant()", func(t *testing.T) {
 		want = &auth.Tenant{
 			ID:                    id,

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -357,32 +357,13 @@ func TestImportUsers(t *testing.T) {
 }
 
 func TestImportUsersWithPassword(t *testing.T) {
-	const (
-		rawScryptKey    = "jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA=="
-		rawPasswordHash = "V358E8LdWJXAO7muq0CufVpEOXaj8aFiC7T/rcaGieN04q/ZPJ08WhJEHGjj9lz/2TT+/86N5VjVoc5DdBhBiw=="
-		rawSeparator    = "Bw=="
-	)
-	scryptKey, err := base64.StdEncoding.DecodeString(rawScryptKey)
+	scrypt, passwordHash, err := newScryptHash()
 	if err != nil {
-		t.Fatal(err)
-	}
-	saltSeparator, err := base64.StdEncoding.DecodeString(rawSeparator)
-	if err != nil {
-		t.Fatal(err)
-	}
-	scrypt := hash.Scrypt{
-		Key:           scryptKey,
-		SaltSeparator: saltSeparator,
-		Rounds:        8,
-		MemoryCost:    14,
+		t.Fatalf("newScryptHash() = %v", err)
 	}
 
 	uid := randomUID()
 	email := randomEmail(uid)
-	passwordHash, err := base64.StdEncoding.DecodeString(rawPasswordHash)
-	if err != nil {
-		t.Fatal(err)
-	}
 	user := (&auth.UserToImport{}).
 		UID(uid).
 		Email(email).
@@ -411,6 +392,37 @@ func TestImportUsersWithPassword(t *testing.T) {
 	if idToken == "" {
 		t.Errorf("ID Token = empty; want = non-empty")
 	}
+}
+
+func newScryptHash() (*hash.Scrypt, []byte, error) {
+	const (
+		rawScryptKey    = "jxspr8Ki0RYycVU8zykbdLGjFQ3McFUH0uiiTvC8pVMXAn210wjLNmdZJzxUECKbm0QsEmYUSDzZvpjeJ9WmXA=="
+		rawPasswordHash = "V358E8LdWJXAO7muq0CufVpEOXaj8aFiC7T/rcaGieN04q/ZPJ08WhJEHGjj9lz/2TT+/86N5VjVoc5DdBhBiw=="
+		rawSeparator    = "Bw=="
+	)
+
+	scryptKey, err := base64.StdEncoding.DecodeString(rawScryptKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	saltSeparator, err := base64.StdEncoding.DecodeString(rawSeparator)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	passwordHash, err := base64.StdEncoding.DecodeString(rawPasswordHash)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	scrypt := hash.Scrypt{
+		Key:           scryptKey,
+		SaltSeparator: saltSeparator,
+		Rounds:        8,
+		MemoryCost:    14,
+	}
+	return &scrypt, passwordHash, nil
 }
 
 func TestSessionCookie(t *testing.T) {


### PR DESCRIPTION
Adding integration tests for:
* Tenant-scoped user management operations
* OIDC/SAML provider config management operations

```
=== RUN   TestTenantManager
=== RUN   TestTenantManager/CreateTenant()
=== RUN   TestTenantManager/Tenant()
=== RUN   TestTenantManager/Tenants()
=== RUN   TestTenantManager/UserManagement
=== RUN   TestTenantManager/UserManagement/CreateUser()
=== RUN   TestTenantManager/UserManagement/UpdateUser()
=== RUN   TestTenantManager/UserManagement/GetUser()
=== RUN   TestTenantManager/UserManagement/Users()
=== RUN   TestTenantManager/UserManagement/SetCustomUserClaims()
=== RUN   TestTenantManager/UserManagement/EmailVerificationLink()
=== RUN   TestTenantManager/UserManagement/PasswordResetLink()
=== RUN   TestTenantManager/UserManagement/EmailSignInLink()
=== RUN   TestTenantManager/UserManagement/RevokeRefreshTokens()
=== RUN   TestTenantManager/UserManagement/ImportUsers()
=== RUN   TestTenantManager/UserManagement/DeleteUser()
=== RUN   TestTenantManager/OIDCProviderConfig
=== RUN   TestTenantManager/OIDCProviderConfig/CreateOIDCProviderConfig()
=== RUN   TestTenantManager/OIDCProviderConfig/OIDCProviderConfig()
=== RUN   TestTenantManager/OIDCProviderConfig/OIDCProviderConfigs()
=== RUN   TestTenantManager/OIDCProviderConfig/UpdateOIDCProviderConfig()
=== RUN   TestTenantManager/OIDCProviderConfig/DeleteOIDCProviderConfig()
=== RUN   TestTenantManager/SAMLProviderConfig
=== RUN   TestTenantManager/SAMLProviderConfig/CreateSAMLProviderConfig()
=== RUN   TestTenantManager/SAMLProviderConfig/SAMLProviderConfig()
=== RUN   TestTenantManager/SAMLProviderConfig/SAMLProviderConfigs()
=== RUN   TestTenantManager/SAMLProviderConfig/UpdateSAMLProviderConfig()
=== RUN   TestTenantManager/SAMLProviderConfig/DeleteSAMLProviderConfig()
=== RUN   TestTenantManager/UpdateTenant()
=== RUN   TestTenantManager/DeleteTenant()
--- PASS: TestTenantManager (17.52s)
    --- PASS: TestTenantManager/CreateTenant() (0.00s)
    --- PASS: TestTenantManager/Tenant() (0.14s)
    --- PASS: TestTenantManager/Tenants() (0.18s)
    --- PASS: TestTenantManager/UserManagement (8.35s)
        --- PASS: TestTenantManager/UserManagement/CreateUser() (0.00s)
        --- PASS: TestTenantManager/UserManagement/UpdateUser() (1.21s)
        --- PASS: TestTenantManager/UserManagement/GetUser() (0.17s)
        --- PASS: TestTenantManager/UserManagement/Users() (0.20s)
        --- PASS: TestTenantManager/UserManagement/SetCustomUserClaims() (0.57s)
        --- PASS: TestTenantManager/UserManagement/EmailVerificationLink() (0.57s)
        --- PASS: TestTenantManager/UserManagement/PasswordResetLink() (0.69s)
        --- PASS: TestTenantManager/UserManagement/EmailSignInLink() (0.78s)
        --- PASS: TestTenantManager/UserManagement/RevokeRefreshTokens() (1.54s)
        --- PASS: TestTenantManager/UserManagement/ImportUsers() (1.30s)
        --- PASS: TestTenantManager/UserManagement/DeleteUser() (0.70s)
    --- PASS: TestTenantManager/OIDCProviderConfig (2.58s)
        --- PASS: TestTenantManager/OIDCProviderConfig/CreateOIDCProviderConfig() (0.00s)
        --- PASS: TestTenantManager/OIDCProviderConfig/OIDCProviderConfig() (0.20s)
        --- PASS: TestTenantManager/OIDCProviderConfig/OIDCProviderConfigs() (0.22s)
        --- PASS: TestTenantManager/OIDCProviderConfig/UpdateOIDCProviderConfig() (0.68s)
        --- PASS: TestTenantManager/OIDCProviderConfig/DeleteOIDCProviderConfig() (1.06s)
    --- PASS: TestTenantManager/SAMLProviderConfig (4.71s)
        --- PASS: TestTenantManager/SAMLProviderConfig/CreateSAMLProviderConfig() (0.00s)
        --- PASS: TestTenantManager/SAMLProviderConfig/SAMLProviderConfig() (1.27s)
        --- PASS: TestTenantManager/SAMLProviderConfig/SAMLProviderConfigs() (0.22s)
        --- PASS: TestTenantManager/SAMLProviderConfig/UpdateSAMLProviderConfig() (0.49s)
        --- PASS: TestTenantManager/SAMLProviderConfig/DeleteSAMLProviderConfig() (1.14s)
    --- PASS: TestTenantManager/UpdateTenant() (0.26s)
    --- PASS: TestTenantManager/DeleteTenant() (0.37s)
PASS
ok  	firebase.google.com/go/integration/auth	17.611s
```