### PR TITLE
Renamed WebpushFcmOptions to WebpushFCMOptions

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -554,7 +554,7 @@ type WebpushConfig struct {
 	Headers      map[string]string    `json:"headers,omitempty"`
 	Data         map[string]string    `json:"data,omitempty"`
 	Notification *WebpushNotification `json:"notification,omitempty"`
-	FcmOptions   *WebpushFcmOptions   `json:"fcm_options,omitempty"`
+	FCMOptions   *WebpushFCMOptions   `json:"fcm_options,omitempty"`
 }
 
 // WebpushNotificationAction represents an action that can be performed upon receiving a WebPush notification.
@@ -660,8 +660,8 @@ func (n *WebpushNotification) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// WebpushFcmOptions contains additional options for features provided by the FCM web SDK.
-type WebpushFcmOptions struct {
+// WebpushFCMOptions contains additional options for features provided by the FCM web SDK.
+type WebpushFCMOptions struct {
 	Link string `json:"link,omitempty"`
 }
 

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -311,7 +311,7 @@ var validMessages = []struct {
 					Vibrate:            []int{100, 200, 100},
 					CustomData:         map[string]interface{}{"k1": "v1", "k2": "v2"},
 				},
-				FcmOptions: &WebpushFcmOptions{
+				FCMOptions: &WebpushFCMOptions{
 					Link: "https://link.com",
 				},
 			},
@@ -959,7 +959,7 @@ var invalidMessages = []struct {
 		req: &Message{
 			Webpush: &WebpushConfig{
 				Notification: &WebpushNotification{},
-				FcmOptions: &WebpushFcmOptions{
+				FCMOptions: &WebpushFCMOptions{
 					Link: "link",
 				},
 			},
@@ -972,7 +972,7 @@ var invalidMessages = []struct {
 		req: &Message{
 			Webpush: &WebpushConfig{
 				Notification: &WebpushNotification{},
-				FcmOptions: &WebpushFcmOptions{
+				FCMOptions: &WebpushFCMOptions{
 					Link: "http://link.com",
 				},
 			},

--- a/messaging/messaging_utils.go
+++ b/messaging/messaging_utils.go
@@ -222,8 +222,8 @@ func validateWebpushConfig(webpush *WebpushConfig) error {
 			return fmt.Errorf("multiple specifications for the key %q", k)
 		}
 	}
-	if webpush.FcmOptions != nil {
-		link := webpush.FcmOptions.Link
+	if webpush.FCMOptions != nil {
+		link := webpush.FCMOptions.Link
 		p, err := url.ParseRequestURI(link)
 		if err != nil {
 			return fmt.Errorf("invalid link URL: %q", link)


### PR DESCRIPTION
This is a breaking change. Change proposed against the new v4 branch.

Resolves #260 