### PR TITLE
feat(auth): Exposing CustomToken() on auth.TenantClient

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -44,8 +44,6 @@ var reservedClaims = []string{
 type Client struct {
 	*baseClient
 	TenantManager *TenantManager
-	signer        cryptoSigner
-	clock         internal.Clock
 }
 
 // NewClient creates a new instance of the Firebase Auth Client.
@@ -116,11 +114,11 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		httpClient:             hc,
 		idTokenVerifier:        idTokenVerifier,
 		cookieVerifier:         cookieVerifier,
+		signer:                 signer,
+		clock:                  internal.SystemClock,
 	}
 	return &Client{
 		baseClient:    base,
-		signer:        signer,
-		clock:         internal.SystemClock,
 		TenantManager: newTenantManager(hc, conf, base),
 	}, nil
 }
@@ -144,13 +142,13 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 //     conjunction with the IAM service to sign tokens remotely.
 //
 // CustomToken returns an error the SDK fails to discover a viable mechanism for signing tokens.
-func (c *Client) CustomToken(ctx context.Context, uid string) (string, error) {
+func (c *baseClient) CustomToken(ctx context.Context, uid string) (string, error) {
 	return c.CustomTokenWithClaims(ctx, uid, nil)
 }
 
 // CustomTokenWithClaims is similar to CustomToken, but in addition to the user ID, it also encodes
 // all the key-value pairs in the provided map as claims in the resulting JWT.
-func (c *Client) CustomTokenWithClaims(ctx context.Context, uid string, devClaims map[string]interface{}) (string, error) {
+func (c *baseClient) CustomTokenWithClaims(ctx context.Context, uid string, devClaims map[string]interface{}) (string, error) {
 	iss, err := c.signer.Email(ctx)
 	if err != nil {
 		return "", err
@@ -176,13 +174,14 @@ func (c *Client) CustomTokenWithClaims(ctx context.Context, uid string, devClaim
 	info := &jwtInfo{
 		header: jwtHeader{Algorithm: "RS256", Type: "JWT"},
 		payload: &customToken{
-			Iss:    iss,
-			Sub:    iss,
-			Aud:    firebaseAudience,
-			UID:    uid,
-			Iat:    now,
-			Exp:    now + oneHourInSeconds,
-			Claims: devClaims,
+			Iss:      iss,
+			Sub:      iss,
+			Aud:      firebaseAudience,
+			UID:      uid,
+			Iat:      now,
+			Exp:      now + oneHourInSeconds,
+			TenantID: c.tenantID,
+			Claims:   devClaims,
 		},
 	}
 	return info.Token(ctx, c.signer)
@@ -235,6 +234,8 @@ type baseClient struct {
 	httpClient             *internal.HTTPClient
 	idTokenVerifier        *tokenVerifier
 	cookieVerifier         *tokenVerifier
+	signer                 cryptoSigner
+	clock                  internal.Clock
 }
 
 func (c *baseClient) withTenantID(tenantID string) *baseClient {

--- a/auth/token_generator.go
+++ b/auth/token_generator.go
@@ -41,13 +41,14 @@ type jwtHeader struct {
 }
 
 type customToken struct {
-	Iss    string                 `json:"iss"`
-	Aud    string                 `json:"aud"`
-	Exp    int64                  `json:"exp"`
-	Iat    int64                  `json:"iat"`
-	Sub    string                 `json:"sub,omitempty"`
-	UID    string                 `json:"uid,omitempty"`
-	Claims map[string]interface{} `json:"claims,omitempty"`
+	Iss      string                 `json:"iss"`
+	Aud      string                 `json:"aud"`
+	Exp      int64                  `json:"exp"`
+	Iat      int64                  `json:"iat"`
+	Sub      string                 `json:"sub,omitempty"`
+	UID      string                 `json:"uid,omitempty"`
+	TenantID string                 `json:"tenant_id,omitempty"`
+	Claims   map[string]interface{} `json:"claims,omitempty"`
 }
 
 type jwtInfo struct {

--- a/integration/auth/auth_test.go
+++ b/integration/auth/auth_test.go
@@ -207,10 +207,19 @@ func verifyCustomToken(t *testing.T, ct, uid string) *auth.Token {
 }
 
 func signInWithCustomToken(token string) (string, error) {
-	req, err := json.Marshal(map[string]interface{}{
+	return signInWithCustomTokenForTenant(token, "")
+}
+
+func signInWithCustomTokenForTenant(token string, tenantID string) (string, error) {
+	payload := map[string]interface{}{
 		"token":             token,
 		"returnSecureToken": true,
-	})
+	}
+	if tenantID != "" {
+		payload["tenantId"] = tenantID
+	}
+
+	req, err := json.Marshal(payload)
 	if err != nil {
 		return "", err
 	}

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -97,6 +97,10 @@ func TestTenantManager(t *testing.T) {
 		}
 	})
 
+	t.Run("CustomTokens", func(t *testing.T) {
+		testTenantAwareCustomToken(t, id)
+	})
+
 	t.Run("UserManagement", func(t *testing.T) {
 		testTenantAwareUserManagement(t, id)
 	})
@@ -152,6 +156,40 @@ func TestTenantManager(t *testing.T) {
 
 		id = ""
 	})
+}
+
+func testTenantAwareCustomToken(t *testing.T, id string) {
+	tenantClient, err := client.TenantManager.AuthForTenant(id)
+	if err != nil {
+		t.Fatalf("AuthForTenant() = %v", err)
+	}
+
+	uid := randomUID()
+	ct, err := tenantClient.CustomToken(context.Background(), uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	idToken, err := signInWithCustomTokenForTenant(ct, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		tenantClient.DeleteUser(context.Background(), uid)
+	}()
+
+	vt, err := tenantClient.VerifyIDToken(context.Background(), idToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if vt.UID != uid {
+		t.Errorf("UID = %q; want UID = %q", vt.UID, uid)
+	}
+	if vt.Firebase.Tenant != id {
+		t.Errorf("Tenant = %q; want = %q", vt.Firebase.Tenant, id)
+	}
 }
 
 func testTenantAwareUserManagement(t *testing.T, id string) {


### PR DESCRIPTION
Implements the ability to mint custom tokens scoped to specific tenants.

Resolves #337 

RELEASE NOTE: Implemented support for creating custom tokens scoped to specific tenants. `CustomToken()` and `CustomTokenWithClaims()` functions are now also exposed on `auth.TenantClient` types.