### PR TITLE
Removing deprecated HTTP and error handling utils

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -106,7 +106,6 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 
 	hc := internal.WithDefaultRetryConfig(transport)
 	hc.CreateErrFn = handleHTTPError
-	hc.SuccessFn = internal.HasSuccessStatus
 	hc.Opts = []internal.HTTPOption{
 		internal.WithHeader("X-Client-Version", fmt.Sprintf("Go/Admin/%s", conf.Version)),
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -306,6 +306,7 @@ func TestCustomTokenInvalidCredential(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s.signer.(*iamSigner).httpClient.RetryConfig = nil
 	token, err := s.CustomToken(ctx, "user1")
 	if token != "" || err == nil {
 		t.Errorf("CustomTokenWithClaims() = (%q, %v); want = (\"\", error)", token, err)

--- a/db/db.go
+++ b/db/db.go
@@ -69,7 +69,6 @@ func NewClient(ctx context.Context, c *internal.DatabaseConfig) (*Client, error)
 	}
 
 	hc.CreateErrFn = handleRTDBError
-	hc.SuccessFn = internal.HasSuccessStatus
 	return &Client{
 		hc:           hc,
 		url:          fmt.Sprintf("https://%s", p.Host),

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -121,7 +121,6 @@ func NewClient(ctx context.Context, c *internal.InstanceIDConfig) (*Client, erro
 	}
 
 	hc.CreateErrFn = createError
-	hc.SuccessFn = internal.HasSuccessStatus
 	return &Client{
 		endpoint: iidEndpoint,
 		client:   hc,

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -82,7 +82,6 @@ const (
 // FirebaseError is an error type containing an error code string.
 type FirebaseError struct {
 	ErrorCode ErrorCode
-	Code      string
 	String    string
 	Response  *http.Response
 	Ext       map[string]interface{}
@@ -96,31 +95,6 @@ func (fe *FirebaseError) Error() string {
 func HasPlatformErrorCode(err error, code ErrorCode) bool {
 	fe, ok := err.(*FirebaseError)
 	return ok && fe.ErrorCode == code
-}
-
-// HasErrorCode checks if the given error contain a specific error code.
-//
-// Deprecated.
-func HasErrorCode(err error, code string) bool {
-	fe, ok := err.(*FirebaseError)
-	return ok && fe.Code == code
-}
-
-// Error creates a new FirebaseError from the specified error code and message.
-//
-// Deprecated.
-func Error(code string, msg string) *FirebaseError {
-	return &FirebaseError{
-		Code:   code,
-		String: msg,
-	}
-}
-
-// Errorf creates a new FirebaseError from the specified error code and message.
-//
-// Deprecated.
-func Errorf(code string, msg string, args ...interface{}) *FirebaseError {
-	return Error(code, fmt.Sprintf(msg, args...))
 }
 
 var httpStatusToErrorCodes = map[int]ErrorCode{

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -43,8 +43,7 @@ func TestPlatformError(t *testing.T) {
 	defer server.Close()
 
 	client := &HTTPClient{
-		Client:    http.DefaultClient,
-		SuccessFn: HasSuccessStatus,
+		Client: http.DefaultClient,
 	}
 	get := &Request{
 		Method: http.MethodGet,
@@ -98,8 +97,7 @@ func TestPlatformErrorWithoutDetails(t *testing.T) {
 	defer server.Close()
 
 	client := &HTTPClient{
-		Client:    http.DefaultClient,
-		SuccessFn: HasSuccessStatus,
+		Client: http.DefaultClient,
 	}
 	get := &Request{
 		Method: http.MethodGet,

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -16,7 +16,9 @@ package internal
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -142,5 +144,54 @@ func TestPlatformErrorWithoutDetails(t *testing.T) {
 		if fe.Ext == nil || len(fe.Ext) > 0 {
 			t.Errorf("[%d]: Do() err.Ext = %v; want = empty-map", httpStatus, fe.Ext)
 		}
+	}
+}
+
+func TestErrorHTTPResponse(t *testing.T) {
+	body := `{"key": "value"}`
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(body))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	client := &HTTPClient{
+		Client: http.DefaultClient,
+	}
+	get := &Request{
+		Method: http.MethodGet,
+		URL:    server.URL,
+	}
+	want := fmt.Sprintf("unexpected http response with status: 500\n%s", body)
+
+	resp, err := client.Do(context.Background(), get)
+	if resp != nil || err == nil || err.Error() != want {
+		t.Fatalf("Do() = (%v, %v); want = (nil, %q)", resp, err, want)
+	}
+
+	fe, ok := err.(*FirebaseError)
+	if !ok {
+		t.Fatalf("Do() err = %v; want = FirebaseError", err)
+	}
+
+	hr := fe.Response
+	defer hr.Body.Close()
+	if hr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("Do() Response.StatusCode = %d; want = %d", hr.StatusCode, http.StatusInternalServerError)
+	}
+
+	b, err := ioutil.ReadAll(hr.Body)
+	if err != nil {
+		t.Fatalf("ReadAll(Response.Body) = %v", err)
+	}
+
+	var m map[string]string
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("Unmarshal(Response.Body) = %v", err)
+	}
+
+	if len(m) != 1 || m["key"] != "value" {
+		t.Errorf("Unmarshal(Response.Body) = %v; want = {key: value}", m)
 	}
 }

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -219,14 +219,11 @@ func (c *HTTPClient) success(req *Request, resp *Response) bool {
 		successFn = req.SuccessFn
 	} else if c.SuccessFn != nil {
 		successFn = c.SuccessFn
+	} else {
+		successFn = HasSuccessStatus
 	}
 
-	if successFn != nil {
-		return successFn(resp)
-	}
-
-	// TODO: Default to HasSuccessStatusCode
-	return true
+	return successFn(resp)
 }
 
 func (c *HTTPClient) newError(req *Request, resp *Response) error {

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -166,20 +166,13 @@ func TestHTTPClient(t *testing.T) {
 	client := &HTTPClient{Client: http.DefaultClient}
 	for _, tc := range testRequests {
 		tc.req.URL = server.URL
-		resp, err := client.Do(context.Background(), tc.req)
+		var got map[string]interface{}
+		resp, err := client.DoAndUnmarshal(context.Background(), tc.req, &got)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := resp.CheckStatus(http.StatusOK); err != nil {
-			t.Errorf("CheckStatus() = %v; want nil", err)
-		}
-		if err := resp.CheckStatus(http.StatusCreated); err == nil {
-			t.Errorf("CheckStatus() = nil; want error")
-		}
-
-		var got map[string]interface{}
-		if err := resp.Unmarshal(http.StatusOK, &got); err != nil {
-			t.Errorf("Unmarshal() = %v; want nil", err)
+		if resp.Status != http.StatusOK {
+			t.Errorf("Status = %d; want = %d", resp.Status, http.StatusOK)
 		}
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("Body = %v; want = %v", got, want)
@@ -364,9 +357,6 @@ func TestContext(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resp.CheckStatus(http.StatusOK); err != nil {
-		t.Fatal(err)
-	}
 
 	cancel()
 	resp, err = client.Do(ctx, &Request{
@@ -375,55 +365,6 @@ func TestContext(t *testing.T) {
 	})
 	if resp != nil || err == nil {
 		t.Errorf("Do() = (%v; %v); want = (nil, error)", resp, err)
-	}
-}
-
-func TestErrorParser(t *testing.T) {
-	data := map[string]interface{}{
-		"error": "test error",
-	}
-	b, err := json.Marshal(data)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(b)
-	})
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
-	ep := func(b []byte) string {
-		var p struct {
-			Error string `json:"error"`
-		}
-		if err := json.Unmarshal(b, &p); err != nil {
-			return ""
-		}
-		return p.Error
-	}
-	client := &HTTPClient{
-		Client:    http.DefaultClient,
-		ErrParser: ep,
-	}
-	req := &Request{Method: http.MethodGet, URL: server.URL}
-	resp, err := client.Do(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	want := "http error status: 500; reason: test error"
-	if err := resp.CheckStatus(http.StatusOK); err.Error() != want {
-		t.Errorf("CheckStatus() = %q; want = %q", err.Error(), want)
-	}
-	var got map[string]interface{}
-	if err := resp.Unmarshal(http.StatusOK, &got); err.Error() != want {
-		t.Errorf("CheckStatus() = %q; want = %q", err.Error(), want)
-	}
-	if got != nil {
-		t.Errorf("Body = %v; want = nil", got)
 	}
 }
 
@@ -456,14 +397,10 @@ func TestUnmarshalError(t *testing.T) {
 
 	req := &Request{Method: http.MethodGet, URL: server.URL}
 	client := &HTTPClient{Client: http.DefaultClient}
-	resp, err := client.Do(context.Background(), req)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	var got func()
-	if err := resp.Unmarshal(http.StatusOK, &got); err == nil {
-		t.Errorf("Unmarshal() = nil; want error")
+	_, err = client.DoAndUnmarshal(context.Background(), req, &got)
+	if err == nil {
+		t.Errorf("DoAndUnmarshal() = nil; want error")
 	}
 }
 
@@ -487,8 +424,8 @@ func TestRetryDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resp.CheckStatus(http.StatusServiceUnavailable); err != nil {
-		t.Errorf("CheckStatus() = %q; want = nil", err.Error())
+	if resp.Status != http.StatusServiceUnavailable {
+		t.Errorf("Status = %d; want = %d", resp.Status, http.StatusServiceUnavailable)
 	}
 	if requests != 1 {
 		t.Errorf("Total requests = %d; want = 1", requests)
@@ -803,8 +740,8 @@ func TestNewHTTPClientRetryOnHTTPErrors(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := resp.CheckStatus(status); err != nil {
-			t.Errorf("CheckStatus(%d) = %q; want = nil", status, err.Error())
+		if resp.Status != status {
+			t.Errorf("Status = %d; want = %d", resp.Status, status)
 		}
 		wantRequests := 1 + defaultMaxRetries
 		if requests != wantRequests {
@@ -833,8 +770,8 @@ func TestNewHttpClientNoRetryOnNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := resp.CheckStatus(http.StatusNotFound); err != nil {
-		t.Errorf("CheckStatus() = %q; want = nil", err.Error())
+	if resp.Status != http.StatusNotFound {
+		t.Errorf("Status = %d; want = %d", resp.Status, http.StatusNotFound)
 	}
 	if requests != 1 {
 		t.Errorf("Total requests = %d; want = 1", requests)

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -884,7 +884,6 @@ type fcmClient struct {
 func newFCMClient(hc *http.Client, conf *internal.MessagingConfig) *fcmClient {
 	client := internal.WithDefaultRetryConfig(hc)
 	client.CreateErrFn = handleFCMError
-	client.SuccessFn = internal.HasSuccessStatus
 
 	version := fmt.Sprintf("fire-admin-go/%s", conf.Version)
 	client.Opts = []internal.HTTPOption{

--- a/messaging/topic_mgt.go
+++ b/messaging/topic_mgt.go
@@ -66,7 +66,6 @@ type iidClient struct {
 func newIIDClient(hc *http.Client) *iidClient {
 	client := internal.WithDefaultRetryConfig(hc)
 	client.CreateErrFn = handleIIDError
-	client.SuccessFn = internal.HasSuccessStatus
 	client.Opts = []internal.HTTPOption{internal.WithHeader("access_token_auth", "true")}
 	return &iidClient{
 		iidEndpoint: iidEndpoint,


### PR DESCRIPTION
* Make `internal.HasSuccessStatus()` the default error checking function.
* Using `internal.NewHTTPClient()` for `auth.iamSigner` which essentially enables automatic retries for it.
* Removed all deprecated HTTP and error handling utils from the `internal` package.
