### PR TITLE
Expand the scope of accepted valid email addresses

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -458,7 +458,7 @@ func validateEmail(email string) error {
 	if email == "" {
 		return fmt.Errorf("email must be a non-empty string")
 	}
-	if parts := strings.Split(email, "@"); len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	if !strings.Contains(email, "@") {
 		return fmt.Errorf("malformed email string: %q", email)
 	}
 	return nil

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -283,15 +283,6 @@ func TestInvalidCreateUser(t *testing.T) {
 		}, {
 			(&UserToCreate{}).Email("a"),
 			`malformed email string: "a"`,
-		}, {
-			(&UserToCreate{}).Email("a@"),
-			`malformed email string: "a@"`,
-		}, {
-			(&UserToCreate{}).Email("@a"),
-			`malformed email string: "@a"`,
-		}, {
-			(&UserToCreate{}).Email("a@a@a"),
-			`malformed email string: "a@a@a"`,
 		},
 	}
 	client := &Client{


### PR DESCRIPTION
It is possible for an email address to contain more than one @ symbol. Validating email addresses is hard and complicated. The best way to validate an email address is to check for the presence of an @, in proper place or not, and send an email to it. Nothing more.

Closes #351.

I edited this on the web interface, and the patch branch is off of master. Will this be an issue, even though the PR is onto dev?