### PR TITLE
feat(auth): Recognize `FIREBASE_AUTH_EMULATOR_HOST` environment variable

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -29,6 +30,7 @@ import (
 
 const (
 	authErrorCode    = "authErrorCode"
+	defaultAuthURL   = "https://identitytoolkit.googleapis.com"
 	firebaseAudience = "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
 	oneHourInSeconds = 3600
 
@@ -61,6 +63,17 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 		signer cryptoSigner
 		err    error
 	)
+
+	baseURL := defaultAuthURL
+	if authEmulatorHost := os.Getenv("FIREBASE_AUTH_EMULATOR_HOST"); authEmulatorHost != "" {
+		baseURL = fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", authEmulatorHost)
+	}
+
+	idToolkitV1Endpoint := fmt.Sprintf("%s/v1", baseURL)
+	idToolkitV2Beta1Endpoint := fmt.Sprintf("%s/v2beta1", baseURL)
+	userManagementEndpoint := idToolkitV1Endpoint
+	providerConfigEndpoint := idToolkitV2Beta1Endpoint
+	tenantMgtEndpoint := idToolkitV2Beta1Endpoint
 
 	creds, _ := transport.Creds(ctx, conf.Opts...)
 
@@ -113,8 +126,9 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 	}
 
 	base := &baseClient{
-		userManagementEndpoint: idToolkitV1Endpoint,
+		userManagementEndpoint: userManagementEndpoint,
 		providerConfigEndpoint: providerConfigEndpoint,
+		tenantMgtEndpoint:      tenantMgtEndpoint,
 		projectID:              conf.ProjectID,
 		httpClient:             hc,
 		idTokenVerifier:        idTokenVerifier,
@@ -234,6 +248,7 @@ type FirebaseInfo struct {
 type baseClient struct {
 	userManagementEndpoint string
 	providerConfigEndpoint string
+	tenantMgtEndpoint      string
 	projectID              string
 	tenantID               string
 	httpClient             *internal.HTTPClient

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -29,10 +29,11 @@ import (
 )
 
 const (
-	authErrorCode    = "authErrorCode"
-	defaultAuthURL   = "https://identitytoolkit.googleapis.com"
-	firebaseAudience = "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
-	oneHourInSeconds = 3600
+	authErrorCode      = "authErrorCode"
+	emulatorHostEnvVar = "FIREBASE_AUTH_EMULATOR_HOST"
+	defaultAuthURL     = "https://identitytoolkit.googleapis.com"
+	firebaseAudience   = "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
+	oneHourInSeconds   = 3600
 
 	// SDK-generated error codes
 	idTokenRevoked       = "ID_TOKEN_REVOKED"
@@ -65,7 +66,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 	)
 
 	baseURL := defaultAuthURL
-	if authEmulatorHost := os.Getenv("FIREBASE_AUTH_EMULATOR_HOST"); authEmulatorHost != "" {
+	if authEmulatorHost := os.Getenv(emulatorHostEnvVar); authEmulatorHost != "" {
 		baseURL = fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", authEmulatorHost)
 	}
 

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	credEnvVar                      = "GOOGLE_APPLICATION_CREDENTIALS"
-	emulatorHostEnvVar              = "FIREBASE_AUTH_EMULATOR_HOST"
 	testProjectID                   = "mock-project-id"
 	testVersion                     = "test-version"
 	defaultIDToolkitV1Endpoint      = "https://identitytoolkit.googleapis.com/v1"

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -694,6 +694,27 @@ func TestVerifyIDTokenWithNoProjectID(t *testing.T) {
 	}
 }
 
+func TestVerifyIDTokenInEmulatorMode(t *testing.T) {
+	os.Setenv(emulatorHostEnvVar, "localhost:9099")
+	defer os.Unsetenv(emulatorHostEnvVar)
+
+	conf := &internal.AuthConfig{
+		ProjectID: "",
+		Opts:      optsWithTokenSource,
+	}
+	c, err := NewClient(context.Background(), conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("VeridyIDToken() didn't panic")
+		}
+	}()
+	c.VerifyIDToken(context.Background(), testIDToken)
+}
+
 func TestCustomTokenVerification(t *testing.T) {
 	client := &Client{
 		baseClient: &baseClient{
@@ -713,7 +734,7 @@ func TestCustomTokenVerification(t *testing.T) {
 }
 
 func TestCertificateRequestError(t *testing.T) {
-	tv, err := newIDTokenVerifier(context.Background(), testProjectID)
+	tv, err := newIDTokenVerifier(context.Background(), testProjectID, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1053,7 +1074,7 @@ func signerForTests(ctx context.Context) (cryptoSigner, error) {
 }
 
 func idTokenVerifierForTests(ctx context.Context) (*tokenVerifier, error) {
-	tv, err := newIDTokenVerifier(ctx, testProjectID)
+	tv, err := newIDTokenVerifier(ctx, testProjectID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1067,7 +1088,7 @@ func idTokenVerifierForTests(ctx context.Context) (*tokenVerifier, error) {
 }
 
 func cookieVerifierForTests(ctx context.Context) (*tokenVerifier, error) {
-	tv, err := newSessionCookieVerifier(ctx, testProjectID)
+	tv, err := newSessionCookieVerifier(ctx, testProjectID, false)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -309,6 +309,9 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	if baseClient.tenantMgtEndpoint != idToolkitV2Beta1Endpoint {
 		t.Errorf("baseClient.tenantMgtEndpoint = %q; want = %q", baseClient.tenantMgtEndpoint, idToolkitV2Beta1Endpoint)
 	}
+	if _, ok := baseClient.signer.(emulatedSigner); !ok {
+		t.Errorf("baseClient.signer = %#v; want = %#v", baseClient.signer, emulatedSigner{})
+	}
 }
 
 func TestCustomToken(t *testing.T) {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -298,9 +298,9 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	}
 	baseClient := client.baseClient
 
-	baseUrl := fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", os.Getenv(emulatorHostEnvVar))
-	idToolkitV1Endpoint := fmt.Sprintf("%s/v1", baseUrl)
-	idToolkitV2Beta1Endpoint := fmt.Sprintf("%s/v2beta1", baseUrl)
+	baseURL := fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", os.Getenv(emulatorHostEnvVar))
+	idToolkitV1Endpoint := fmt.Sprintf("%s/v1", baseURL)
+	idToolkitV2Beta1Endpoint := fmt.Sprintf("%s/v2beta1", baseURL)
 	if baseClient.userManagementEndpoint != idToolkitV1Endpoint {
 		t.Errorf("baseClient.userManagementEndpoint = %q; want = %q", baseClient.userManagementEndpoint, idToolkitV1Endpoint)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -284,7 +284,11 @@ func TestNewClientExplicitNoAuth(t *testing.T) {
 }
 
 func TestNewClientEmulatorHostEnvVar(t *testing.T) {
-	os.Setenv(emulatorHostEnvVar, "localhost:9099")
+	emulatorHost := "localhost:9099"
+	idToolkitV1Endpoint := "http://localhost:9099/identitytoolkit.googleapis.com/v1"
+	idToolkitV2Beta1Endpoint := "http://localhost:9099/identitytoolkit.googleapis.com/v2beta1"
+
+	os.Setenv(emulatorHostEnvVar, emulatorHost)
 	defer os.Unsetenv(emulatorHostEnvVar)
 
 	conf := &internal.AuthConfig{
@@ -297,10 +301,6 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 		t.Fatal(err)
 	}
 	baseClient := client.baseClient
-
-	baseURL := fmt.Sprintf("http://%s/identitytoolkit.googleapis.com", os.Getenv(emulatorHostEnvVar))
-	idToolkitV1Endpoint := fmt.Sprintf("%s/v1", baseURL)
-	idToolkitV2Beta1Endpoint := fmt.Sprintf("%s/v2beta1", baseURL)
 	if baseClient.userManagementEndpoint != idToolkitV1Endpoint {
 		t.Errorf("baseClient.userManagementEndpoint = %q; want = %q", baseClient.userManagementEndpoint, idToolkitV1Endpoint)
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -308,7 +308,7 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 		t.Errorf("baseClient.providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, idToolkitV2Beta1Endpoint)
 	}
 	if baseClient.tenantMgtEndpoint != idToolkitV2Beta1Endpoint {
-		t.Errorf("baseClient.providerConfigEndpoint = %q; want = %q", baseClient.providerConfigEndpoint, idToolkitV2Beta1Endpoint)
+		t.Errorf("baseClient.tenantMgtEndpoint = %q; want = %q", baseClient.tenantMgtEndpoint, idToolkitV2Beta1Endpoint)
 	}
 }
 

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -28,8 +28,6 @@ import (
 )
 
 const (
-	providerConfigEndpoint = "https://identitytoolkit.googleapis.com/v2beta1"
-
 	maxConfigs = 100
 
 	idpEntityIDKey = "idpConfig.idpEntityId"

--- a/auth/tenant_mgt.go
+++ b/auth/tenant_mgt.go
@@ -26,10 +26,6 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-const (
-	tenantMgtEndpoint = "https://identitytoolkit.googleapis.com/v2beta1"
-)
-
 // Tenant represents a tenant in a multi-tenant application.
 //
 // Multi-tenancy support requires Google Cloud's Identity Platform (GCIP). To learn more about GCIP,
@@ -88,7 +84,7 @@ type TenantManager struct {
 func newTenantManager(client *internal.HTTPClient, conf *internal.AuthConfig, base *baseClient) *TenantManager {
 	return &TenantManager{
 		base:       base,
-		endpoint:   tenantMgtEndpoint,
+		endpoint:   base.tenantMgtEndpoint,
 		projectID:  conf.ProjectID,
 		httpClient: client,
 	}

--- a/auth/token_generator_test.go
+++ b/auth/token_generator_test.go
@@ -279,7 +279,7 @@ func TestEmulatedSigner(t *testing.T) {
 
 	algorithm := signer.Algorithm()
 	if algorithm != algorithmNone {
-		t.Errorf("Algorithm() = %q; want = %q", algorithm, algorithmRS256)
+		t.Errorf("Algorithm() = %q; want = %q", algorithm, algorithmNone)
 	}
 
 	email, err := signer.Email(context.Background())

--- a/auth/token_generator_test.go
+++ b/auth/token_generator_test.go
@@ -103,6 +103,10 @@ func TestServiceAccountSigner(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	algorithm := signer.Algorithm()
+	if algorithm != algorithmRS256 {
+		t.Errorf("Algorithm() = %q; want = %q", algorithm, algorithmRS256)
+	}
 	email, err := signer.Email(context.Background())
 	if email != sa.ClientEmail || err != nil {
 		t.Errorf("Email() = (%q, %v); want = (%q, nil)", email, err, sa.ClientEmail)
@@ -122,6 +126,11 @@ func TestIAMSigner(t *testing.T) {
 	signer, err := newIAMSigner(ctx, conf)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	algorithm := signer.Algorithm()
+	if algorithm != algorithmRS256 {
+		t.Errorf("Algorithm() = %q; want = %q", algorithm, algorithmRS256)
 	}
 	email, err := signer.Email(ctx)
 	if email != conf.ServiceAccountID || err != nil {
@@ -265,8 +274,38 @@ func TestIAMSignerNoMetadataService(t *testing.T) {
 	}
 }
 
+func TestEmulatedSigner(t *testing.T) {
+	signer := emulatedSigner{}
+
+	algorithm := signer.Algorithm()
+	if algorithm != algorithmNone {
+		t.Errorf("Algorithm() = %q; want = %q", algorithm, algorithmRS256)
+	}
+
+	email, err := signer.Email(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if email != emulatorEmail {
+		t.Errorf("Email() = %q; want = %q", email, emulatorEmail)
+	}
+
+	wantSignature := ""
+	sign, err := signer.Sign(context.Background(), []byte("test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sign) != wantSignature {
+		t.Errorf("Sign() = %q; want = %q", string(sign), wantSignature)
+	}
+}
+
 type mockSigner struct {
 	err error
+}
+
+func (s *mockSigner) Algorithm() string {
+	return ""
 }
 
 func (s *mockSigner) Email(ctx context.Context) (string, error) {

--- a/auth/token_verifier.go
+++ b/auth/token_verifier.go
@@ -100,9 +100,10 @@ type tokenVerifier struct {
 	expiredTokenCode  string
 	keySource         keySource
 	clock             internal.Clock
+	isEmulator        bool
 }
 
-func newIDTokenVerifier(ctx context.Context, projectID string) (*tokenVerifier, error) {
+func newIDTokenVerifier(ctx context.Context, projectID string, isEmulator bool) (*tokenVerifier, error) {
 	noAuthHTTPClient, _, err := transport.NewHTTPClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return nil, err
@@ -118,10 +119,11 @@ func newIDTokenVerifier(ctx context.Context, projectID string) (*tokenVerifier, 
 		expiredTokenCode:  idTokenExpired,
 		keySource:         newHTTPKeySource(idTokenCertURL, noAuthHTTPClient),
 		clock:             internal.SystemClock,
+		isEmulator:        isEmulator,
 	}, nil
 }
 
-func newSessionCookieVerifier(ctx context.Context, projectID string) (*tokenVerifier, error) {
+func newSessionCookieVerifier(ctx context.Context, projectID string, isEmulator bool) (*tokenVerifier, error) {
 	noAuthHTTPClient, _, err := transport.NewHTTPClient(ctx, option.WithoutAuthentication())
 	if err != nil {
 		return nil, err
@@ -137,6 +139,7 @@ func newSessionCookieVerifier(ctx context.Context, projectID string) (*tokenVeri
 		expiredTokenCode:  sessionCookieExpired,
 		keySource:         newHTTPKeySource(sessionCookieCertURL, noAuthHTTPClient),
 		clock:             internal.SystemClock,
+		isEmulator:        isEmulator,
 	}, nil
 }
 
@@ -154,6 +157,10 @@ func newSessionCookieVerifier(ctx context.Context, projectID string) (*tokenVeri
 // If any of the above conditions are not met, an error is returned. Otherwise a pointer to a
 // decoded Token is returned.
 func (tv *tokenVerifier) VerifyToken(ctx context.Context, token string) (*Token, error) {
+	if tv.isEmulator {
+		panic("not implemented")
+	}
+
 	if tv.projectID == "" {
 		// Configuration error.
 		return nil, errors.New("project id not available")

--- a/auth/token_verifier_test.go
+++ b/auth/token_verifier_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNewIDTokenVerifier(t *testing.T) {
-	tv, err := newIDTokenVerifier(context.Background(), testProjectID)
+	tv, err := newIDTokenVerifier(context.Background(), testProjectID, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,6 +47,9 @@ func TestNewIDTokenVerifier(t *testing.T) {
 	}
 	if ks.KeyURI != idTokenCertURL {
 		t.Errorf("tokenVerifier.certURL = %q; want = %q", ks.KeyURI, idTokenCertURL)
+	}
+	if tv.isEmulator != true {
+		t.Errorf("tokenVerifier.isEmulator = %t; want = %t", tv.isEmulator, true)
 	}
 }
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -30,9 +30,8 @@ import (
 )
 
 const (
-	maxLenPayloadCC     = 1000
-	defaultProviderID   = "firebase"
-	idToolkitV1Endpoint = "https://identitytoolkit.googleapis.com/v1"
+	maxLenPayloadCC   = 1000
+	defaultProviderID = "firebase"
 
 	// Maximum number of users allowed to batch get at a time.
 	maxGetAccountsBatchSize = 100


### PR DESCRIPTION
If `FIREBASE_AUTH_EMULATOR_HOST` is set, auth API request will be sent to the host according to the environment variable.

### Discussion

#409 

~~Reflecting the [comment on the issue](https://github.com/firebase/firebase-admin-go/issues/409#issuecomment-743111881), the behavior of signers and token verifiers are unchanged.~~

Now the signer is replaced to `emulatedSigner`, and token verifiers panic when the environment variable is set. https://github.com/firebase/firebase-admin-go/pull/414#issuecomment-754931543 https://github.com/firebase/firebase-admin-go/pull/414#issuecomment-758166352
