### PR TITLE
fix(auth): Fix Tenant iterator to return the correct sequence of pointers

### DIFF
--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -343,9 +343,9 @@ func (it *TenantIterator) fetch(pageSize int, pageToken string) (string, error) 
 		return "", err
 	}
 
-	for _, tenant := range result.Tenants {
-		tenant.ID = extractResourceID(tenant.ID)
-		it.tenants = append(it.tenants, &tenant)
+	for i := range result.Tenants {
+		result.Tenants[i].ID = extractResourceID(result.Tenants[i].ID)
+		it.tenants = append(it.tenants, &result.Tenants[i])
 	}
 
 	it.pageInfo.Token = result.NextPageToken

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -1086,6 +1086,13 @@ const tenantResponse = `{
     "enableEmailLinkSignin": true
 }`
 
+const tenantResponse2 = `{
+    "name":"projects/mock-project-id/tenants/tenantID2",
+    "displayName": "Test Tenant 2",
+    "allowPasswordSignup": true,
+    "enableEmailLinkSignin": true
+}`
+
 const tenantNotFoundResponse = `{
 	"error": {
 		"message": "TENANT_NOT_FOUND"
@@ -1095,6 +1102,13 @@ const tenantNotFoundResponse = `{
 var testTenant = &Tenant{
 	ID:                    "tenantID",
 	DisplayName:           "Test Tenant",
+	AllowPasswordSignUp:   true,
+	EnableEmailLinkSignIn: true,
+}
+
+var testTenant2 = &Tenant{
+	ID:                    "tenantID2",
+	DisplayName:           "Test Tenant 2",
 	AllowPasswordSignUp:   true,
 	EnableEmailLinkSignIn: true,
 }
@@ -1423,13 +1437,13 @@ func TestTenants(t *testing.T) {
                 ],
                 "nextPageToken": ""
         }`
-	response := fmt.Sprintf(template, tenantResponse, tenantResponse, tenantResponse)
+	response := fmt.Sprintf(template, tenantResponse, tenantResponse2, tenantResponse)
 	s := echoServer([]byte(response), t)
 	defer s.Close()
 
 	want := []*Tenant{
 		testTenant,
-		testTenant,
+		testTenant2,
 		testTenant,
 	}
 	wantPath := "/projects/mock-project-id/tenants"


### PR DESCRIPTION
Previously, tenant_mgt.go would copy the tenant from the network
response, and return a pointer to it. Then it would re-use the same
memory for the next tenant, resulting in a list of pointers that all
pointed to the last tenant.

This change returns pointers to the network response instead (and as a
bonus, avoids the copy entirely).