### PR TITLE
chore: Installing golint before checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.12, 1.13, 1.14]
+        go: [1.12, 1.16]
 
     steps:
     - name: Set up Go ${{ matrix.go }}
@@ -15,12 +15,14 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
 
+    - name: Install golint
+      run: go get golang.org/x/lint/golint
+
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Run Linter
       run: |
-        go get -u golang.org/x/lint/golint
         GOLINT=`go list -f {{.Target}} golang.org/x/lint/golint`
         $GOLINT -set_exit_status ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
     name: Module build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go: [1.12, 1.16]
 
@@ -46,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}/go
+      GO111MODULE: off
 
     steps:
     - name: Set up Go 1.16

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,10 @@ jobs:
       GOPATH: ${{ github.workspace }}/go
 
     steps:
-    - name: Set up Go 1.12
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.16
 
     - name: Check out code into GOPATH
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
       with:
         go-version: 1.12
 
+    - name: Install golint
+      run: go get golang.org/x/lint/golint
+
     - name: Check out code
       uses: actions/checkout@v2
       with:
@@ -51,7 +54,6 @@ jobs:
 
     - name: Run Linter
       run: |
-        go get -u golang.org/x/lint/golint
         GOLINT=`go list -f {{.Target}} golang.org/x/lint/golint`
         $GOLINT -set_exit_status ./...
 


### PR DESCRIPTION
* Restricting build matrix to the oldest and latest go versions we support.
* Installing `golint` before checking out source to avoid accidental changes to the module dependencies (`go.mod` and `go.sum` files).
* Bumped the go version to 1.16 for the GOPATH build, since in this mode go pulls all the dependencies at their HEAD versions, and some of them no longer works on go 1.12.