### PR TITLE
Add make commands for common tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+unit:
+	go test -v -race -test.short ./...
+
+lint:
+	go get -u golang.org/x/lint/golint
+	`go list -f {{.Target}} golang.org/x/lint/golint` -set_exit_status ./...
+
+format:
+	gofmt -d -s .
+
+analysis:
+	go vet -v ./...
+
+all: format lint analysis unit


### PR DESCRIPTION
Added a `Makefile` with commonly used tasks to make it easier for contributors to verify that their changes meet the expected standards.