### PR TITLE
fix: Deferring credential loading until required

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -57,14 +57,18 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		signer cryptoSigner
 		err    error
 	)
+
+	creds, _ := transport.Creds(ctx, conf.Opts...)
+
 	// Initialize a signer by following the go/firebase-admin-sign protocol.
-	if conf.Creds != nil && len(conf.Creds.JSON) > 0 {
+	if creds != nil && len(creds.JSON) > 0 {
 		// If the SDK was initialized with a service account, use it to sign bytes.
-		signer, err = signerFromCreds(conf.Creds.JSON)
+		signer, err = signerFromCreds(creds.JSON)
 		if err != nil && err != errNotAServiceAcct {
 			return nil, err
 		}
 	}
+
 	if signer == nil {
 		if conf.ServiceAccountID != "" {
 			// If the SDK was initialized with a service account email, use it with the IAM service

--- a/firebase.go
+++ b/firebase.go
@@ -31,7 +31,6 @@ import (
 	"firebase.google.com/go/internal"
 	"firebase.google.com/go/messaging"
 	"firebase.google.com/go/storage"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
 )
@@ -47,7 +46,6 @@ const firebaseEnvName = "FIREBASE_CONFIG"
 // An App holds configuration and state common to all Firebase services that are exposed from the SDK.
 type App struct {
 	authOverride     map[string]interface{}
-	creds            *google.DefaultCredentials
 	dbURL            string
 	projectID        string
 	serviceAccountID string
@@ -67,7 +65,6 @@ type Config struct {
 // Auth returns an instance of auth.Client.
 func (a *App) Auth(ctx context.Context) (*auth.Client, error) {
 	conf := &internal.AuthConfig{
-		Creds:            a.creds,
 		ProjectID:        a.projectID,
 		Opts:             a.opts,
 		ServiceAccountID: a.serviceAccountID,
@@ -142,28 +139,14 @@ func (a *App) Messaging(ctx context.Context) (*messaging.Client, error) {
 func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*App, error) {
 	o := []option.ClientOption{option.WithScopes(internal.FirebaseScopes...)}
 	o = append(o, opts...)
-	creds, err := transport.Creds(ctx, o...)
-	if err != nil {
-		return nil, err
-	}
 	if config == nil {
+		var err error
 		if config, err = getConfigDefaults(); err != nil {
 			return nil, err
 		}
 	}
 
-	var pid string
-	if config.ProjectID != "" {
-		pid = config.ProjectID
-	} else if creds.ProjectID != "" {
-		pid = creds.ProjectID
-	} else {
-		pid = os.Getenv("GOOGLE_CLOUD_PROJECT")
-		if pid == "" {
-			pid = os.Getenv("GCLOUD_PROJECT")
-		}
-	}
-
+	pid := getProjectID(ctx, config, o...)
 	ao := defaultAuthOverrides
 	if config.AuthOverride != nil {
 		ao = *config.AuthOverride
@@ -171,7 +154,6 @@ func NewApp(ctx context.Context, config *Config, opts ...option.ClientOption) (*
 
 	return &App{
 		authOverride:     ao,
-		creds:            creds,
 		dbURL:            config.DatabaseURL,
 		projectID:        pid,
 		serviceAccountID: config.ServiceAccountID,
@@ -212,4 +194,21 @@ func getConfigDefaults() (*Config, error) {
 		fbc.AuthOverride = &nullMap
 	}
 	return fbc, nil
+}
+
+func getProjectID(ctx context.Context, config *Config, opts ...option.ClientOption) string {
+	if config.ProjectID != "" {
+		return config.ProjectID
+	}
+
+	creds, _ := transport.Creds(ctx, opts...)
+	if creds != nil && creds.ProjectID != "" {
+		return creds.ProjectID
+	}
+
+	if pid := os.Getenv("GOOGLE_CLOUD_PROJECT"); pid != "" {
+		return pid
+	}
+
+	return os.Getenv("GCLOUD_PROJECT")
 }

--- a/firebase_test.go
+++ b/firebase_test.go
@@ -58,11 +58,6 @@ func TestServiceAcctFile(t *testing.T) {
 	if len(app.opts) != 2 {
 		t.Errorf("Client opts: %d; want: 2", len(app.opts))
 	}
-	if app.creds == nil {
-		t.Error("Credentials: nil; want creds")
-	} else if len(app.creds.JSON) == 0 {
-		t.Error("JSON: empty; want; non-empty")
-	}
 }
 
 func TestClientOptions(t *testing.T) {
@@ -116,11 +111,6 @@ func TestRefreshTokenFile(t *testing.T) {
 	if len(app.opts) != 2 {
 		t.Errorf("Client opts: %d; want: 2", len(app.opts))
 	}
-	if app.creds == nil {
-		t.Error("Credentials: nil; want creds")
-	} else if len(app.creds.JSON) == 0 {
-		t.Error("JSON: empty; want; non-empty")
-	}
 }
 
 func TestRefreshTokenFileWithConfig(t *testing.T) {
@@ -134,11 +124,6 @@ func TestRefreshTokenFileWithConfig(t *testing.T) {
 	}
 	if len(app.opts) != 2 {
 		t.Errorf("Client opts: %d; want: 2", len(app.opts))
-	}
-	if app.creds == nil {
-		t.Error("Credentials: nil; want creds")
-	} else if len(app.creds.JSON) == 0 {
-		t.Error("JSON: empty; want; non-empty")
 	}
 }
 
@@ -157,11 +142,6 @@ func TestRefreshTokenWithEnvVar(t *testing.T) {
 		}
 		if app.projectID != "mock-project-id" {
 			t.Errorf("[env=%s] Project ID: %q; want: mock-project-id", varName, app.projectID)
-		}
-		if app.creds == nil {
-			t.Errorf("[env=%s] Credentials: nil; want creds", varName)
-		} else if len(app.creds.JSON) == 0 {
-			t.Errorf("[env=%s] JSON: empty; want; non-empty", varName)
 		}
 	}
 	for _, varName := range []string{"GCLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT"} {
@@ -185,11 +165,6 @@ func TestAppDefault(t *testing.T) {
 	if len(app.opts) != 1 {
 		t.Errorf("Client opts: %d; want: 1", len(app.opts))
 	}
-	if app.creds == nil {
-		t.Error("Credentials: nil; want creds")
-	} else if len(app.creds.JSON) == 0 {
-		t.Error("JSON: empty; want; non-empty")
-	}
 }
 
 func TestAppDefaultWithInvalidFile(t *testing.T) {
@@ -201,8 +176,8 @@ func TestAppDefaultWithInvalidFile(t *testing.T) {
 	defer os.Setenv(credEnvVar, current)
 
 	app, err := NewApp(context.Background(), nil)
-	if app != nil || err == nil {
-		t.Errorf("NewApp() = (%v, %v); want: (nil, error)", app, err)
+	if app == nil || err != nil {
+		t.Fatalf("NewApp() = (%v, %v); want = (app, nil)", app, err)
 	}
 }
 
@@ -215,9 +190,17 @@ func TestInvalidCredentialFile(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range invalidFiles {
 		app, err := NewApp(ctx, nil, option.WithCredentialsFile(tc))
-		if app != nil || err == nil {
-			t.Errorf("NewApp(%q) = (%v, %v); want: (nil, error)", tc, app, err)
+		if app == nil || err != nil {
+			t.Fatalf("NewApp() = (%v, %v); want = (app, nil)", app, err)
 		}
+	}
+}
+
+func TestExplicitNoAuth(t *testing.T) {
+	ctx := context.Background()
+	app, err := NewApp(ctx, nil, option.WithoutAuthentication())
+	if app == nil || err != nil {
+		t.Fatalf("NewApp() = (%v, %v); want = (app, nil)", app, err)
 	}
 }
 

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 )
 
@@ -40,7 +39,6 @@ var SystemClock = &systemClock{}
 // AuthConfig represents the configuration of Firebase Auth service.
 type AuthConfig struct {
 	Opts             []option.ClientOption
-	Creds            *google.DefaultCredentials
 	ProjectID        string
 	ServiceAccountID string
 	Version          string


### PR DESCRIPTION
Currently the `firebase.NewApp()` functions attempts to load Google credentials, and fails fast if the ADC lookup fails. But some use cases (e.g. ID token verification) do not require credentials at all. This PR makes the following changes to support such use cases a little better:

1. `firebase` package looks up credentials only to discover a project ID. But this is performed as a "soft" lookup, and errors at this stage are not exposed to the user.
2. The `auth` package performs its own credential look up to discover service account private key. This is also performed as a soft lookup without fail fast (this was in fact the existing behavior of the auth package).

This makes it possible to do things like:

```
app, err := firebase.NewApp(ctx, nil, option.WithoutAuthentication())
if err != nil {
  log.Fatal(err)
}

client, err := app.Auth(ctx)
if err != nil {
  log.Fatal(err)
}

client.VerifyIDToken(ctx, idToken)
```

Resolves #357 