### PR TITLE
chore: Adding a CI job to build in non-module (gopath) mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,9 @@ jobs:
     name: Gopath build
     runs-on: ubuntu-latest
     env:
-        GOPATH: ${{ github.workspace }}/go
+      GOPATH: ${{ github.workspace }}/go
 
+    steps:
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,4 @@ jobs:
       run: go get -t -v $(go list ./... | grep -v integration)
 
     - name: Run Unit Tests
-      if: success() || failure()
       run: go test -v -race -test.short firebase.google.com/go/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: Continuous Integration
 on: pull_request
 jobs:
 
-  build:
-    name: Build
+  module:
+    name: Module build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,3 +38,26 @@ jobs:
 
     - name: Run Static Analyzer
       run: go vet -v ./...
+
+  gopath:
+    name: Gopath build
+    runs-on: ubuntu-latest
+    env:
+        GOPATH: ${{ github.workspace }}/go
+
+    - name: Set up Go 1.12
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12
+
+    - name: Check out code into GOPATH
+      uses: actions/checkout@v2
+      with:
+        path: go/src/firebase.google.com/go
+
+    - name: Get dependencies
+      run: go get -t -v $(go list ./... | grep -v integration)
+
+    - name: Run Unit Tests
+      if: success() || failure()
+      run: go test -v -race -test.short firebase.google.com/go/...


### PR DESCRIPTION
Checks out source into `GOPATH/src` and tries to compile as a non-module package.