### PR TITLE
FCM error handling revamp

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -85,6 +85,7 @@ type FirebaseError struct {
 	Code      string
 	String    string
 	Response  *http.Response
+	Ext       map[string]interface{}
 }
 
 func (fe *FirebaseError) Error() string {
@@ -144,6 +145,7 @@ func NewFirebaseError(resp *Response) *FirebaseError {
 		ErrorCode: code,
 		String:    fmt.Sprintf("unexpected http response with status: %d\n%s", resp.Status, string(resp.Body)),
 		Response:  resp.LowLevelResponse(),
+		Ext:       make(map[string]interface{}),
 	}
 }
 

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -82,6 +82,9 @@ func TestPlatformError(t *testing.T) {
 		if fe.Response.StatusCode != http.StatusNotFound {
 			t.Errorf("[%s]: Do() err.Response.StatusCode = %d; want = %d", code, fe.Response.StatusCode, http.StatusNotFound)
 		}
+		if fe.Ext == nil || len(fe.Ext) > 0 {
+			t.Errorf("[%s]: Do() err.Ext = %v; want = empty-map", code, fe.Ext)
+		}
 	}
 }
 
@@ -137,6 +140,9 @@ func TestPlatformErrorWithoutDetails(t *testing.T) {
 		}
 		if fe.Response.StatusCode != httpStatus {
 			t.Errorf("[%d]: Do() err.Response.StatusCode = %d; want = %d", httpStatus, fe.Response.StatusCode, httpStatus)
+		}
+		if fe.Ext == nil || len(fe.Ext) > 0 {
+			t.Errorf("[%d]: Do() err.Ext = %v; want = empty-map", httpStatus, fe.Ext)
 		}
 	}
 }

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -115,6 +115,8 @@ type Response struct {
 // returned response with no impact on the underlying HTTP connection. Closing the Body on the
 // returned response is a No-op.
 func (r *Response) LowLevelResponse() *http.Response {
+	// If the Response instance was initialized manually (as is the case when parsing batch
+	// responses) the resp field may be nil.
 	if r.resp == nil {
 		return nil
 	}

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -115,6 +115,10 @@ type Response struct {
 // returned response with no impact on the underlying HTTP connection. Closing the Body on the
 // returned response is a No-op.
 func (r *Response) LowLevelResponse() *http.Response {
+	if r.resp == nil {
+		return nil
+	}
+
 	resp := *r.resp
 	resp.Body = ioutil.NopCloser(bytes.NewBuffer(r.Body))
 	return &resp

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -869,6 +869,16 @@ func TestNewHttpClientRetryOnResponseReadError(t *testing.T) {
 	}
 }
 
+func TestNilLowLevelResponse(t *testing.T) {
+	r := &Response{
+		resp: nil,
+	}
+
+	if ll := r.LowLevelResponse(); ll != nil {
+		t.Errorf("LowLevelResponse() = %v; want = nil", ll)
+	}
+}
+
 type faultyEntity struct {
 	RequestAttempts int
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -39,71 +39,20 @@ const (
 	apiFormatVersionHeader = "X-GOOG-API-FORMAT-VERSION"
 	apiFormatVersion       = "2"
 
-	internalError                  = "internal-error"
-	invalidAPNSCredentials         = "invalid-apns-credentials"
-	invalidArgument                = "invalid-argument"
-	messageRateExceeded            = "message-rate-exceeded"
-	mismatchedCredential           = "mismatched-credential"
-	registrationTokenNotRegistered = "registration-token-not-registered"
-	serverUnavailable              = "server-unavailable"
-	tooManyTopics                  = "too-many-topics"
-	unknownError                   = "unknown-error"
+	apnsAuthError       = "APNS_AUTH_ERROR"
+	internalError       = "INTERNAL"
+	thirdPartyAuthError = "THIRD_PARTY_AUTH_ERROR"
+	invalidArgument     = "INVALID_ARGUMENT"
+	quotaExceeded       = "QUOTA_EXCEEDED"
+	senderIDMismatch    = "SENDER_ID_MISMATCH"
+	unregistered        = "UNREGISTERED"
+	unavailable         = "UNAVAILABLE"
 
 	rfc3339Zulu = "2006-01-02T15:04:05.000000000Z"
 )
 
 var (
 	topicNamePattern = regexp.MustCompile("^(/topics/)?(private/)?[a-zA-Z0-9-_.~%]+$")
-
-	fcmErrorCodes = map[string]struct{ Code, Msg string }{
-		// FCM v1 canonical error codes
-		"NOT_FOUND": {
-			registrationTokenNotRegistered,
-			"app instance has been unregistered; code: " + registrationTokenNotRegistered,
-		},
-		"PERMISSION_DENIED": {
-			mismatchedCredential,
-			"sender id does not match registration token; code: " + mismatchedCredential,
-		},
-		"RESOURCE_EXHAUSTED": {
-			messageRateExceeded,
-			"messaging service quota exceeded; code: " + messageRateExceeded,
-		},
-		"UNAUTHENTICATED": {
-			invalidAPNSCredentials,
-			"apns certificate or auth key was invalid; code: " + invalidAPNSCredentials,
-		},
-
-		// FCM v1 new error codes
-		"APNS_AUTH_ERROR": {
-			invalidAPNSCredentials,
-			"apns certificate or auth key was invalid; code: " + invalidAPNSCredentials,
-		},
-		"INTERNAL": {
-			internalError,
-			"backend servers encountered an unknown internl error; code: " + internalError,
-		},
-		"INVALID_ARGUMENT": {
-			invalidArgument,
-			"request contains an invalid argument; code: " + invalidArgument,
-		},
-		"SENDER_ID_MISMATCH": {
-			mismatchedCredential,
-			"sender id does not match registration token; code: " + mismatchedCredential,
-		},
-		"QUOTA_EXCEEDED": {
-			messageRateExceeded,
-			"messaging service quota exceeded; code: " + messageRateExceeded,
-		},
-		"UNAVAILABLE": {
-			serverUnavailable,
-			"backend servers are temporarily unavailable; code: " + serverUnavailable,
-		},
-		"UNREGISTERED": {
-			registrationTokenNotRegistered,
-			"app instance has been unregistered; code: " + registrationTokenNotRegistered,
-		},
-	}
 )
 
 // Message to be sent via Firebase Cloud Messaging.
@@ -994,52 +943,95 @@ func (c *fcmClient) makeSendRequest(ctx context.Context, req *fcmRequest) (strin
 
 // IsInternal checks if the given error was due to an internal server error.
 func IsInternal(err error) bool {
-	return internal.HasErrorCode(err, internalError)
+	return hasMessagingErrorCode(err, internalError)
 }
 
 // IsInvalidAPNSCredentials checks if the given error was due to invalid APNS certificate or auth
 // key.
+//
+// Deprecated. Use IsThirdPartyAuthError().
 func IsInvalidAPNSCredentials(err error) bool {
-	return internal.HasErrorCode(err, invalidAPNSCredentials)
+	return IsThirdPartyAuthError(err)
+}
+
+// IsThirdPartyAuthError checks if the given error was due to invalid APNS certificate or auth
+// key.
+func IsThirdPartyAuthError(err error) bool {
+	return hasMessagingErrorCode(err, thirdPartyAuthError) || hasMessagingErrorCode(err, apnsAuthError)
 }
 
 // IsInvalidArgument checks if the given error was due to an invalid argument in the request.
 func IsInvalidArgument(err error) bool {
-	return internal.HasErrorCode(err, invalidArgument)
+	return hasMessagingErrorCode(err, invalidArgument)
 }
 
 // IsMessageRateExceeded checks if the given error was due to the client exceeding a quota.
+//
+// Deprecated. Use IsQuotaExceeded().
 func IsMessageRateExceeded(err error) bool {
-	return internal.HasErrorCode(err, messageRateExceeded)
+	return IsQuotaExceeded(err)
+}
+
+// IsQuotaExceeded checks if the given error was due to the client exceeding a quota.
+func IsQuotaExceeded(err error) bool {
+	return hasMessagingErrorCode(err, quotaExceeded)
 }
 
 // IsMismatchedCredential checks if the given error was due to an invalid credential or permission
 // error.
+//
+// Deprecated. Use IsSenderIDMismatch().
 func IsMismatchedCredential(err error) bool {
-	return internal.HasErrorCode(err, mismatchedCredential)
+	return IsSenderIDMismatch(err)
+}
+
+// IsSenderIDMismatch checks if the given error was due to an invalid credential or permission
+// error.
+func IsSenderIDMismatch(err error) bool {
+	return hasMessagingErrorCode(err, senderIDMismatch)
 }
 
 // IsRegistrationTokenNotRegistered checks if the given error was due to a registration token that
 // became invalid.
+//
+// Deprecated. Use IsUnregistered().
 func IsRegistrationTokenNotRegistered(err error) bool {
-	return internal.HasErrorCode(err, registrationTokenNotRegistered)
+	return IsUnregistered(err)
+}
+
+// IsUnregistered checks if the given error was due to a registration token that
+// became invalid.
+func IsUnregistered(err error) bool {
+	return hasMessagingErrorCode(err, unregistered)
 }
 
 // IsServerUnavailable checks if the given error was due to the backend server being temporarily
 // unavailable.
+//
+// Deprecated. Use IsUnavailable().
 func IsServerUnavailable(err error) bool {
-	return internal.HasErrorCode(err, serverUnavailable)
+	return IsUnavailable(err)
+}
+
+// IsUnavailable checks if the given error was due to the backend server being temporarily
+// unavailable.
+func IsUnavailable(err error) bool {
+	return hasMessagingErrorCode(err, unavailable)
 }
 
 // IsTooManyTopics checks if the given error was due to the client exceeding the allowed number
 // of topics.
+//
+// Deprecated. Always returns false.
 func IsTooManyTopics(err error) bool {
-	return internal.HasErrorCode(err, tooManyTopics)
+	return false
 }
 
 // IsUnknown checks if the given error was due to unknown error returned by the backend server.
+//
+// Deprecated. Always returns false.
 func IsUnknown(err error) bool {
-	return internal.HasErrorCode(err, unknownError)
+	return false
 }
 
 type fcmRequest struct {
@@ -1051,10 +1043,8 @@ type fcmResponse struct {
 	Name string `json:"name"`
 }
 
-type fcmError struct {
+type fcmErrorResponse struct {
 	Error struct {
-		Status  string `json:"status"`
-		Message string `json:"message"`
 		Details []struct {
 			Type      string `json:"@type"`
 			ErrorCode string `json:"errorCode"`
@@ -1063,29 +1053,25 @@ type fcmError struct {
 }
 
 func handleFCMError(resp *internal.Response) error {
-	var fe fcmError
+	base := internal.NewFirebaseErrorOnePlatform(resp)
+	var fe fcmErrorResponse
 	json.Unmarshal(resp.Body, &fe) // ignore any json parse errors at this level
-	var serverCode string
 	for _, d := range fe.Error.Details {
 		if d.Type == "type.googleapis.com/google.firebase.fcm.v1.FcmError" {
-			serverCode = d.ErrorCode
+			base.Ext["messagingErrorCode"] = d.ErrorCode
 			break
 		}
 	}
-	if serverCode == "" {
-		serverCode = fe.Error.Status
+
+	return base
+}
+
+func hasMessagingErrorCode(err error, code string) bool {
+	fe, ok := err.(*internal.FirebaseError)
+	if !ok {
+		return false
 	}
 
-	var clientCode, msg string
-	info, ok := fcmErrorCodes[serverCode]
-	if ok {
-		clientCode, msg = info.Code, info.Msg
-	} else {
-		clientCode = unknownError
-		msg = fmt.Sprintf("server responded with an unknown error; response: %s", string(resp.Body))
-	}
-	if fe.Error.Message != "" {
-		msg += "; details: " + fe.Error.Message
-	}
-	return internal.Errorf(clientCode, "http error status: %d; reason: %s", resp.Status, msg)
+	got, ok := fe.Ext["messagingErrorCode"]
+	return ok && got == code
 }

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"firebase.google.com/go/v4/errorutils"
 	"firebase.google.com/go/v4/internal"
 	"google.golang.org/api/option"
 )
@@ -1172,11 +1173,11 @@ func TestSendError(t *testing.T) {
 	client.fcmEndpoint = ts.URL
 	client.fcmClient.httpClient.RetryConfig = nil
 
-	for _, tc := range httpErrors {
+	for idx, tc := range httpErrors {
 		resp = tc.resp
 		name, err := client.Send(ctx, &Message{Topic: "topic"})
 		if err == nil || err.Error() != tc.want || !tc.check(err) {
-			t.Errorf("Send() = (%q, %v); want = (%q, %q)", name, err, "", tc.want)
+			t.Errorf("Send(%d) = (%q, %v); want = (%q, %q)", idx, name, err, "", tc.want)
 		}
 	}
 }
@@ -1240,60 +1241,89 @@ var httpErrors = []struct {
 }{
 	{
 		resp:  "{}",
-		want:  "http error status: 500; reason: server responded with an unknown error; response: {}",
-		check: IsUnknown,
+		want:  "unexpected http response with status: 500\n{}",
+		check: errorutils.IsInternal,
 	},
 	{
 		resp:  "{\"error\": {\"status\": \"INVALID_ARGUMENT\", \"message\": \"test error\"}}",
-		want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument; details: test error",
-		check: IsInvalidArgument,
+		want:  "test error",
+		check: errorutils.IsInvalidArgument,
 	},
 	{
-		resp: "{\"error\": {\"status\": \"NOT_FOUND\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
-			"details: test error",
-		check: IsRegistrationTokenNotRegistered,
+		resp:  "{\"error\": {\"status\": \"NOT_FOUND\", \"message\": \"test error\"}}",
+		want:  "test error",
+		check: errorutils.IsNotFound,
 	},
 	{
-		resp: "{\"error\": {\"status\": \"QUOTA_EXCEEDED\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: messaging service quota exceeded; code: message-rate-exceeded; " +
-			"details: test error",
-		check: IsMessageRateExceeded,
+		resp:  "{\"error\": {\"status\": \"RESOURCE_EXHAUSTED\", \"message\": \"test error\"}}",
+		want:  "test error",
+		check: errorutils.IsResourceExhausted,
 	},
 	{
-		resp: "{\"error\": {\"status\": \"UNAVAILABLE\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: backend servers are temporarily unavailable; code: server-unavailable; " +
-			"details: test error",
-		check: IsServerUnavailable,
+		resp:  "{\"error\": {\"status\": \"UNAVAILABLE\", \"message\": \"test error\"}}",
+		want:  "test error",
+		check: errorutils.IsUnavailable,
 	},
 	{
-		resp: "{\"error\": {\"status\": \"INTERNAL\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: backend servers encountered an unknown internl error; code: internal-error; " +
-			"details: test error",
-		check: IsInternal,
-	},
-	{
-		resp: "{\"error\": {\"status\": \"APNS_AUTH_ERROR\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: apns certificate or auth key was invalid; code: invalid-apns-credentials; " +
-			"details: test error",
-		check: IsInvalidAPNSCredentials,
-	},
-	{
-		resp: "{\"error\": {\"status\": \"SENDER_ID_MISMATCH\", \"message\": \"test error\"}}",
-		want: "http error status: 500; reason: sender id does not match registration token; code: mismatched-credential; " +
-			"details: test error",
-		check: IsMismatchedCredential,
+		resp:  "{\"error\": {\"status\": \"INTERNAL\", \"message\": \"test error\"}}",
+		want:  "test error",
+		check: errorutils.IsInternal,
 	},
 	{
 		resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
 			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "UNREGISTERED"}]}}`,
-		want: "http error status: 500; reason: app instance has been unregistered; code: registration-token-not-registered; " +
-			"details: test error",
-		check: IsRegistrationTokenNotRegistered,
+		want: "test error",
+		check: func(err error) bool {
+			return IsRegistrationTokenNotRegistered(err) && IsUnregistered(err)
+		},
+	},
+	{
+		resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "SENDER_ID_MISMATCH"}]}}`,
+		want: "test error",
+		check: func(err error) bool {
+			return IsMismatchedCredential(err) && IsSenderIDMismatch(err)
+		},
+	},
+	{
+		resp: `{"error": {"status": "RESOURCE_EXHAUSTED", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "QUOTA_EXCEEDED"}]}}`,
+		want: "test error",
+		check: func(err error) bool {
+			return IsMessageRateExceeded(err) && IsQuotaExceeded(err)
+		},
+	},
+	{
+		resp: `{"error": {"status": "UNAVAILABLE", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "UNAVAILABLE"}]}}`,
+		want: "test error",
+		check: func(err error) bool {
+			return IsServerUnavailable(err) && IsUnavailable(err)
+		},
+	},
+	{
+		resp: `{"error": {"status": "INTERNAL", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "INTERNAL"}]}}`,
+		want:  "test error",
+		check: IsInternal,
+	},
+	{
+		resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "INVALID_ARGUMENT"}]}}`,
+		want:  "test error",
+		check: IsInvalidArgument,
+	},
+	{
+		resp: `{"error": {"status": "INVALID_ARGUMENT", "message": "test error", "details": [` +
+			`{"@type": "type.googleapis.com/google.firebase.fcm.v1.FcmError", "errorCode": "THIRD_PARTY_AUTH_ERROR"}]}}`,
+		want: "test error",
+		check: func(err error) bool {
+			return IsInvalidAPNSCredentials(err) && IsThirdPartyAuthError(err)
+		},
 	},
 	{
 		resp:  "not json",
-		want:  "http error status: 500; reason: server responded with an unknown error; response: not json",
-		check: IsUnknown,
+		want:  "unexpected http response with status: 500\nnot json",
+		check: errorutils.IsInternal,
 	},
 }

--- a/messaging/topic_mgt.go
+++ b/messaging/topic_mgt.go
@@ -30,25 +30,6 @@ const (
 	iidUnsubscribe = ":batchRemove"
 )
 
-var iidErrorCodes = map[string]struct{ Code, Msg string }{
-	"INVALID_ARGUMENT": {
-		invalidArgument,
-		"request contains an invalid argument; code: " + invalidArgument,
-	},
-	"NOT_FOUND": {
-		registrationTokenNotRegistered,
-		"request contains an invalid argument; code: " + registrationTokenNotRegistered,
-	},
-	"INTERNAL": {
-		internalError,
-		"server encountered an internal error; code: " + internalError,
-	},
-	"TOO_MANY_TOPICS": {
-		tooManyTopics,
-		"client exceeded the number of allowed topics; code: " + tooManyTopics,
-	},
-}
-
 // TopicManagementResponse is the result produced by topic management operations.
 //
 // TopicManagementResponse provides an overview of how many input tokens were successfully handled,
@@ -67,14 +48,7 @@ func newTopicManagementResponse(resp *iidResponse) *TopicManagementResponse {
 			tmr.SuccessCount++
 		} else {
 			tmr.FailureCount++
-			code := res["error"].(string)
-			info, ok := iidErrorCodes[code]
-			var reason string
-			if ok {
-				reason = info.Msg
-			} else {
-				reason = unknownError
-			}
+			reason := res["error"].(string)
 			tmr.Errors = append(tmr.Errors, &ErrorInfo{
 				Index:  idx,
 				Reason: reason,
@@ -134,7 +108,7 @@ type iidResponse struct {
 	Results []map[string]interface{} `json:"results"`
 }
 
-type iidError struct {
+type iidErrorResponse struct {
 	Error string `json:"error"`
 }
 
@@ -176,15 +150,12 @@ func (c *iidClient) makeTopicManagementRequest(ctx context.Context, req *iidRequ
 }
 
 func handleIIDError(resp *internal.Response) error {
-	var ie iidError
+	base := internal.NewFirebaseError(resp)
+	var ie iidErrorResponse
 	json.Unmarshal(resp.Body, &ie) // ignore any json parse errors at this level
-	var clientCode, msg string
-	info, ok := iidErrorCodes[ie.Error]
-	if ok {
-		clientCode, msg = info.Code, info.Msg
-	} else {
-		clientCode = unknownError
-		msg = fmt.Sprintf("client encountered an unknown error; response: %s", string(resp.Body))
+	if ie.Error != "" {
+		base.String = fmt.Sprintf("error while calling the iid service: %s", ie.Error)
 	}
-	return internal.Errorf(clientCode, "http error status: %d; reason: %s", resp.Status, msg)
+
+	return base
 }

--- a/messaging/topic_mgt_test.go
+++ b/messaging/topic_mgt_test.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"firebase.google.com/go/v4/errorutils"
 )
 
 func TestSubscribe(t *testing.T) {
@@ -113,8 +115,9 @@ func TestInvalidUnsubscribe(t *testing.T) {
 
 func TestTopicManagementError(t *testing.T) {
 	var resp string
+	var status int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(status)
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(resp))
 	}))
@@ -129,42 +132,45 @@ func TestTopicManagementError(t *testing.T) {
 	client.iidClient.httpClient.RetryConfig = nil
 
 	cases := []struct {
-		resp, want string
-		check      func(error) bool
+		name, resp, want string
+		status           int
+		check            func(err error) bool
 	}{
 		{
-			resp:  "{}",
-			want:  "http error status: 500; reason: client encountered an unknown error; response: {}",
-			check: IsUnknown,
+			name:   "EmptyResponse",
+			resp:   "{}",
+			want:   "unexpected http response with status: 500\n{}",
+			status: http.StatusInternalServerError,
+			check:  errorutils.IsInternal,
 		},
 		{
-			resp:  "{\"error\": \"INVALID_ARGUMENT\"}",
-			want:  "http error status: 500; reason: request contains an invalid argument; code: invalid-argument",
-			check: IsInvalidArgument,
+			name:   "ErrorCode",
+			resp:   "{\"error\": \"INVALID_ARGUMENT\"}",
+			want:   "error while calling the iid service: INVALID_ARGUMENT",
+			status: http.StatusBadRequest,
+			check:  errorutils.IsInvalidArgument,
 		},
 		{
-			resp:  "{\"error\": \"TOO_MANY_TOPICS\"}",
-			want:  "http error status: 500; reason: client exceeded the number of allowed topics; code: too-many-topics",
-			check: IsTooManyTopics,
-		},
-		{
-			resp:  "not json",
-			want:  "http error status: 500; reason: client encountered an unknown error; response: not json",
-			check: IsUnknown,
+			name:   "NotJson",
+			resp:   "not json",
+			want:   "unexpected http response with status: 500\nnot json",
+			status: http.StatusInternalServerError,
+			check:  errorutils.IsInternal,
 		},
 	}
+
 	for _, tc := range cases {
 		resp = tc.resp
+		status = tc.status
+
 		tmr, err := client.SubscribeToTopic(ctx, []string{"id1"}, "topic")
 		if err == nil || err.Error() != tc.want || !tc.check(err) {
-			t.Errorf("SubscribeToTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
+			t.Errorf("SubscribeToTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, tmr, err, tc.want)
 		}
-	}
-	for _, tc := range cases {
-		resp = tc.resp
-		tmr, err := client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
-		if err == nil || err.Error() != tc.want {
-			t.Errorf("UnsubscribeFromTopic() = (%#v, %v); want = (nil, %q)", tmr, err, tc.want)
+
+		tmr, err = client.UnsubscribeFromTopic(ctx, []string{"id1"}, "topic")
+		if err == nil || err.Error() != tc.want || !tc.check(err) {
+			t.Errorf("UnsubscribeFromTopic(%s) = (%#v, %v); want = (nil, %q)", tc.name, tmr, err, tc.want)
 		}
 	}
 }
@@ -208,8 +214,8 @@ func checkTopicMgtResponse(t *testing.T, resp *TopicManagementResponse) {
 	if e.Index != 1 {
 		t.Errorf("ErrorInfo.Index = %d; want = %d", e.Index, 1)
 	}
-	if e.Reason != "unknown-error" {
-		t.Errorf("ErrorInfo.Reason = %s; want = %s", e.Reason, "unknown-error")
+	if e.Reason != "error_reason" {
+		t.Errorf("ErrorInfo.Reason = %s; want = %s", e.Reason, "error_reason")
 	}
 }
 


### PR DESCRIPTION
* Deprecated the old error handling functions in the `messaging` package.
* Introduced new error handling functions as replacements.
* `messaging.ErrorInfo.Reason` now contains the original error code sent by the IID service instead of a custom SDK-generated error message.