### PR TITLE
fix(fcm): correct the iidEndpoint endpoints used for topic management

### DIFF
--- a/messaging/topic_mgt.go
+++ b/messaging/topic_mgt.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	iidEndpoint    = "https://iid.googleapis.com/iid/v1"
-	iidSubscribe   = ":batchAdd"
-	iidUnsubscribe = ":batchRemove"
+	iidSubscribe   = "batchAdd"
+	iidUnsubscribe = "batchRemove"
 )
 
 var iidErrorCodes = map[string]struct{ Code, Msg string }{
@@ -164,7 +164,7 @@ func (c *iidClient) makeTopicManagementRequest(ctx context.Context, req *iidRequ
 
 	request := &internal.Request{
 		Method: http.MethodPost,
-		URL:    fmt.Sprintf("%s/%s", c.iidEndpoint, req.op),
+		URL:    fmt.Sprintf("%s:%s", c.iidEndpoint, req.op),
 		Body:   internal.NewJSONEntity(req),
 	}
 	var result iidResponse

--- a/messaging/topic_mgt_test.go
+++ b/messaging/topic_mgt_test.go
@@ -41,7 +41,7 @@ func TestSubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.iidEndpoint = ts.URL
+	client.iidEndpoint = ts.URL + "/v1"
 
 	resp, err := client.SubscribeToTopic(ctx, []string{"id1", "id2"}, "test-topic")
 	if err != nil {
@@ -84,7 +84,7 @@ func TestUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.iidEndpoint = ts.URL
+	client.iidEndpoint = ts.URL + "/v1"
 
 	resp, err := client.UnsubscribeFromTopic(ctx, []string{"id1", "id2"}, "test-topic")
 	if err != nil {
@@ -125,7 +125,7 @@ func TestTopicManagementError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client.iidEndpoint = ts.URL
+	client.iidEndpoint = ts.URL + "/v1"
 	client.iidClient.httpClient.RetryConfig = nil
 
 	cases := []struct {
@@ -185,7 +185,7 @@ func checkIIDRequest(t *testing.T, b []byte, tr *http.Request, op string) {
 	if tr.Method != http.MethodPost {
 		t.Errorf("Method = %q; want = %q", tr.Method, http.MethodPost)
 	}
-	wantOp := "/" + op
+	wantOp := "/v1:" + op
 	if tr.URL.Path != wantOp {
 		t.Errorf("Path = %q; want = %q", tr.URL.Path, wantOp)
 	}


### PR DESCRIPTION
According to the document https://developers.google.com/instance-id/reference/server,
the endpoints should be:

https://iid.googleapis.com/iid/v1:batchAdd
https://iid.googleapis.com/iid/v1:batchRemove

NOT:

https://iid.googleapis.com/iid/v1/:batchAdd
https://iid.googleapis.com/iid/v1/:batchRemove

RELEASE NOTE: Updated the remote endpoint used by the topic management operations.
