### PR TITLE
Add enableAnonymousUser param to CreateTenant and UpdateTenant

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -144,10 +144,10 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		baseURL = fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", authEmulatorHost)
 	}
 	idToolkitV1Endpoint := fmt.Sprintf("%s/v1", baseURL)
-	idToolkitV2Beta1Endpoint := fmt.Sprintf("%s/v2beta1", baseURL)
+	idToolkitV2Endpoint := fmt.Sprintf("%s/v2", baseURL)
 	userManagementEndpoint := idToolkitV1Endpoint
-	providerConfigEndpoint := idToolkitV2Beta1Endpoint
-	tenantMgtEndpoint := idToolkitV2Beta1Endpoint
+	providerConfigEndpoint := idToolkitV2Endpoint
+	tenantMgtEndpoint := idToolkitV2Endpoint
 
 	base := &baseClient{
 		userManagementEndpoint: userManagementEndpoint,

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	credEnvVar                      = "GOOGLE_APPLICATION_CREDENTIALS"
-	testProjectID                   = "mock-project-id"
-	testVersion                     = "test-version"
+	credEnvVar                 = "GOOGLE_APPLICATION_CREDENTIALS"
+	testProjectID              = "mock-project-id"
+	testVersion                = "test-version"
 	defaultIDToolkitV1Endpoint = "https://identitytoolkit.googleapis.com/v1"
 	defaultIDToolkitV2Endpoint = "https://identitytoolkit.googleapis.com/v2"
 )

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -39,8 +39,8 @@ const (
 	credEnvVar                      = "GOOGLE_APPLICATION_CREDENTIALS"
 	testProjectID                   = "mock-project-id"
 	testVersion                     = "test-version"
-	defaultIDToolkitV1Endpoint      = "https://identitytoolkit.googleapis.com/v1"
-	defaultIDToolkitV2Beta1Endpoint = "https://identitytoolkit.googleapis.com/v2beta1"
+	defaultIDToolkitV1Endpoint = "https://identitytoolkit.googleapis.com/v1"
+	defaultIDToolkitV2Endpoint = "https://identitytoolkit.googleapis.com/v2"
 )
 
 var (
@@ -291,7 +291,7 @@ func TestNewClientExplicitNoAuth(t *testing.T) {
 func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	emulatorHost := "localhost:9099"
 	idToolkitV1Endpoint := "http://localhost:9099/identitytoolkit.googleapis.com/v1"
-	idToolkitV2Beta1Endpoint := "http://localhost:9099/identitytoolkit.googleapis.com/v2beta1"
+	idToolkitV2Endpoint := "http://localhost:9099/identitytoolkit.googleapis.com/v2"
 
 	os.Setenv(emulatorHostEnvVar, emulatorHost)
 	defer os.Unsetenv(emulatorHostEnvVar)
@@ -305,11 +305,11 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	if baseClient.userManagementEndpoint != idToolkitV1Endpoint {
 		t.Errorf("baseClient.userManagementEndpoint = %q; want = %q", baseClient.userManagementEndpoint, idToolkitV1Endpoint)
 	}
-	if baseClient.providerConfigEndpoint != idToolkitV2Beta1Endpoint {
-		t.Errorf("baseClient.providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, idToolkitV2Beta1Endpoint)
+	if baseClient.providerConfigEndpoint != idToolkitV2Endpoint {
+		t.Errorf("baseClient.providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, idToolkitV2Endpoint)
 	}
-	if baseClient.tenantMgtEndpoint != idToolkitV2Beta1Endpoint {
-		t.Errorf("baseClient.tenantMgtEndpoint = %q; want = %q", baseClient.tenantMgtEndpoint, idToolkitV2Beta1Endpoint)
+	if baseClient.tenantMgtEndpoint != idToolkitV2Endpoint {
+		t.Errorf("baseClient.tenantMgtEndpoint = %q; want = %q", baseClient.tenantMgtEndpoint, idToolkitV2Endpoint)
 	}
 	if _, ok := baseClient.signer.(emulatedSigner); !ok {
 		t.Errorf("baseClient.signer = %#v; want = %#v", baseClient.signer, emulatedSigner{})
@@ -1427,11 +1427,11 @@ func checkBaseClient(client *Client, wantProjectID string) error {
 	if baseClient.userManagementEndpoint != defaultIDToolkitV1Endpoint {
 		return fmt.Errorf("userManagementEndpoint = %q; want = %q", baseClient.userManagementEndpoint, defaultIDToolkitV1Endpoint)
 	}
-	if baseClient.providerConfigEndpoint != defaultIDToolkitV2Beta1Endpoint {
-		return fmt.Errorf("providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, defaultIDToolkitV2Beta1Endpoint)
+	if baseClient.providerConfigEndpoint != defaultIDToolkitV2Endpoint {
+		return fmt.Errorf("providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, defaultIDToolkitV2Endpoint)
 	}
-	if baseClient.tenantMgtEndpoint != defaultIDToolkitV2Beta1Endpoint {
-		return fmt.Errorf("providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, defaultIDToolkitV2Beta1Endpoint)
+	if baseClient.tenantMgtEndpoint != defaultIDToolkitV2Endpoint {
+		return fmt.Errorf("providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, defaultIDToolkitV2Endpoint)
 	}
 	if baseClient.projectID != wantProjectID {
 		return fmt.Errorf("projectID = %q; want = %q", baseClient.projectID, wantProjectID)

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -47,7 +47,7 @@ type Tenant struct {
 	DisplayName           string `json:"displayName"`
 	AllowPasswordSignUp   bool   `json:"allowPasswordSignup"`
 	EnableEmailLinkSignIn bool   `json:"enableEmailLinkSignin"`
-	EnableAnonymousUser   bool   `json:"enableAnonymousUser"`
+	EnableAnonymousUsers  bool   `json:"enableAnonymousUser"`
 }
 
 // TenantClient is used for managing users, configuring SAML/OIDC providers, and generating email
@@ -242,8 +242,8 @@ func (t *TenantToCreate) EnableEmailLinkSignIn(enable bool) *TenantToCreate {
 	return t.set(enableEmailLinkSignInKey, enable)
 }
 
-// EnableAnonymousUser enables or disables anonymous user.
-func (t *TenantToCreate) EnableAnonymousUser(enable bool) *TenantToCreate {
+// EnableAnonymousUsers enables or disables anonymous user.
+func (t *TenantToCreate) EnableAnonymousUsers(enable bool) *TenantToCreate {
 	return t.set(enableAnonymousUser, enable)
 }
 
@@ -282,8 +282,8 @@ func (t *TenantToUpdate) EnableEmailLinkSignIn(enable bool) *TenantToUpdate {
 	return t.set(enableEmailLinkSignInKey, enable)
 }
 
-// EnableAnonymousUser enables or disables anonymous user.
-func (t *TenantToUpdate) EnableAnonymousUser(enable bool) *TenantToUpdate {
+// EnableAnonymousUsers enables or disables anonymous user.
+func (t *TenantToUpdate) EnableAnonymousUsers(enable bool) *TenantToUpdate {
 	return t.set(enableAnonymousUser, enable)
 }
 

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -47,6 +47,7 @@ type Tenant struct {
 	DisplayName           string `json:"displayName"`
 	AllowPasswordSignUp   bool   `json:"allowPasswordSignup"`
 	EnableEmailLinkSignIn bool   `json:"enableEmailLinkSignin"`
+	EnableAnonymousUser   bool   `json:"enableAnonymousUser"`
 }
 
 // TenantClient is used for managing users, configuring SAML/OIDC providers, and generating email
@@ -216,6 +217,7 @@ const (
 	tenantDisplayNameKey     = "displayName"
 	allowPasswordSignUpKey   = "allowPasswordSignup"
 	enableEmailLinkSignInKey = "enableEmailLinkSignin"
+	enableAnonymousUser      = "enableAnonymousUser"
 )
 
 // TenantToCreate represents the options used to create a new tenant.
@@ -238,6 +240,11 @@ func (t *TenantToCreate) AllowPasswordSignUp(allow bool) *TenantToCreate {
 // Disabling this makes the password required for email sign-in.
 func (t *TenantToCreate) EnableEmailLinkSignIn(enable bool) *TenantToCreate {
 	return t.set(enableEmailLinkSignInKey, enable)
+}
+
+// EnableAnonymousUser enables or disables anonymous user.
+func (t *TenantToCreate) EnableAnonymousUser(enable bool) *TenantToCreate {
+	return t.set(enableAnonymousUser, enable)
 }
 
 func (t *TenantToCreate) set(key string, value interface{}) *TenantToCreate {
@@ -273,6 +280,11 @@ func (t *TenantToUpdate) AllowPasswordSignUp(allow bool) *TenantToUpdate {
 // Disabling this makes the password required for email sign-in.
 func (t *TenantToUpdate) EnableEmailLinkSignIn(enable bool) *TenantToUpdate {
 	return t.set(enableEmailLinkSignInKey, enable)
+}
+
+// EnableAnonymousUser enables or disables anonymous user.
+func (t *TenantToUpdate) EnableAnonymousUser(enable bool) *TenantToUpdate {
+	return t.set(enableAnonymousUser, enable)
 }
 
 func (t *TenantToUpdate) set(key string, value interface{}) *TenantToUpdate {

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -242,7 +242,7 @@ func (t *TenantToCreate) EnableEmailLinkSignIn(enable bool) *TenantToCreate {
 	return t.set(enableEmailLinkSignInKey, enable)
 }
 
-// EnableAnonymousUsers enables or disables anonymous user.
+// EnableAnonymousUsers enables or disables anonymous authentication.
 func (t *TenantToCreate) EnableAnonymousUsers(enable bool) *TenantToCreate {
 	return t.set(enableAnonymousUser, enable)
 }

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -282,7 +282,7 @@ func (t *TenantToUpdate) EnableEmailLinkSignIn(enable bool) *TenantToUpdate {
 	return t.set(enableEmailLinkSignInKey, enable)
 }
 
-// EnableAnonymousUsers enables or disables anonymous user.
+// EnableAnonymousUsers enables or disables anonymous authentication.
 func (t *TenantToUpdate) EnableAnonymousUsers(enable bool) *TenantToUpdate {
 	return t.set(enableAnonymousUser, enable)
 }

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -1084,14 +1084,16 @@ const tenantResponse = `{
     "name":"projects/mock-project-id/tenants/tenantID",
     "displayName": "Test Tenant",
     "allowPasswordSignup": true,
-    "enableEmailLinkSignin": true
+    "enableEmailLinkSignin": true,
+    "enableAnonymousUser": true
 }`
 
 const tenantResponse2 = `{
     "name":"projects/mock-project-id/tenants/tenantID2",
     "displayName": "Test Tenant 2",
     "allowPasswordSignup": true,
-    "enableEmailLinkSignin": true
+    "enableEmailLinkSignin": true,
+    "enableAnonymousUser": true
 }`
 
 const tenantNotFoundResponse = `{
@@ -1105,6 +1107,7 @@ var testTenant = &Tenant{
 	DisplayName:           "Test Tenant",
 	AllowPasswordSignUp:   true,
 	EnableEmailLinkSignIn: true,
+	EnableAnonymousUser:   true,
 }
 
 var testTenant2 = &Tenant{
@@ -1112,6 +1115,7 @@ var testTenant2 = &Tenant{
 	DisplayName:           "Test Tenant 2",
 	AllowPasswordSignUp:   true,
 	EnableEmailLinkSignIn: true,
+	EnableAnonymousUser:   true,
 }
 
 func TestTenant(t *testing.T) {
@@ -1177,7 +1181,8 @@ func TestCreateTenant(t *testing.T) {
 	options := (&TenantToCreate{}).
 		DisplayName(testTenant.DisplayName).
 		AllowPasswordSignUp(testTenant.AllowPasswordSignUp).
-		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn)
+		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn).
+		EnableAnonymousUser(testTenant.EnableAnonymousUser)
 	tenant, err := client.TenantManager.CreateTenant(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -1191,6 +1196,7 @@ func TestCreateTenant(t *testing.T) {
 		"displayName":           testTenant.DisplayName,
 		"allowPasswordSignup":   testTenant.AllowPasswordSignUp,
 		"enableEmailLinkSignin": testTenant.EnableEmailLinkSignIn,
+		"enableAnonymousUser":   testTenant.EnableAnonymousUser,
 	}
 	if err := checkCreateTenantRequest(s, wantBody); err != nil {
 		t.Fatal(err)
@@ -1225,7 +1231,8 @@ func TestCreateTenantZeroValues(t *testing.T) {
 	options := (&TenantToCreate{}).
 		DisplayName("").
 		AllowPasswordSignUp(false).
-		EnableEmailLinkSignIn(false)
+		EnableEmailLinkSignIn(false).
+		EnableAnonymousUser(false)
 	tenant, err := client.TenantManager.CreateTenant(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -1239,6 +1246,7 @@ func TestCreateTenantZeroValues(t *testing.T) {
 		"displayName":           "",
 		"allowPasswordSignup":   false,
 		"enableEmailLinkSignin": false,
+		"enableAnonymousUser":   false,
 	}
 	if err := checkCreateTenantRequest(s, wantBody); err != nil {
 		t.Fatal(err)
@@ -1274,7 +1282,8 @@ func TestUpdateTenant(t *testing.T) {
 	options := (&TenantToUpdate{}).
 		DisplayName(testTenant.DisplayName).
 		AllowPasswordSignUp(testTenant.AllowPasswordSignUp).
-		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn)
+		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn).
+		EnableAnonymousUser(testTenant.EnableAnonymousUser)
 	tenant, err := client.TenantManager.UpdateTenant(context.Background(), "tenantID", options)
 	if err != nil {
 		t.Fatal(err)
@@ -1288,8 +1297,9 @@ func TestUpdateTenant(t *testing.T) {
 		"displayName":           testTenant.DisplayName,
 		"allowPasswordSignup":   testTenant.AllowPasswordSignUp,
 		"enableEmailLinkSignin": testTenant.EnableEmailLinkSignIn,
+		"enableAnonymousUser":   testTenant.EnableAnonymousUser,
 	}
-	wantMask := []string{"allowPasswordSignup", "displayName", "enableEmailLinkSignin"}
+	wantMask := []string{"allowPasswordSignup", "displayName", "enableAnonymousUser", "enableEmailLinkSignin"}
 	if err := checkUpdateTenantRequest(s, wantBody, wantMask); err != nil {
 		t.Fatal(err)
 	}
@@ -1327,7 +1337,8 @@ func TestUpdateTenantZeroValues(t *testing.T) {
 	options := (&TenantToUpdate{}).
 		DisplayName("").
 		AllowPasswordSignUp(false).
-		EnableEmailLinkSignIn(false)
+		EnableEmailLinkSignIn(false).
+		EnableAnonymousUser(false)
 	tenant, err := client.TenantManager.UpdateTenant(context.Background(), "tenantID", options)
 	if err != nil {
 		t.Fatal(err)
@@ -1341,8 +1352,9 @@ func TestUpdateTenantZeroValues(t *testing.T) {
 		"displayName":           "",
 		"allowPasswordSignup":   false,
 		"enableEmailLinkSignin": false,
+		"enableAnonymousUser":   false,
 	}
-	wantMask := []string{"allowPasswordSignup", "displayName", "enableEmailLinkSignin"}
+	wantMask := []string{"allowPasswordSignup", "displayName", "enableAnonymousUser", "enableEmailLinkSignin"}
 	if err := checkUpdateTenantRequest(s, wantBody, wantMask); err != nil {
 		t.Fatal(err)
 	}

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -1107,7 +1107,7 @@ var testTenant = &Tenant{
 	DisplayName:           "Test Tenant",
 	AllowPasswordSignUp:   true,
 	EnableEmailLinkSignIn: true,
-	EnableAnonymousUser:   true,
+	EnableAnonymousUsers:  true,
 }
 
 var testTenant2 = &Tenant{
@@ -1115,7 +1115,7 @@ var testTenant2 = &Tenant{
 	DisplayName:           "Test Tenant 2",
 	AllowPasswordSignUp:   true,
 	EnableEmailLinkSignIn: true,
-	EnableAnonymousUser:   true,
+	EnableAnonymousUsers:  true,
 }
 
 func TestTenant(t *testing.T) {
@@ -1182,7 +1182,7 @@ func TestCreateTenant(t *testing.T) {
 		DisplayName(testTenant.DisplayName).
 		AllowPasswordSignUp(testTenant.AllowPasswordSignUp).
 		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn).
-		EnableAnonymousUser(testTenant.EnableAnonymousUser)
+		EnableAnonymousUsers(testTenant.EnableAnonymousUsers)
 	tenant, err := client.TenantManager.CreateTenant(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -1196,7 +1196,7 @@ func TestCreateTenant(t *testing.T) {
 		"displayName":           testTenant.DisplayName,
 		"allowPasswordSignup":   testTenant.AllowPasswordSignUp,
 		"enableEmailLinkSignin": testTenant.EnableEmailLinkSignIn,
-		"enableAnonymousUser":   testTenant.EnableAnonymousUser,
+		"enableAnonymousUser":   testTenant.EnableAnonymousUsers,
 	}
 	if err := checkCreateTenantRequest(s, wantBody); err != nil {
 		t.Fatal(err)
@@ -1232,7 +1232,7 @@ func TestCreateTenantZeroValues(t *testing.T) {
 		DisplayName("").
 		AllowPasswordSignUp(false).
 		EnableEmailLinkSignIn(false).
-		EnableAnonymousUser(false)
+		EnableAnonymousUsers(false)
 	tenant, err := client.TenantManager.CreateTenant(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -1283,7 +1283,7 @@ func TestUpdateTenant(t *testing.T) {
 		DisplayName(testTenant.DisplayName).
 		AllowPasswordSignUp(testTenant.AllowPasswordSignUp).
 		EnableEmailLinkSignIn(testTenant.EnableEmailLinkSignIn).
-		EnableAnonymousUser(testTenant.EnableAnonymousUser)
+		EnableAnonymousUsers(testTenant.EnableAnonymousUsers)
 	tenant, err := client.TenantManager.UpdateTenant(context.Background(), "tenantID", options)
 	if err != nil {
 		t.Fatal(err)
@@ -1297,7 +1297,7 @@ func TestUpdateTenant(t *testing.T) {
 		"displayName":           testTenant.DisplayName,
 		"allowPasswordSignup":   testTenant.AllowPasswordSignUp,
 		"enableEmailLinkSignin": testTenant.EnableEmailLinkSignIn,
-		"enableAnonymousUser":   testTenant.EnableAnonymousUser,
+		"enableAnonymousUser":   testTenant.EnableAnonymousUsers,
 	}
 	wantMask := []string{"allowPasswordSignup", "displayName", "enableAnonymousUser", "enableEmailLinkSignin"}
 	if err := checkUpdateTenantRequest(s, wantBody, wantMask); err != nil {
@@ -1338,7 +1338,7 @@ func TestUpdateTenantZeroValues(t *testing.T) {
 		DisplayName("").
 		AllowPasswordSignUp(false).
 		EnableEmailLinkSignIn(false).
-		EnableAnonymousUser(false)
+		EnableAnonymousUsers(false)
 	tenant, err := client.TenantManager.UpdateTenant(context.Background(), "tenantID", options)
 	if err != nil {
 		t.Fatal(err)

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=

--- a/go.sum
+++ b/go.sum
@@ -231,7 +231,6 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -31,12 +31,14 @@ func TestTenantManager(t *testing.T) {
 		DisplayName:           "admin-go-tenant",
 		AllowPasswordSignUp:   true,
 		EnableEmailLinkSignIn: true,
+		EnableAnonymousUser:   true,
 	}
 
 	req := (&auth.TenantToCreate{}).
 		DisplayName("admin-go-tenant").
 		AllowPasswordSignUp(true).
-		EnableEmailLinkSignIn(true)
+		EnableEmailLinkSignIn(true).
+		EnableAnonymousUser(true)
 	created, err := client.TenantManager.CreateTenant(context.Background(), req)
 	if err != nil {
 		t.Fatalf("CreateTenant() = %v", err)
@@ -129,11 +131,13 @@ func TestTenantManager(t *testing.T) {
 			DisplayName:           "updated-go-tenant",
 			AllowPasswordSignUp:   false,
 			EnableEmailLinkSignIn: false,
+			EnableAnonymousUser:   false,
 		}
 		req := (&auth.TenantToUpdate{}).
 			DisplayName("updated-go-tenant").
 			AllowPasswordSignUp(false).
-			EnableEmailLinkSignIn(false)
+			EnableEmailLinkSignIn(false).
+			EnableAnonymousUser(false)
 		tenant, err := client.TenantManager.UpdateTenant(context.Background(), id, req)
 		if err != nil {
 			t.Fatalf("UpdateTenant() = %v", err)

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -31,14 +31,14 @@ func TestTenantManager(t *testing.T) {
 		DisplayName:           "admin-go-tenant",
 		AllowPasswordSignUp:   true,
 		EnableEmailLinkSignIn: true,
-		EnableAnonymousUser:   true,
+		EnableAnonymousUsers:  true,
 	}
 
 	req := (&auth.TenantToCreate{}).
 		DisplayName("admin-go-tenant").
 		AllowPasswordSignUp(true).
 		EnableEmailLinkSignIn(true).
-		EnableAnonymousUser(true)
+		EnableAnonymousUsers(true)
 	created, err := client.TenantManager.CreateTenant(context.Background(), req)
 	if err != nil {
 		t.Fatalf("CreateTenant() = %v", err)
@@ -131,13 +131,13 @@ func TestTenantManager(t *testing.T) {
 			DisplayName:           "updated-go-tenant",
 			AllowPasswordSignUp:   false,
 			EnableEmailLinkSignIn: false,
-			EnableAnonymousUser:   false,
+			EnableAnonymousUsers:  false,
 		}
 		req := (&auth.TenantToUpdate{}).
 			DisplayName("updated-go-tenant").
 			AllowPasswordSignUp(false).
 			EnableEmailLinkSignIn(false).
-			EnableAnonymousUser(false)
+			EnableAnonymousUsers(false)
 		tenant, err := client.TenantManager.UpdateTenant(context.Background(), id, req)
 		if err != nil {
 			t.Fatalf("UpdateTenant() = %v", err)


### PR DESCRIPTION
#411 
#372

"https://identitytoolkit.googleapis.com/v2beta1" does not support `enableAnonymousUser` param. use "https://identitytoolkit.googleapis.com/v2".

RELEASE NOTE: Allowed enabling of anonymous provider via tenant configuration