### PR TITLE
Add support for Remote Config

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -30,6 +30,7 @@ import (
 	"firebase.google.com/go/v4/iid"
 	"firebase.google.com/go/v4/internal"
 	"firebase.google.com/go/v4/messaging"
+	"firebase.google.com/go/v4/remoteconfig"
 	"firebase.google.com/go/v4/storage"
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
@@ -126,6 +127,15 @@ func (a *App) Messaging(ctx context.Context) (*messaging.Client, error) {
 		Version:   Version,
 	}
 	return messaging.NewClient(ctx, conf)
+}
+
+// RemoteConfig returns an instance of remoteconfig.Client.
+func (a *App) RemoteConfig(ctx context.Context) (*remoteconfig.Client, error) {
+	conf := &internal.RemoteConfig{
+		ProjectID: a.projectID,
+		Opts:      a.opts,
+	}
+	return remoteconfig.NewClient(ctx, conf)
 }
 
 // NewApp creates a new App from the provided config and client options.

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -73,6 +73,12 @@ type MessagingConfig struct {
 	Version   string
 }
 
+// RemoteConfig represents the configuration of Firebase Cloud Remote Config service.
+type RemoteConfig struct {
+	Opts      []option.ClientOption
+	ProjectID string
+}
+
 // MockTokenSource is a TokenSource implementation that can be used for testing.
 type MockTokenSource struct {
 	AccessToken string

--- a/remoteconfig/client.go
+++ b/remoteconfig/client.go
@@ -1,0 +1,181 @@
+package remoteconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"firebase.google.com/go/v4/internal"
+)
+
+const (
+	defaultRemoteConfigEndpoint = "https://firebaseremoteconfig.googleapis.com/v1"
+)
+
+// Client .
+type Client struct {
+	hc        *internal.HTTPClient
+	projectID string
+}
+
+func (c *Client) getRootURL() string {
+	return fmt.Sprintf("%s/projects/%s/remoteConfig", defaultRemoteConfigEndpoint, c.projectID)
+}
+
+// GetRemoteConfig https://firebase.google.com/docs/reference/remote-config/rest/v1/projects/getRemoteConfig
+func (c *Client) GetRemoteConfig(versionNumber string) (*Response, error) {
+	var opts []internal.HTTPOption
+
+	// Optional. Version number of the RemoteConfig to look up.
+	// If not specified, the latest RemoteConfig will be returned.
+	if versionNumber != "" {
+		opts = append(opts, internal.WithQueryParam("versionNumber", versionNumber))
+	}
+
+	var data RemoteConfig
+
+	resp, err := c.hc.DoAndUnmarshal(
+		context.Background(),
+		&internal.Request{
+			Method: http.MethodGet,
+			URL:    c.getRootURL(),
+			Opts:   opts,
+		},
+		&data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Response{
+		RemoteConfig: data,
+		Etag:         resp.Header.Get("Etag"),
+	}
+
+	return result, nil
+}
+
+// UpdateRemoteConfig https://firebase.google.com/docs/reference/remote-config/rest/v1/projects/updateRemoteConfig
+func (c *Client) UpdateRemoteConfig(eTag string, validateOnly bool) (*Response, error) {
+	if eTag == "" {
+		eTag = "*"
+	}
+
+	var opts []internal.HTTPOption
+	opts = append(opts, internal.WithHeader("If-Match", eTag))
+	opts = append(opts, internal.WithQueryParam("validateOnly", strconv.FormatBool(validateOnly)))
+
+	var data RemoteConfig
+
+	resp, err := c.hc.DoAndUnmarshal(
+		context.Background(),
+		&internal.Request{
+			Method: http.MethodPut,
+			URL:    c.getRootURL(),
+			Opts:   opts,
+		},
+		&data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &Response{
+		RemoteConfig: data,
+		Etag:         resp.Header.Get("Etag"),
+	}
+
+	return result, nil
+}
+
+// ListVersions https://firebase.google.com/docs/reference/remote-config/rest/v1/projects.remoteConfig/listVersions
+func (c *Client) ListVersions(options *ListVersionsOptions) (*ListVersionsResponse, error) {
+	var opts []internal.HTTPOption
+	if options.PageSize != 0 {
+		opts = append(opts, internal.WithQueryParam("pageSize", strconv.FormatInt(options.PageSize, 10)))
+	}
+
+	if options.PageToken != "" {
+		opts = append(opts, internal.WithQueryParam("pageToken", options.PageToken))
+	}
+
+	if options.EndVersionNumber != "" {
+		opts = append(opts, internal.WithQueryParam("endVersionNumber", options.EndVersionNumber))
+	}
+
+	if options.StartTime != "" {
+		opts = append(opts, internal.WithQueryParam("startTime", options.StartTime))
+	}
+
+	if options.EndTime != "" {
+		opts = append(opts, internal.WithQueryParam("endTime", options.EndTime))
+	}
+
+	var data ListVersionsResponse
+	url := fmt.Sprintf("%s:listVersions", c.getRootURL())
+
+	_, err := c.hc.DoAndUnmarshal(
+		context.Background(),
+		&internal.Request{
+			Method: http.MethodGet,
+			URL:    url,
+			Opts:   opts,
+		},
+		&data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// Rollback https://firebase.google.com/docs/reference/remote-config/rest/v1/projects.remoteConfig/rollback
+func (c *Client) Rollback(versionNumber string) (*Template, error) {
+	if versionNumber == "" {
+		return nil, errors.New("versionNumber is required to rollback a Remote Config template")
+	}
+
+	var data Template
+	url := fmt.Sprintf("%s:listVersions", c.getRootURL())
+
+	_, err := c.hc.DoAndUnmarshal(
+		context.Background(),
+		&internal.Request{
+			Method: http.MethodPost,
+			Body: internal.NewJSONEntity(
+				struct {
+					VersionNumber string `json:"versionNumber"`
+				}{
+					VersionNumber: versionNumber,
+				},
+			),
+			URL: url,
+		},
+		&data,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &data, nil
+}
+
+// NewClient returns the default remote config
+func NewClient(ctx context.Context, c *internal.RemoteConfig) (*Client, error) {
+	if c.ProjectID == "" {
+		return nil, errors.New("project ID is required to access Firebase Cloud Remote Config client")
+	}
+
+	hc, _, err := internal.NewHTTPClient(ctx, c.Opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		hc:        hc,
+		projectID: c.ProjectID,
+	}, nil
+}

--- a/remoteconfig/client.go
+++ b/remoteconfig/client.go
@@ -179,3 +179,45 @@ func NewClient(ctx context.Context, c *internal.RemoteConfig) (*Client, error) {
 		projectID: c.ProjectID,
 	}, nil
 }
+
+// GetTemplate will retrieve the latest template
+func (c *Client) GetTemplate(ctx context.Context) (*Template, error) {
+	// TODO
+	return nil, nil
+}
+
+// GetTemplateAtVersion will retrieve the specified version of the template
+func (c *Client) GetTemplateAtVersion(ctx context.Context, versionNumber string) (*Template, error) {
+	// TODO
+	return nil, nil
+}
+
+// Versions will list the versions of the template
+func (c *Client) Versions(ctx context.Context, options *ListVersionsOptions) (*VersionIterator, error) {
+	// TODO
+	return nil, nil
+}
+
+// Rollback will perform a rollback operation on the template
+func (c *Client) Rollback(ctx context.Context, versionNumber string) (*Template, error) {
+	// TODO
+	return nil, nil
+}
+
+// PublishTemplate will publish the specified temnplate
+func (c *Client) PublishTemplate(ctx context.Context, template *Template) (*Template, error) {
+	// TODO
+	return nil, nil
+}
+
+// ValidateTemplate will run validations for the current template
+func (c *Client) ValidateTemplate(ctx context.Context, template *Template) (*Template, error) {
+	// TODO
+	return nil, nil
+}
+
+// ForcePublishTemplate will publish the template irrespective of the outcome from validations
+func (c *Client) ForcePublishTemplate(ctx context.Context, template *Template) (*Template, error) {
+	// TODO
+	return nil, nil
+}

--- a/remoteconfig/doc.go
+++ b/remoteconfig/doc.go
@@ -1,0 +1,3 @@
+// Reference RemoteConfig using the REST API implementation
+
+package remoteconfig

--- a/remoteconfig/types.go
+++ b/remoteconfig/types.go
@@ -1,19 +1,58 @@
 package remoteconfig
 
+import (
+	"time"
+
+	"google.golang.org/api/iterator"
+)
+
+// TagColor represents a tag color
+type TagColor int
+
+// Tag colors
+const (
+	colorUnspecified TagColor = iota
+	Blue
+	Brown
+	Cyan
+	DeepOrange
+	Green
+	Indigo
+	Lime
+	Orange
+	Pink
+	Purple
+	Teal
+)
+
 // Version a Remote Config template version.
 // Output only, except for the version description.
 // Contains metadata about a particular version of the Remote Config template.
 // All fields are set at the time the specified Remote Config template is published.
 // A version's description field may be specified in PublishTemplate calls
 type Version struct {
-	Description    string `json:"description"`
-	IsLegacy       bool   `json:"isLegacy"`
-	RollbackSource string `json:"rollbackSource"`
-	UpdateOrigin   string `json:"updateOrigin"`
-	UpdateTime     string `json:"updateTime"`
-	UpdateType     string `json:"updateType"`
-	UpdateUser     User   `json:"updateUser"`
-	VersionNumber  string `json:"versionNumber"`
+	Description    string    `json:"description"`
+	IsLegacy       bool      `json:"isLegacy"`
+	RollbackSource string    `json:"rollbackSource"`
+	UpdateOrigin   string    `json:"updateOrigin"`
+	UpdateTime     time.Time `json:"updateTime"`
+	UpdateType     string    `json:"updateType"`
+	UpdateUser     *User     `json:"updateUser"`
+	VersionNumber  string    `json:"versionNumber"`
+}
+
+// VersionIterator represents the iterator for looping over versions
+type VersionIterator struct{}
+
+// PageInfo represents the information about a Page
+func (it *VersionIterator) PageInfo() *iterator.PageInfo {
+	// TODO
+	return nil
+}
+
+// Next will return the next version item in the loop
+func (it *VersionIterator) Next() (*Version, error) {
+	return nil, nil
 }
 
 // ListVersionsResponse is a list of Remote Config template versions
@@ -24,19 +63,19 @@ type ListVersionsResponse struct {
 
 // ListVersionsOptions to be used as query params in the request to list versions
 type ListVersionsOptions struct {
-	StartTime        string
-	EndTime          string
+	StartTime        time.Time
+	EndTime          time.Time
 	EndVersionNumber string
-	PageSize         int64
+	PageSize         int
 	PageToken        string
 }
 
 // Condition targets a specific group of users
 // A list of these conditions make up part of a Remote Config template
 type Condition struct {
-	Expression string `json:"expression"`
-	Name       string `json:"name"`
-	TagColor   string `json:"tagColor"`
+	Expression string   `json:"expression"`
+	Name       string   `json:"name"`
+	TagColor   TagColor `json:"tagColor"`
 }
 
 // RemoteConfig represents a Remote Config
@@ -55,31 +94,45 @@ type Response struct {
 
 // Parameter .
 type Parameter struct {
-	ConditionalValues map[string]ParameterValue `json:"conditionalValues"`
-	DefaultValue      ParameterValue            `json:"defaultValue"`
-	Description       string                    `json:"description"`
+	ConditionalValues map[string]*ParameterValue `json:"conditionalValues"`
+	DefaultValue      *ParameterValue            `json:"defaultValue"`
+	Description       string                     `json:"description"`
 }
 
 // ParameterValue .
 type ParameterValue struct {
-	Value           string `json:"value"`
-	UseInAppDefault bool   `json:"useInAppDefault"`
+	explicitValue   string
+	useInAppDefault bool
+}
+
+// UseInAppDefaultValue returns a parameter value with the in app default as false
+func UseInAppDefaultValue() *ParameterValue {
+	return &ParameterValue{
+		useInAppDefault: false,
+	}
+}
+
+// NewExplicitParameterValue will add a new explicit parameter value
+func NewExplicitParameterValue(value string) *ParameterValue {
+	pm := UseInAppDefaultValue()
+	pm.explicitValue = value
+	return pm
 }
 
 // ParameterGroup representing a Remote Config parameter group
 // Grouping parameters is only for management purposes and does not affect client-side fetching of parameter values
 type ParameterGroup struct {
-	Description string               `json:"description"`
-	Parameters  map[string]Parameter `json:"parameters"`
+	Description string                `json:"description"`
+	Parameters  map[string]*Parameter `json:"parameters"`
 }
 
 // Template .
 type Template struct {
-	Conditions      []Condition
+	Conditions      []*Condition
 	ETag            string
-	ParameterGroups map[string]ParameterGroup
-	Parameters      map[string]Parameter
-	Version         Version
+	Parameters      map[string]*Parameter
+	ParameterGroups map[string]*ParameterGroup
+	Version         *Version
 }
 
 // User represents a remote config user

--- a/remoteconfig/types.go
+++ b/remoteconfig/types.go
@@ -1,0 +1,90 @@
+package remoteconfig
+
+// Version a Remote Config template version.
+// Output only, except for the version description.
+// Contains metadata about a particular version of the Remote Config template.
+// All fields are set at the time the specified Remote Config template is published.
+// A version's description field may be specified in PublishTemplate calls
+type Version struct {
+	Description    string `json:"description"`
+	IsLegacy       bool   `json:"isLegacy"`
+	RollbackSource string `json:"rollbackSource"`
+	UpdateOrigin   string `json:"updateOrigin"`
+	UpdateTime     string `json:"updateTime"`
+	UpdateType     string `json:"updateType"`
+	UpdateUser     User   `json:"updateUser"`
+	VersionNumber  string `json:"versionNumber"`
+}
+
+// ListVersionsResponse is a list of Remote Config template versions
+type ListVersionsResponse struct {
+	NextPageToken string    `json:"nextPageToken"`
+	Versions      []Version `json:"versions"`
+}
+
+// ListVersionsOptions to be used as query params in the request to list versions
+type ListVersionsOptions struct {
+	StartTime        string
+	EndTime          string
+	EndVersionNumber string
+	PageSize         int64
+	PageToken        string
+}
+
+// Condition targets a specific group of users
+// A list of these conditions make up part of a Remote Config template
+type Condition struct {
+	Expression string `json:"expression"`
+	Name       string `json:"name"`
+	TagColor   string `json:"tagColor"`
+}
+
+// RemoteConfig represents a Remote Config
+type RemoteConfig struct {
+	Conditions      []Condition               `json:"conditions"`
+	Parameters      map[string]Parameter      `json:"parameters"`
+	Version         Version                   `json:"version"`
+	ParameterGroups map[string]ParameterGroup `json:"parameterGroups"`
+}
+
+// Response to save the API response including ETag
+type Response struct {
+	RemoteConfig
+	Etag string `json:"etag"`
+}
+
+// Parameter .
+type Parameter struct {
+	ConditionalValues map[string]ParameterValue `json:"conditionalValues"`
+	DefaultValue      ParameterValue            `json:"defaultValue"`
+	Description       string                    `json:"description"`
+}
+
+// ParameterValue .
+type ParameterValue struct {
+	Value           string `json:"value"`
+	UseInAppDefault bool   `json:"useInAppDefault"`
+}
+
+// ParameterGroup representing a Remote Config parameter group
+// Grouping parameters is only for management purposes and does not affect client-side fetching of parameter values
+type ParameterGroup struct {
+	Description string               `json:"description"`
+	Parameters  map[string]Parameter `json:"parameters"`
+}
+
+// Template .
+type Template struct {
+	Conditions      []Condition
+	ETag            string
+	ParameterGroups map[string]ParameterGroup
+	Parameters      map[string]Parameter
+	Version         Version
+}
+
+// User represents a remote config user
+type User struct {
+	Email    string `json:"email"`
+	ImageURL string `json:"imageUrl"`
+	Name     string `json:"name"`
+}


### PR DESCRIPTION
**Summary**
This PR adds support for Remote Config based on the REST API reference. I ran these methods by invoking them from another file with service account credentials. Tests are pending.

**Related Issue : ** https://github.com/firebase/firebase-admin-go/issues/391