### PR TITLE
Handling timeouts, connection and other network errors

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -174,7 +174,7 @@ func newFirebaseErrorTransport(err error) *FirebaseError {
 	}
 }
 
-// isConnectionRefused attempts to determine if the given was caused by a failure to establish a
+// isConnectionRefused attempts to determine if the given error was caused by a failure to establish a
 // connection.
 //
 // A net.OpError where the Op field is set to "dial" or "read" is considered a connection refused

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -177,8 +177,8 @@ func newFirebaseErrorTransport(err error) *FirebaseError {
 // isConnectionRefused attempts to determine if the given was caused by a failure to establish a
 // connection.
 //
-// A net.OpError where the Op field is set to "dial" or "read" are considered connection refused
-// errors. Similarly an ECONNREFUSED error code (Linux-specific) is also considered a connection
+// A net.OpError where the Op field is set to "dial" or "read" is considered a connection refused
+// error. Similarly an ECONNREFUSED error code (Linux-specific) is also considered a connection
 // refused error.
 func isConnectionRefused(err error) bool {
 	switch t := err.(type) {

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -203,6 +203,13 @@ func TestNetworkOutageError(t *testing.T) {
 	}{
 		{"NetDialError", &net.OpError{Op: "dial", Err: errors.New("test error")}},
 		{"NetReadError", &net.OpError{Op: "read", Err: errors.New("test error")}},
+		{
+			"WrappedNetReadError",
+			&net.OpError{
+				Op:  "test",
+				Err: &net.OpError{Op: "read", Err: errors.New("test error")},
+			},
+		},
 		{"ECONNREFUSED", syscall.ECONNREFUSED},
 	}
 

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -17,10 +17,14 @@ package internal
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -144,6 +148,135 @@ func TestPlatformErrorWithoutDetails(t *testing.T) {
 		if fe.Ext == nil || len(fe.Ext) > 0 {
 			t.Errorf("[%d]: Do() err.Ext = %v; want = empty-map", httpStatus, fe.Ext)
 		}
+	}
+}
+
+func TestTimeoutError(t *testing.T) {
+	client := &HTTPClient{
+		Client: &http.Client{
+			Transport: &faultyTransport{
+				Err: &timeoutError{},
+			},
+		},
+	}
+	get := &Request{
+		Method: http.MethodGet,
+		URL:    "http://test.url",
+	}
+	want := "timed out while making an http call"
+
+	resp, err := client.Do(context.Background(), get)
+	if resp != nil || err == nil || !strings.HasPrefix(err.Error(), want) {
+		t.Fatalf("Do() = (%v, %v); want = (nil, %q)", resp, err, want)
+	}
+
+	fe, ok := err.(*FirebaseError)
+	if !ok {
+		t.Fatalf("Do() err = %v; want = FirebaseError", err)
+	}
+
+	if fe.ErrorCode != DeadlineExceeded {
+		t.Errorf("Do() err.ErrorCode = %q; want = %q", fe.ErrorCode, DeadlineExceeded)
+	}
+	if fe.Response != nil {
+		t.Errorf("Do() err.Response = %v; want = nil", fe.Response)
+	}
+	if fe.Ext == nil || len(fe.Ext) > 0 {
+		t.Errorf("Do() err.Ext = %v; want = empty-map", fe.Ext)
+	}
+}
+
+type timeoutError struct{}
+
+func (t *timeoutError) Error() string {
+	return "test timeout error"
+}
+
+func (t *timeoutError) Timeout() bool {
+	return true
+}
+
+func TestNetworkOutageError(t *testing.T) {
+	errors := []struct {
+		name string
+		err  error
+	}{
+		{"NetDialError", &net.OpError{Op: "dial", Err: errors.New("test error")}},
+		{"NetReadError", &net.OpError{Op: "read", Err: errors.New("test error")}},
+		{"ECONNREFUSED", syscall.ECONNREFUSED},
+	}
+
+	get := &Request{
+		Method: http.MethodGet,
+		URL:    "http://test.url",
+	}
+	want := "failed to establish a connection"
+
+	for _, tc := range errors {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &HTTPClient{
+				Client: &http.Client{
+					Transport: &faultyTransport{
+						Err: tc.err,
+					},
+				},
+			}
+
+			resp, err := client.Do(context.Background(), get)
+			if resp != nil || err == nil || !strings.HasPrefix(err.Error(), want) {
+				t.Fatalf("Do() = (%v, %v); want = (nil, %q)", resp, err, want)
+			}
+
+			fe, ok := err.(*FirebaseError)
+			if !ok {
+				t.Fatalf("Do() err = %v; want = FirebaseError", err)
+			}
+
+			if fe.ErrorCode != Unavailable {
+				t.Errorf("Do() err.ErrorCode = %q; want = %q", fe.ErrorCode, Unavailable)
+			}
+			if fe.Response != nil {
+				t.Errorf("Do() err.Response = %v; want = nil", fe.Response)
+			}
+			if fe.Ext == nil || len(fe.Ext) > 0 {
+				t.Errorf("Do() err.Ext = %v; want = empty-map", fe.Ext)
+			}
+		})
+	}
+}
+
+func TestUnknownNetworkError(t *testing.T) {
+	client := &HTTPClient{
+		Client: &http.Client{
+			Transport: &faultyTransport{
+				Err: errors.New("unknown error"),
+			},
+		},
+	}
+	get := &Request{
+		Method: http.MethodGet,
+		URL:    "http://test.url",
+	}
+	want := "unknown error while making an http call"
+
+	resp, err := client.Do(context.Background(), get)
+	if resp != nil || err == nil || !strings.HasPrefix(err.Error(), want) {
+		t.Fatalf("Do() = (%v, %v); want = (nil, %q)", resp, err, want)
+	}
+
+	fe, ok := err.(*FirebaseError)
+	if !ok {
+		t.Fatalf("Do() err = %v; want = FirebaseError", err)
+	}
+
+	if fe.ErrorCode != Unknown {
+		t.Errorf("Do() err.ErrorCode = %q; want = %q", fe.ErrorCode, Unknown)
+	}
+	if fe.Response != nil {
+		t.Errorf("Do() err.Response = %v; want = nil", fe.Response)
+	}
+	if fe.Ext == nil || len(fe.Ext) > 0 {
+		t.Errorf("Do() err.Ext = %v; want = empty-map", fe.Ext)
 	}
 }
 

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -202,8 +202,7 @@ func (c *HTTPClient) attempt(ctx context.Context, hr *http.Request, retries int)
 
 func (c *HTTPClient) handleResult(req *Request, result *attemptResult) (*Response, error) {
 	if result.Err != nil {
-		// TODO: Handle transport and I/O errors.
-		return nil, result.Err
+		return nil, newFirebaseErrorTransport(result.Err)
 	}
 
 	if !c.success(req, result.Resp) {

--- a/internal/http_client_test.go
+++ b/internal/http_client_test.go
@@ -834,10 +834,15 @@ func (e *faultyEntity) Mime() string {
 
 type faultyTransport struct {
 	RequestAttempts int
+	Err             error
 }
 
 func (e *faultyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	e.RequestAttempts++
+	if e.Err != nil {
+		return nil, e.Err
+	}
+
 	return nil, errors.New("test error")
 }
 


### PR DESCRIPTION
Handling low-level transport errors:
  * Timeouts: DeadlineExceeded
  * Connection errors: Unavailable
  * Everything else: Unknown

I'm using `os.IsTimeout()` function to detect timeout errors. There's no similar util for detecting connection errors, so I implemented one. Most errors returned by the `http` package are wrapped in `url.Error`, so we need to unwrap it to get to the original error. Some of the error conditions this implementation looks for is Linux specific, but probably good enough for us to start with. 