### PR TITLE
chore: Running CI workflow on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: Continuous Integration
-on: push
+on: pull_request
 jobs:
 
   build:


### PR DESCRIPTION
Unless we trigger this workflow on `pull_request` event, we won't get CI coverage for pull requests sent by external contributors.