### PR TITLE
add DEPRECATED labels on godoc

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -476,7 +476,7 @@ func IsEmailNotFound(err error) bool {
 
 // IsInsufficientPermission checks if the given error was due to insufficient permissions.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsInsufficientPermission(err error) bool {
 	return false
 }
@@ -488,7 +488,7 @@ func IsInvalidDynamicLinkDomain(err error) bool {
 
 // IsInvalidEmail checks if the given error was due to an invalid email.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsInvalidEmail(err error) bool {
 	return false
 }
@@ -500,7 +500,7 @@ func IsPhoneNumberAlreadyExists(err error) bool {
 
 // IsProjectNotFound checks if the given error was due to a non-existing project.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsProjectNotFound(err error) bool {
 	return false
 }
@@ -522,7 +522,7 @@ func IsUnauthorizedContinueURI(err error) bool {
 
 // IsUnknown checks if the given error was due to a unknown server error.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsUnknown(err error) bool {
 	return false
 }
@@ -640,7 +640,7 @@ func (c *baseClient) GetUserByPhoneNumber(ctx context.Context, phone string) (*U
 
 // GetUserByProviderID is an alias for GetUserByProviderUID.
 //
-// Deprecated. Use GetUserByProviderUID instead.
+// Deprecated: Use GetUserByProviderUID instead.
 func (c *baseClient) GetUserByProviderID(ctx context.Context, providerID string, providerUID string) (*UserRecord, error) {
 	return c.GetUserByProviderUID(ctx, providerID, providerUID)
 }

--- a/iid/iid.go
+++ b/iid/iid.go
@@ -41,7 +41,7 @@ var errorMessages = map[int]string{
 
 // IsInvalidArgument checks if the given error was due to an invalid instance ID argument.
 //
-// Deprecated. Use errorutils.IsInvalidArgument() function instead.
+// Deprecated: Use errorutils.IsInvalidArgument() function instead.
 func IsInvalidArgument(err error) bool {
 	return errorutils.IsInvalidArgument(err)
 }
@@ -50,7 +50,7 @@ func IsInvalidArgument(err error) bool {
 // required authorization. This could be due to the client not having the required permission
 // or the specified instance ID not matching the target Firebase project.
 //
-// Deprecated. Use errorutils.IsUnauthenticated() or errorutils.IsPermissionDenied() instead.
+// Deprecated: Use errorutils.IsUnauthenticated() or errorutils.IsPermissionDenied() instead.
 func IsInsufficientPermission(err error) bool {
 	return errorutils.IsUnauthenticated(err) || errorutils.IsPermissionDenied(err)
 }
@@ -63,7 +63,7 @@ func IsNotFound(err error) bool {
 // IsAlreadyDeleted checks if the given error was due to the instance ID being already deleted from
 // the project.
 //
-// Deprecated. Use errorutils.IsConflict() function instead.
+// Deprecated: Use errorutils.IsConflict() function instead.
 func IsAlreadyDeleted(err error) bool {
 	return errorutils.IsConflict(err)
 }
@@ -71,14 +71,14 @@ func IsAlreadyDeleted(err error) bool {
 // IsTooManyRequests checks if the given error was due to the client sending too many requests
 // causing a server quota to exceed.
 //
-// Deprecated. Use errorutils.IsResourceExhausted() function instead.
+// Deprecated: Use errorutils.IsResourceExhausted() function instead.
 func IsTooManyRequests(err error) bool {
 	return errorutils.IsResourceExhausted(err)
 }
 
 // IsInternal checks if the given error was due to an internal server error.
 //
-// Deprecated. Use errorutils.IsInternal() function instead.
+// Deprecated: Use errorutils.IsInternal() function instead.
 func IsInternal(err error) bool {
 	return errorutils.IsInternal(err)
 }
@@ -86,14 +86,14 @@ func IsInternal(err error) bool {
 // IsServerUnavailable checks if the given error was due to the backend server being temporarily
 // unavailable.
 //
-// Deprecated. Use errorutils.IsUnavailable() function instead.
+// Deprecated: Use errorutils.IsUnavailable() function instead.
 func IsServerUnavailable(err error) bool {
 	return errorutils.IsUnavailable(err)
 }
 
 // IsUnknown checks if the given error was due to unknown error returned by the backend server.
 //
-// Deprecated. Use errorutils.IsUnknown() function instead.
+// Deprecated: Use errorutils.IsUnknown() function instead.
 func IsUnknown(err error) bool {
 	return errorutils.IsUnknown(err)
 }

--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -955,7 +955,7 @@ func IsInternal(err error) bool {
 // IsInvalidAPNSCredentials checks if the given error was due to invalid APNS certificate or auth
 // key.
 //
-// Deprecated. Use IsThirdPartyAuthError().
+// Deprecated: Use IsThirdPartyAuthError().
 func IsInvalidAPNSCredentials(err error) bool {
 	return IsThirdPartyAuthError(err)
 }
@@ -973,7 +973,7 @@ func IsInvalidArgument(err error) bool {
 
 // IsMessageRateExceeded checks if the given error was due to the client exceeding a quota.
 //
-// Deprecated. Use IsQuotaExceeded().
+// Deprecated: Use IsQuotaExceeded().
 func IsMessageRateExceeded(err error) bool {
 	return IsQuotaExceeded(err)
 }
@@ -986,7 +986,7 @@ func IsQuotaExceeded(err error) bool {
 // IsMismatchedCredential checks if the given error was due to an invalid credential or permission
 // error.
 //
-// Deprecated. Use IsSenderIDMismatch().
+// Deprecated: Use IsSenderIDMismatch().
 func IsMismatchedCredential(err error) bool {
 	return IsSenderIDMismatch(err)
 }
@@ -1000,7 +1000,7 @@ func IsSenderIDMismatch(err error) bool {
 // IsRegistrationTokenNotRegistered checks if the given error was due to a registration token that
 // became invalid.
 //
-// Deprecated. Use IsUnregistered().
+// Deprecated: Use IsUnregistered().
 func IsRegistrationTokenNotRegistered(err error) bool {
 	return IsUnregistered(err)
 }
@@ -1014,7 +1014,7 @@ func IsUnregistered(err error) bool {
 // IsServerUnavailable checks if the given error was due to the backend server being temporarily
 // unavailable.
 //
-// Deprecated. Use IsUnavailable().
+// Deprecated: Use IsUnavailable().
 func IsServerUnavailable(err error) bool {
 	return IsUnavailable(err)
 }
@@ -1028,14 +1028,14 @@ func IsUnavailable(err error) bool {
 // IsTooManyTopics checks if the given error was due to the client exceeding the allowed number
 // of topics.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsTooManyTopics(err error) bool {
 	return false
 }
 
 // IsUnknown checks if the given error was due to unknown error returned by the backend server.
 //
-// Deprecated. Always returns false.
+// Deprecated: Always returns false.
 func IsUnknown(err error) bool {
 	return false
 }


### PR DESCRIPTION
godoc accepts “Deprecated:” comments as a depected feature.

https://go.dev/blog/godoc

> Sometimes a struct field, function, type, or even a whole package becomes redundant or unnecessary,
> but must be kept for compatibility with existing programs. To signal that an identifier should not be used,
> add a paragraph to its doc comment that begins with “Deprecated:” followed by some information about the deprecation.

For example, https://pkg.go.dev/net/http/httputil#ClientConn

![image](https://user-images.githubusercontent.com/1157344/143366768-37f8a5ce-99e5-48bc-866f-dbba3f1eae17.png)

