### PR TITLE
feat(auth): enables OIDC Auth code flow

### DIFF
--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -215,10 +215,8 @@ func (config *OIDCProviderConfigToCreate) buildRequest() (nestedMap, string, err
 		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
 			return nil, "", errors.New("Only one response type may be chosen")
 		}
-	} else {
-		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || !val.(bool) {
-			return nil, "", errors.New("At least one response type must be returned")
-		}
+	} else if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || !val.(bool) {
+		return nil, "", errors.New("At least one response type must be returned")
 	}
 
 	return config.params, config.id, nil
@@ -309,9 +307,7 @@ func (config *OIDCProviderConfigToUpdate) buildRequest() (nestedMap, error) {
 		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
 			return nil, errors.New("Only one response type may be chosen")
 		}
-	}
-
-	if val, ok := config.params.Get(codeResponseTypeKey); ok && !val.(bool) {
+	} else if ok && !val.(bool) {
 		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && !val.(bool) {
 			return nil, errors.New("At least one response type must be returned")
 		}

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -159,14 +159,23 @@ func (config *OIDCProviderConfigToCreate) Enabled(enabled bool) *OIDCProviderCon
 	return config.set(enabledKey, enabled)
 }
 
+// ClientSecret sets the client secret for the new provider.
+// This is required for the code flow.
 func (config *OIDCProviderConfigToCreate) ClientSecret(secret string) *OIDCProviderConfigToCreate {
 	return config.set(clientSecretKey, secret)
 }
 
+// IDTokenResponseType sets whether to enable the ID token response flow for the new provider.
+// By default, this is enabled if no response type is specified.
+// Having both the code and ID token response flows is currently not supported.
 func (config *OIDCProviderConfigToCreate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToCreate {
 	return config.set(idTokenResponseTypeKey, enabled)
 }
 
+// CodeResponseType sets whether to enable the code response flow for the new provider.
+// By default, this is not enabled if no response type is specified.
+// A client secret must be set for this response type.
+// Having both the code and ID token response flows is currently not supported.
 func (config *OIDCProviderConfigToCreate) CodeResponseType(enabled bool) *OIDCProviderConfigToCreate {
 	return config.set(codeResponseTypeKey, enabled)
 }
@@ -238,14 +247,23 @@ func (config *OIDCProviderConfigToUpdate) Enabled(enabled bool) *OIDCProviderCon
 	return config.set(enabledKey, enabled)
 }
 
+// ClientSecret sets the client secret for the provider.
+// This is required for the code flow.
 func (config *OIDCProviderConfigToUpdate) ClientSecret(secret string) *OIDCProviderConfigToUpdate {
 	return config.set(clientSecretKey, secret)
 }
 
+// IDTokenResponseType sets whether to enable the ID token response flow for the provider.
+// By default, this is enabled if no response type is specified.
+// Having both the code and ID token response flows is currently not supported.
 func (config *OIDCProviderConfigToUpdate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToUpdate {
 	return config.set(idTokenResponseTypeKey, enabled)
 }
 
+// CodeResponseType sets whether to enable the code response flow for the new provider.
+// By default, this is not enabled if no response type is specified.
+// A client secret must be set for this response type.
+// Having both the code and ID token response flows is currently not supported.
 func (config *OIDCProviderConfigToUpdate) CodeResponseType(enabled bool) *OIDCProviderConfigToUpdate {
 	return config.set(codeResponseTypeKey, enabled)
 }

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -901,13 +901,13 @@ func (c *baseClient) makeRequest(
 }
 
 type oidcProviderConfigDAO struct {
-	Name            string                   `json:"name"`
-	ClientID        string                   `json:"clientId"`
-	Issuer          string                   `json:"issuer"`
-	DisplayName     string                   `json:"displayName"`
-	Enabled         bool                     `json:"enabled"`
-	ClientSecret    string                   `json:"clientSecret"`
-	ResponseEnabled oidcProviderResponseType `json:"responseType"`
+	Name         string                   `json:"name"`
+	ClientID     string                   `json:"clientId"`
+	Issuer       string                   `json:"issuer"`
+	DisplayName  string                   `json:"displayName"`
+	Enabled      bool                     `json:"enabled"`
+	ClientSecret string                   `json:"clientSecret"`
+	ResponseType oidcProviderResponseType `json:"responseType"`
 }
 
 type oidcProviderResponseType struct {
@@ -923,8 +923,8 @@ func (dao *oidcProviderConfigDAO) toOIDCProviderConfig() *OIDCProviderConfig {
 		ClientID:               dao.ClientID,
 		Issuer:                 dao.Issuer,
 		ClientSecret:           dao.ClientSecret,
-		CodeResponseEnabled:    dao.ResponseEnabled.Code,
-		IDTokenResponseEnabled: dao.ResponseEnabled.IDToken,
+		CodeResponseEnabled:    dao.ResponseType.Code,
+		IDTokenResponseEnabled: dao.ResponseType.IDToken,
 	}
 }
 

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -212,6 +212,13 @@ func (config *OIDCProviderConfigToCreate) buildRequest() (nestedMap, string, err
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, "", errors.New("Client Secret must not be empty for Code Response Type")
 		}
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
+			return nil, "", errors.New("Only one response type may be chosen")
+		}
+	} else {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || val.(bool) {
+			return nil, "", errors.New("At least one response type must be returned")
+		}
 	}
 
 	return config.params, config.id, nil
@@ -298,6 +305,13 @@ func (config *OIDCProviderConfigToUpdate) buildRequest() (nestedMap, error) {
 	if val, ok := config.params.Get(codeResponseTypeKey); ok && val.(bool) {
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, errors.New("Client Secret must not be empty for Code Response Type")
+		}
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
+			return nil, errors.New("Only one response type may be chosen")
+		}
+	} else {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || val.(bool) {
+			return nil, errors.New("At least one response type must be returned")
 		}
 	}
 

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -45,8 +45,8 @@ const (
 	displayNameKey = "displayName"
 	enabledKey     = "enabled"
 
-	idTokenResponseEnabledKey = "responseType.idToken"
-	codeResponseEnabledKey    = "responseType.code"
+	idTokenResponseTypeKey = "responseType.idToken"
+	codeResponseTypeKey    = "responseType.code"
 )
 
 type nestedMap map[string]interface{}
@@ -117,14 +117,14 @@ func buildMask(data map[string]interface{}) []string {
 // OIDCProviderConfig is the OIDC auth provider configuration.
 // See https://openid.net/specs/openid-connect-core-1_0-final.html.
 type OIDCProviderConfig struct {
-	ID                     string
-	DisplayName            string
-	Enabled                bool
-	ClientID               string
-	Issuer                 string
-	ClientSecret           string
-	CodeResponseEnabled    bool
-	IDTokenResponseEnabled bool
+	ID                  string
+	DisplayName         string
+	Enabled             bool
+	ClientID            string
+	Issuer              string
+	ClientSecret        string
+	CodeResponseType    bool
+	IDTokenResponseType bool
 }
 
 // OIDCProviderConfigToCreate represents the options used to create a new OIDCProviderConfig.
@@ -165,19 +165,19 @@ func (config *OIDCProviderConfigToCreate) ClientSecret(secret string) *OIDCProvi
 	return config.set(clientSecretKey, secret)
 }
 
-// IDTokenResponseEnabled sets whether to enable the ID token response flow for the new provider.
+// IDTokenResponseType sets whether to enable the ID token response flow for the new provider.
 // By default, this is enabled if no response type is specified.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToCreate) IDTokenResponseEnabled(enabled bool) *OIDCProviderConfigToCreate {
-	return config.set(idTokenResponseEnabledKey, enabled)
+func (config *OIDCProviderConfigToCreate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToCreate {
+	return config.set(idTokenResponseTypeKey, enabled)
 }
 
-// CodeResponseEnabled sets whether to enable the code response flow for the new provider.
+// CodeResponseType sets whether to enable the code response flow for the new provider.
 // By default, this is not enabled if no response type is specified.
 // A client secret must be set for this response type.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToCreate) CodeResponseEnabled(enabled bool) *OIDCProviderConfigToCreate {
-	return config.set(codeResponseEnabledKey, enabled)
+func (config *OIDCProviderConfigToCreate) CodeResponseType(enabled bool) *OIDCProviderConfigToCreate {
+	return config.set(codeResponseTypeKey, enabled)
 }
 
 func (config *OIDCProviderConfigToCreate) set(key string, value interface{}) *OIDCProviderConfigToCreate {
@@ -208,15 +208,15 @@ func (config *OIDCProviderConfigToCreate) buildRequest() (nestedMap, string, err
 		return nil, "", fmt.Errorf("failed to parse Issuer: %v", err)
 	}
 
-	if val, ok := config.params.Get(codeResponseEnabledKey); ok && val.(bool) {
+	if val, ok := config.params.Get(codeResponseTypeKey); ok && val.(bool) {
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, "", errors.New("Client Secret must not be empty for Code Response Type")
 		}
-		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
 			return nil, "", errors.New("Only one response type may be chosen")
 		}
 	} else if ok && !val.(bool) {
-		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && !val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && !val.(bool) {
 			return nil, "", errors.New("At least one response type must be returned")
 		}
 	}
@@ -260,19 +260,19 @@ func (config *OIDCProviderConfigToUpdate) ClientSecret(secret string) *OIDCProvi
 	return config.set(clientSecretKey, secret)
 }
 
-// IDTokenResponseEnabled sets whether to enable the ID token response flow for the provider.
+// IDTokenResponseType sets whether to enable the ID token response flow for the provider.
 // By default, this is enabled if no response type is specified.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToUpdate) IDTokenResponseEnabled(enabled bool) *OIDCProviderConfigToUpdate {
-	return config.set(idTokenResponseEnabledKey, enabled)
+func (config *OIDCProviderConfigToUpdate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToUpdate {
+	return config.set(idTokenResponseTypeKey, enabled)
 }
 
-// CodeResponseEnabled sets whether to enable the code response flow for the new provider.
+// CodeResponseType sets whether to enable the code response flow for the new provider.
 // By default, this is not enabled if no response type is specified.
 // A client secret must be set for this response type.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToUpdate) CodeResponseEnabled(enabled bool) *OIDCProviderConfigToUpdate {
-	return config.set(codeResponseEnabledKey, enabled)
+func (config *OIDCProviderConfigToUpdate) CodeResponseType(enabled bool) *OIDCProviderConfigToUpdate {
+	return config.set(codeResponseTypeKey, enabled)
 }
 
 func (config *OIDCProviderConfigToUpdate) set(key string, value interface{}) *OIDCProviderConfigToUpdate {
@@ -302,15 +302,15 @@ func (config *OIDCProviderConfigToUpdate) buildRequest() (nestedMap, error) {
 		}
 	}
 
-	if val, ok := config.params.Get(codeResponseEnabledKey); ok && val.(bool) {
+	if val, ok := config.params.Get(codeResponseTypeKey); ok && val.(bool) {
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, errors.New("Client Secret must not be empty for Code Response Type")
 		}
-		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
 			return nil, errors.New("Only one response type may be chosen")
 		}
 	} else if ok && !val.(bool) {
-		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && !val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && !val.(bool) {
 			return nil, errors.New("At least one response type must be returned")
 		}
 	}
@@ -917,14 +917,14 @@ type oidcProviderResponseType struct {
 
 func (dao *oidcProviderConfigDAO) toOIDCProviderConfig() *OIDCProviderConfig {
 	return &OIDCProviderConfig{
-		ID:                     extractResourceID(dao.Name),
-		DisplayName:            dao.DisplayName,
-		Enabled:                dao.Enabled,
-		ClientID:               dao.ClientID,
-		Issuer:                 dao.Issuer,
-		ClientSecret:           dao.ClientSecret,
-		CodeResponseEnabled:    dao.ResponseType.Code,
-		IDTokenResponseEnabled: dao.ResponseType.IDToken,
+		ID:                  extractResourceID(dao.Name),
+		DisplayName:         dao.DisplayName,
+		Enabled:             dao.Enabled,
+		ClientID:            dao.ClientID,
+		Issuer:              dao.Issuer,
+		ClientSecret:        dao.ClientSecret,
+		CodeResponseType:    dao.ResponseType.Code,
+		IDTokenResponseType: dao.ResponseType.IDToken,
 	}
 }
 

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -216,7 +216,7 @@ func (config *OIDCProviderConfigToCreate) buildRequest() (nestedMap, string, err
 			return nil, "", errors.New("Only one response type may be chosen")
 		}
 	} else {
-		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || !val.(bool) {
 			return nil, "", errors.New("At least one response type must be returned")
 		}
 	}
@@ -309,8 +309,10 @@ func (config *OIDCProviderConfigToUpdate) buildRequest() (nestedMap, error) {
 		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
 			return nil, errors.New("Only one response type may be chosen")
 		}
-	} else {
-		if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || val.(bool) {
+	}
+
+	if val, ok := config.params.Get(codeResponseTypeKey); ok && !val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && !val.(bool) {
 			return nil, errors.New("At least one response type must be returned")
 		}
 	}

--- a/auth/provider_config.go
+++ b/auth/provider_config.go
@@ -45,8 +45,8 @@ const (
 	displayNameKey = "displayName"
 	enabledKey     = "enabled"
 
-	idTokenResponseTypeKey = "responseType.idToken"
-	codeResponseTypeKey    = "responseType.code"
+	idTokenResponseEnabledKey = "responseType.idToken"
+	codeResponseEnabledKey    = "responseType.code"
 )
 
 type nestedMap map[string]interface{}
@@ -117,14 +117,14 @@ func buildMask(data map[string]interface{}) []string {
 // OIDCProviderConfig is the OIDC auth provider configuration.
 // See https://openid.net/specs/openid-connect-core-1_0-final.html.
 type OIDCProviderConfig struct {
-	ID                  string
-	DisplayName         string
-	Enabled             bool
-	ClientID            string
-	Issuer              string
-	ClientSecret        string
-	CodeResponseType    bool
-	IDTokenResponseType bool
+	ID                     string
+	DisplayName            string
+	Enabled                bool
+	ClientID               string
+	Issuer                 string
+	ClientSecret           string
+	CodeResponseEnabled    bool
+	IDTokenResponseEnabled bool
 }
 
 // OIDCProviderConfigToCreate represents the options used to create a new OIDCProviderConfig.
@@ -165,19 +165,19 @@ func (config *OIDCProviderConfigToCreate) ClientSecret(secret string) *OIDCProvi
 	return config.set(clientSecretKey, secret)
 }
 
-// IDTokenResponseType sets whether to enable the ID token response flow for the new provider.
+// IDTokenResponseEnabled sets whether to enable the ID token response flow for the new provider.
 // By default, this is enabled if no response type is specified.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToCreate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToCreate {
-	return config.set(idTokenResponseTypeKey, enabled)
+func (config *OIDCProviderConfigToCreate) IDTokenResponseEnabled(enabled bool) *OIDCProviderConfigToCreate {
+	return config.set(idTokenResponseEnabledKey, enabled)
 }
 
-// CodeResponseType sets whether to enable the code response flow for the new provider.
+// CodeResponseEnabled sets whether to enable the code response flow for the new provider.
 // By default, this is not enabled if no response type is specified.
 // A client secret must be set for this response type.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToCreate) CodeResponseType(enabled bool) *OIDCProviderConfigToCreate {
-	return config.set(codeResponseTypeKey, enabled)
+func (config *OIDCProviderConfigToCreate) CodeResponseEnabled(enabled bool) *OIDCProviderConfigToCreate {
+	return config.set(codeResponseEnabledKey, enabled)
 }
 
 func (config *OIDCProviderConfigToCreate) set(key string, value interface{}) *OIDCProviderConfigToCreate {
@@ -208,15 +208,17 @@ func (config *OIDCProviderConfigToCreate) buildRequest() (nestedMap, string, err
 		return nil, "", fmt.Errorf("failed to parse Issuer: %v", err)
 	}
 
-	if val, ok := config.params.Get(codeResponseTypeKey); ok && val.(bool) {
+	if val, ok := config.params.Get(codeResponseEnabledKey); ok && val.(bool) {
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, "", errors.New("Client Secret must not be empty for Code Response Type")
 		}
-		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && val.(bool) {
 			return nil, "", errors.New("Only one response type may be chosen")
 		}
-	} else if val, ok := config.params.Get(idTokenResponseTypeKey); !ok || !val.(bool) {
-		return nil, "", errors.New("At least one response type must be returned")
+	} else if ok && !val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && !val.(bool) {
+			return nil, "", errors.New("At least one response type must be returned")
+		}
 	}
 
 	return config.params, config.id, nil
@@ -258,19 +260,19 @@ func (config *OIDCProviderConfigToUpdate) ClientSecret(secret string) *OIDCProvi
 	return config.set(clientSecretKey, secret)
 }
 
-// IDTokenResponseType sets whether to enable the ID token response flow for the provider.
+// IDTokenResponseEnabled sets whether to enable the ID token response flow for the provider.
 // By default, this is enabled if no response type is specified.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToUpdate) IDTokenResponseType(enabled bool) *OIDCProviderConfigToUpdate {
-	return config.set(idTokenResponseTypeKey, enabled)
+func (config *OIDCProviderConfigToUpdate) IDTokenResponseEnabled(enabled bool) *OIDCProviderConfigToUpdate {
+	return config.set(idTokenResponseEnabledKey, enabled)
 }
 
-// CodeResponseType sets whether to enable the code response flow for the new provider.
+// CodeResponseEnabled sets whether to enable the code response flow for the new provider.
 // By default, this is not enabled if no response type is specified.
 // A client secret must be set for this response type.
 // Having both the code and ID token response flows is currently not supported.
-func (config *OIDCProviderConfigToUpdate) CodeResponseType(enabled bool) *OIDCProviderConfigToUpdate {
-	return config.set(codeResponseTypeKey, enabled)
+func (config *OIDCProviderConfigToUpdate) CodeResponseEnabled(enabled bool) *OIDCProviderConfigToUpdate {
+	return config.set(codeResponseEnabledKey, enabled)
 }
 
 func (config *OIDCProviderConfigToUpdate) set(key string, value interface{}) *OIDCProviderConfigToUpdate {
@@ -300,15 +302,15 @@ func (config *OIDCProviderConfigToUpdate) buildRequest() (nestedMap, error) {
 		}
 	}
 
-	if val, ok := config.params.Get(codeResponseTypeKey); ok && val.(bool) {
+	if val, ok := config.params.Get(codeResponseEnabledKey); ok && val.(bool) {
 		if val, ok := config.params.GetString(clientSecretKey); !ok || val == "" {
 			return nil, errors.New("Client Secret must not be empty for Code Response Type")
 		}
-		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && val.(bool) {
 			return nil, errors.New("Only one response type may be chosen")
 		}
 	} else if ok && !val.(bool) {
-		if val, ok := config.params.Get(idTokenResponseTypeKey); ok && !val.(bool) {
+		if val, ok := config.params.Get(idTokenResponseEnabledKey); ok && !val.(bool) {
 			return nil, errors.New("At least one response type must be returned")
 		}
 	}
@@ -899,13 +901,13 @@ func (c *baseClient) makeRequest(
 }
 
 type oidcProviderConfigDAO struct {
-	Name         string                   `json:"name"`
-	ClientID     string                   `json:"clientId"`
-	Issuer       string                   `json:"issuer"`
-	DisplayName  string                   `json:"displayName"`
-	Enabled      bool                     `json:"enabled"`
-	ClientSecret string                   `json:"clientSecret"`
-	ResponseType oidcProviderResponseType `json:"responseType"`
+	Name            string                   `json:"name"`
+	ClientID        string                   `json:"clientId"`
+	Issuer          string                   `json:"issuer"`
+	DisplayName     string                   `json:"displayName"`
+	Enabled         bool                     `json:"enabled"`
+	ClientSecret    string                   `json:"clientSecret"`
+	ResponseEnabled oidcProviderResponseType `json:"responseType"`
 }
 
 type oidcProviderResponseType struct {
@@ -915,14 +917,14 @@ type oidcProviderResponseType struct {
 
 func (dao *oidcProviderConfigDAO) toOIDCProviderConfig() *OIDCProviderConfig {
 	return &OIDCProviderConfig{
-		ID:                  extractResourceID(dao.Name),
-		DisplayName:         dao.DisplayName,
-		Enabled:             dao.Enabled,
-		ClientID:            dao.ClientID,
-		Issuer:              dao.Issuer,
-		ClientSecret:        dao.ClientSecret,
-		CodeResponseType:    dao.ResponseType.Code,
-		IDTokenResponseType: dao.ResponseType.IDToken,
+		ID:                     extractResourceID(dao.Name),
+		DisplayName:            dao.DisplayName,
+		Enabled:                dao.Enabled,
+		ClientID:               dao.ClientID,
+		Issuer:                 dao.Issuer,
+		ClientSecret:           dao.ClientSecret,
+		CodeResponseEnabled:    dao.ResponseEnabled.Code,
+		IDTokenResponseEnabled: dao.ResponseEnabled.IDToken,
 	}
 }
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -72,14 +72,14 @@ var idpCertsMap = []interface{}{
 }
 
 var oidcProviderConfig = &OIDCProviderConfig{
-	ID:                     "oidc.provider",
-	DisplayName:            "oidcProviderName",
-	Enabled:                true,
-	ClientID:               "CLIENT_ID",
-	Issuer:                 "https://oidc.com/issuer",
-	ClientSecret:           "CLIENT_SECRET",
-	CodeResponseEnabled:    true,
-	IDTokenResponseEnabled: true,
+	ID:                  "oidc.provider",
+	DisplayName:         "oidcProviderName",
+	Enabled:             true,
+	ClientID:            "CLIENT_ID",
+	Issuer:              "https://oidc.com/issuer",
+	ClientSecret:        "CLIENT_SECRET",
+	CodeResponseType:    true,
+	IDTokenResponseType: true,
 }
 
 var samlProviderConfig = &SAMLProviderConfig{
@@ -167,8 +167,8 @@ func TestCreateOIDCProviderConfig(t *testing.T) {
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
 		ClientSecret(oidcProviderConfig.ClientSecret).
-		CodeResponseEnabled(true).
-		IDTokenResponseEnabled(false)
+		CodeResponseType(true).
+		IDTokenResponseType(false)
 
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
@@ -204,7 +204,7 @@ func TestCreateOIDCProviderConfigMinimal(t *testing.T) {
 		ID(oidcProviderConfig.ID).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		IDTokenResponseEnabled(true)
+		IDTokenResponseType(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -235,8 +235,8 @@ func TestCreateOIDCProviderConfigZeroValues(t *testing.T) {
 		Enabled(false).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		CodeResponseEnabled(false).
-		IDTokenResponseEnabled(true)
+		CodeResponseType(false).
+		IDTokenResponseType(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +272,7 @@ func TestCreateOIDCProviderConfigError(t *testing.T) {
 		ID(oidcProviderConfig.ID).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		IDTokenResponseEnabled(true)
+		IDTokenResponseType(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if oidc != nil || !errorutils.IsInternal(err) {
 		t.Errorf("CreateOIDCProviderConfig() = (%v, %v); want = (nil, %q)", oidc, err, "internal-error")
@@ -336,7 +336,7 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				CodeResponseEnabled(true),
+				CodeResponseType(true),
 		},
 		{
 			name: "TwoResponseTypes",
@@ -345,8 +345,8 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseEnabled(true).
-				CodeResponseEnabled(true).
+				IDTokenResponseType(true).
+				CodeResponseType(true).
 				ClientSecret("secret"),
 		},
 		{
@@ -356,8 +356,8 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseEnabled(false).
-				CodeResponseEnabled(false),
+				IDTokenResponseType(false).
+				CodeResponseType(false),
 		},
 	}
 
@@ -381,8 +381,8 @@ func TestUpdateOIDCProviderConfig(t *testing.T) {
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
 		ClientSecret(oidcProviderConfig.ClientSecret).
-		CodeResponseEnabled(true).
-		IDTokenResponseEnabled(false)
+		CodeResponseType(true).
+		IDTokenResponseType(false)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -452,8 +452,8 @@ func TestUpdateOIDCProviderConfigZeroValues(t *testing.T) {
 	options := (&OIDCProviderConfigToUpdate{}).
 		DisplayName("").
 		Enabled(false).
-		CodeResponseEnabled(false).
-		IDTokenResponseEnabled(true)
+		CodeResponseType(false).
+		IDTokenResponseType(true)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -535,15 +535,15 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			want: "Client Secret must not be empty for Code Response Type",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				CodeResponseEnabled(true),
+				CodeResponseType(true),
 		},
 		{
 			name: "TwoResponseTypes",
 			want: "Only one response type may be chosen",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseEnabled(true).
-				CodeResponseEnabled(true).
+				IDTokenResponseType(true).
+				CodeResponseType(true).
 				ClientSecret("secret"),
 		},
 		{
@@ -551,8 +551,8 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			want: "At least one response type must be returned",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseEnabled(false).
-				CodeResponseEnabled(false),
+				IDTokenResponseType(false).
+				CodeResponseType(false),
 		},
 	}
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -72,14 +72,14 @@ var idpCertsMap = []interface{}{
 }
 
 var oidcProviderConfig = &OIDCProviderConfig{
-	ID:                  "oidc.provider",
-	DisplayName:         "oidcProviderName",
-	Enabled:             true,
-	ClientID:            "CLIENT_ID",
-	Issuer:              "https://oidc.com/issuer",
-	ClientSecret:        "CLIENT_SECRET",
-	CodeResponseType:    true,
-	IDTokenResponseType: true,
+	ID:                     "oidc.provider",
+	DisplayName:            "oidcProviderName",
+	Enabled:                true,
+	ClientID:               "CLIENT_ID",
+	Issuer:                 "https://oidc.com/issuer",
+	ClientSecret:           "CLIENT_SECRET",
+	CodeResponseEnabled:    true,
+	IDTokenResponseEnabled: true,
 }
 
 var samlProviderConfig = &SAMLProviderConfig{
@@ -167,8 +167,8 @@ func TestCreateOIDCProviderConfig(t *testing.T) {
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
 		ClientSecret(oidcProviderConfig.ClientSecret).
-		CodeResponseType(true).
-		IDTokenResponseType(false)
+		CodeResponseEnabled(true).
+		IDTokenResponseEnabled(false)
 
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
@@ -204,7 +204,7 @@ func TestCreateOIDCProviderConfigMinimal(t *testing.T) {
 		ID(oidcProviderConfig.ID).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		IDTokenResponseType(true)
+		IDTokenResponseEnabled(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -235,8 +235,8 @@ func TestCreateOIDCProviderConfigZeroValues(t *testing.T) {
 		Enabled(false).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		CodeResponseType(false).
-		IDTokenResponseType(true)
+		CodeResponseEnabled(false).
+		IDTokenResponseEnabled(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -272,7 +272,7 @@ func TestCreateOIDCProviderConfigError(t *testing.T) {
 		ID(oidcProviderConfig.ID).
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
-		IDTokenResponseType(true)
+		IDTokenResponseEnabled(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if oidc != nil || !errorutils.IsInternal(err) {
 		t.Errorf("CreateOIDCProviderConfig() = (%v, %v); want = (nil, %q)", oidc, err, "internal-error")
@@ -336,7 +336,7 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				CodeResponseType(true),
+				CodeResponseEnabled(true),
 		},
 		{
 			name: "TwoResponseTypes",
@@ -345,8 +345,8 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseType(true).
-				CodeResponseType(true).
+				IDTokenResponseEnabled(true).
+				CodeResponseEnabled(true).
 				ClientSecret("secret"),
 		},
 		{
@@ -356,16 +356,8 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ID("oidc.provider").
 				ClientID("CLIENT_ID").
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseType(false).
-				CodeResponseType(false),
-		},
-		{
-			name: "ResponseTypesMissing",
-			want: "At least one response type must be returned",
-			conf: (&OIDCProviderConfigToCreate{}).
-				ID("oidc.provider").
-				ClientID("CLIENT_ID").
-				Issuer("https://oidc.com/issuer"),
+				IDTokenResponseEnabled(false).
+				CodeResponseEnabled(false),
 		},
 	}
 
@@ -389,8 +381,8 @@ func TestUpdateOIDCProviderConfig(t *testing.T) {
 		ClientID(oidcProviderConfig.ClientID).
 		Issuer(oidcProviderConfig.Issuer).
 		ClientSecret(oidcProviderConfig.ClientSecret).
-		CodeResponseType(true).
-		IDTokenResponseType(false)
+		CodeResponseEnabled(true).
+		IDTokenResponseEnabled(false)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -460,8 +452,8 @@ func TestUpdateOIDCProviderConfigZeroValues(t *testing.T) {
 	options := (&OIDCProviderConfigToUpdate{}).
 		DisplayName("").
 		Enabled(false).
-		CodeResponseType(false).
-		IDTokenResponseType(true)
+		CodeResponseEnabled(false).
+		IDTokenResponseEnabled(true)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -543,15 +535,15 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			want: "Client Secret must not be empty for Code Response Type",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				CodeResponseType(true),
+				CodeResponseEnabled(true),
 		},
 		{
 			name: "TwoResponseTypes",
 			want: "Only one response type may be chosen",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseType(true).
-				CodeResponseType(true).
+				IDTokenResponseEnabled(true).
+				CodeResponseEnabled(true).
 				ClientSecret("secret"),
 		},
 		{
@@ -559,8 +551,8 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			want: "At least one response type must be returned",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
-				IDTokenResponseType(false).
-				CodeResponseType(false),
+				IDTokenResponseEnabled(false).
+				CodeResponseEnabled(false),
 		},
 	}
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -33,7 +33,12 @@ const oidcConfigResponse = `{
     "clientId": "CLIENT_ID",
     "issuer": "https://oidc.com/issuer",
     "displayName": "oidcProviderName",
-    "enabled": true
+    "enabled": true,
+		"clientSecret": "CLIENT_SECRET",
+		"responseType": {
+			"code": true,
+			"idToken": true
+		}
 }`
 
 const samlConfigResponse = `{
@@ -67,11 +72,14 @@ var idpCertsMap = []interface{}{
 }
 
 var oidcProviderConfig = &OIDCProviderConfig{
-	ID:          "oidc.provider",
-	DisplayName: "oidcProviderName",
-	Enabled:     true,
-	ClientID:    "CLIENT_ID",
-	Issuer:      "https://oidc.com/issuer",
+	ID:                  "oidc.provider",
+	DisplayName:         "oidcProviderName",
+	Enabled:             true,
+	ClientID:            "CLIENT_ID",
+	Issuer:              "https://oidc.com/issuer",
+	ClientSecret:        "CLIENT_SECRET",
+	CodeResponseType:    true,
+	IDTokenResponseType: true,
 }
 
 var samlProviderConfig = &SAMLProviderConfig{
@@ -157,7 +165,11 @@ func TestCreateOIDCProviderConfig(t *testing.T) {
 		DisplayName(oidcProviderConfig.DisplayName).
 		Enabled(oidcProviderConfig.Enabled).
 		ClientID(oidcProviderConfig.ClientID).
-		Issuer(oidcProviderConfig.Issuer)
+		Issuer(oidcProviderConfig.Issuer).
+		ClientSecret(oidcProviderConfig.ClientSecret).
+		CodeResponseType(true).
+		IDTokenResponseType(true)
+
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -168,10 +180,15 @@ func TestCreateOIDCProviderConfig(t *testing.T) {
 	}
 
 	wantBody := map[string]interface{}{
-		"displayName": oidcProviderConfig.DisplayName,
-		"enabled":     oidcProviderConfig.Enabled,
-		"clientId":    oidcProviderConfig.ClientID,
-		"issuer":      oidcProviderConfig.Issuer,
+		"displayName":  oidcProviderConfig.DisplayName,
+		"enabled":      oidcProviderConfig.Enabled,
+		"clientId":     oidcProviderConfig.ClientID,
+		"issuer":       oidcProviderConfig.Issuer,
+		"clientSecret": oidcProviderConfig.ClientSecret,
+		"responseType": map[string]interface{}{
+			"code":    true,
+			"idToken": true,
+		},
 	}
 	if err := checkCreateOIDCConfigRequest(s, wantBody); err != nil {
 		t.Fatal(err)
@@ -215,7 +232,9 @@ func TestCreateOIDCProviderConfigZeroValues(t *testing.T) {
 		DisplayName("").
 		Enabled(false).
 		ClientID(oidcProviderConfig.ClientID).
-		Issuer(oidcProviderConfig.Issuer)
+		Issuer(oidcProviderConfig.Issuer).
+		CodeResponseType(false).
+		IDTokenResponseType(false)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -230,6 +249,10 @@ func TestCreateOIDCProviderConfigZeroValues(t *testing.T) {
 		"enabled":     false,
 		"clientId":    oidcProviderConfig.ClientID,
 		"issuer":      oidcProviderConfig.Issuer,
+		"responseType": map[string]interface{}{
+			"code":    false,
+			"idToken": false,
+		},
 	}
 	if err := checkCreateOIDCConfigRequest(s, wantBody); err != nil {
 		t.Fatal(err)
@@ -303,6 +326,15 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				ClientID("CLIENT_ID").
 				Issuer("not a url"),
 		},
+		{
+			name: "MissingClientSecret",
+			want: "Client Secret must not be empty for Code Response Type",
+			conf: (&OIDCProviderConfigToCreate{}).
+				ID("oidc.provider").
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer").
+				CodeResponseType(true),
+		},
 	}
 
 	client := &baseClient{}
@@ -323,7 +355,10 @@ func TestUpdateOIDCProviderConfig(t *testing.T) {
 		DisplayName(oidcProviderConfig.DisplayName).
 		Enabled(oidcProviderConfig.Enabled).
 		ClientID(oidcProviderConfig.ClientID).
-		Issuer(oidcProviderConfig.Issuer)
+		Issuer(oidcProviderConfig.Issuer).
+		ClientSecret(oidcProviderConfig.ClientSecret).
+		CodeResponseType(true).
+		IDTokenResponseType(true)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -334,16 +369,24 @@ func TestUpdateOIDCProviderConfig(t *testing.T) {
 	}
 
 	wantBody := map[string]interface{}{
-		"displayName": oidcProviderConfig.DisplayName,
-		"enabled":     oidcProviderConfig.Enabled,
-		"clientId":    oidcProviderConfig.ClientID,
-		"issuer":      oidcProviderConfig.Issuer,
+		"displayName":  oidcProviderConfig.DisplayName,
+		"enabled":      oidcProviderConfig.Enabled,
+		"clientId":     oidcProviderConfig.ClientID,
+		"issuer":       oidcProviderConfig.Issuer,
+		"clientSecret": oidcProviderConfig.ClientSecret,
+		"responseType": map[string]interface{}{
+			"code":    true,
+			"idToken": true,
+		},
 	}
 	wantMask := []string{
 		"clientId",
+		"clientSecret",
 		"displayName",
 		"enabled",
 		"issuer",
+		"responseType.code",
+		"responseType.idToken",
 	}
 	if err := checkUpdateOIDCConfigRequest(s, wantBody, wantMask); err != nil {
 		t.Fatal(err)
@@ -384,7 +427,9 @@ func TestUpdateOIDCProviderConfigZeroValues(t *testing.T) {
 	client := s.Client
 	options := (&OIDCProviderConfigToUpdate{}).
 		DisplayName("").
-		Enabled(false)
+		Enabled(false).
+		CodeResponseType(false).
+		IDTokenResponseType(false)
 	oidc, err := client.UpdateOIDCProviderConfig(context.Background(), "oidc.provider", options)
 	if err != nil {
 		t.Fatal(err)
@@ -397,10 +442,16 @@ func TestUpdateOIDCProviderConfigZeroValues(t *testing.T) {
 	wantBody := map[string]interface{}{
 		"displayName": nil,
 		"enabled":     false,
+		"responseType": map[string]interface{}{
+			"code":    false,
+			"idToken": false,
+		},
 	}
 	wantMask := []string{
 		"displayName",
 		"enabled",
+		"responseType.code",
+		"responseType.idToken",
 	}
 	if err := checkUpdateOIDCConfigRequest(s, wantBody, wantMask); err != nil {
 		t.Fatal(err)
@@ -454,6 +505,13 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			want: "failed to parse Issuer: ",
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("not a url"),
+		},
+		{
+			name: "MissingClientSecret",
+			want: "Client Secret must not be empty for Code Response Type",
+			conf: (&OIDCProviderConfigToUpdate{}).
+				Issuer("https://oidc.com/issuer").
+				CodeResponseType(true),
 		},
 	}
 

--- a/auth/provider_config_test.go
+++ b/auth/provider_config_test.go
@@ -335,6 +335,35 @@ func TestCreateOIDCProviderConfigInvalidInput(t *testing.T) {
 				Issuer("https://oidc.com/issuer").
 				CodeResponseType(true),
 		},
+		{
+			name: "TwoResponseTypes",
+			want: "Only one response type may be chosen",
+			conf: (&OIDCProviderConfigToCreate{}).
+				ID("oidc.provider").
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer").
+				IdTokenResponseType(true).
+				CodeResponseType(true).
+				ClientSecret("secret"),
+		},
+		{
+			name: "ZeroResponseTypes",
+			want: "At least one response type must be returned",
+			conf: (&OIDCProviderConfigToCreate{}).
+				ID("oidc.provider").
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer").
+				IdTokenResponseType(false).
+				CodeResponseType(false),
+		},
+		{
+			name: "ResponseTypesMissing",
+			want: "At least one response type must be returned",
+			conf: (&OIDCProviderConfigToCreate{}).
+				ID("oidc.provider").
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer"),
+		},
 	}
 
 	client := &baseClient{}
@@ -512,6 +541,32 @@ func TestUpdateOIDCProviderConfigInvalidInput(t *testing.T) {
 			conf: (&OIDCProviderConfigToUpdate{}).
 				Issuer("https://oidc.com/issuer").
 				CodeResponseType(true),
+		},
+		{
+			name: "TwoResponseTypes",
+			want: "Only one response type may be chosen",
+			conf: (&OIDCProviderConfigToUpdate{}).
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer").
+				IdTokenResponseType(true).
+				CodeResponseType(true).
+				ClientSecret("secret"),
+		},
+		{
+			name: "ZeroResponseTypes",
+			want: "At least one response type must be returned",
+			conf: (&OIDCProviderConfigToUpdate{}).
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer").
+				IdTokenResponseType(false).
+				CodeResponseType(false),
+		},
+		{
+			name: "ResponseTypesMissing",
+			want: "At least one response type must be returned",
+			conf: (&OIDCProviderConfigToUpdate{}).
+				ClientID("CLIENT_ID").
+				Issuer("https://oidc.com/issuer"),
 		},
 	}
 

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -612,7 +612,8 @@ func TestTenantCreateOIDCProviderConfig(t *testing.T) {
 		DisplayName(oidcProviderConfig.DisplayName).
 		Enabled(oidcProviderConfig.Enabled).
 		ClientID(oidcProviderConfig.ClientID).
-		Issuer(oidcProviderConfig.Issuer)
+		Issuer(oidcProviderConfig.Issuer).
+		IDTokenResponseType(true)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -623,10 +624,11 @@ func TestTenantCreateOIDCProviderConfig(t *testing.T) {
 	}
 
 	wantBody := map[string]interface{}{
-		"displayName": oidcProviderConfig.DisplayName,
-		"enabled":     oidcProviderConfig.Enabled,
-		"clientId":    oidcProviderConfig.ClientID,
-		"issuer":      oidcProviderConfig.Issuer,
+		"displayName":  oidcProviderConfig.DisplayName,
+		"enabled":      oidcProviderConfig.Enabled,
+		"clientId":     oidcProviderConfig.ClientID,
+		"issuer":       oidcProviderConfig.Issuer,
+		"responseType": map[string]interface{}{"idToken": true},
 	}
 	wantURL := "/projects/mock-project-id/tenants/tenantID/oauthIdpConfigs"
 	if err := checkCreateOIDCConfigRequestWithURL(s, wantBody, wantURL); err != nil {

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -612,8 +612,7 @@ func TestTenantCreateOIDCProviderConfig(t *testing.T) {
 		DisplayName(oidcProviderConfig.DisplayName).
 		Enabled(oidcProviderConfig.Enabled).
 		ClientID(oidcProviderConfig.ClientID).
-		Issuer(oidcProviderConfig.Issuer).
-		IDTokenResponseType(true)
+		Issuer(oidcProviderConfig.Issuer)
 	oidc, err := client.CreateOIDCProviderConfig(context.Background(), options)
 	if err != nil {
 		t.Fatal(err)
@@ -624,11 +623,10 @@ func TestTenantCreateOIDCProviderConfig(t *testing.T) {
 	}
 
 	wantBody := map[string]interface{}{
-		"displayName":  oidcProviderConfig.DisplayName,
-		"enabled":      oidcProviderConfig.Enabled,
-		"clientId":     oidcProviderConfig.ClientID,
-		"issuer":       oidcProviderConfig.Issuer,
-		"responseType": map[string]interface{}{"idToken": true},
+		"displayName": oidcProviderConfig.DisplayName,
+		"enabled":     oidcProviderConfig.Enabled,
+		"clientId":    oidcProviderConfig.ClientID,
+		"issuer":      oidcProviderConfig.Issuer,
 	}
 	wantURL := "/projects/mock-project-id/tenants/tenantID/oauthIdpConfigs"
 	if err := checkCreateOIDCConfigRequestWithURL(s, wantBody, wantURL); err != nil {


### PR DESCRIPTION
Provides an option for developers to specify the OAuth response type for 
their OIDC provider (either one of these can be set:):

id_token
code (if set, must also set the client secret)

RELEASE NOTES: Added support for configuring the authorization code flow for OIDC providers.