### PR TITLE
fix: Removing empty/unspecified fields from UserProvider

### DIFF
--- a/auth/import_users.go
+++ b/auth/import_users.go
@@ -195,9 +195,9 @@ func (u *UserToImport) set(key string, value interface{}) *UserToImport {
 type UserProvider struct {
 	UID         string `json:"rawId"`
 	ProviderID  string `json:"providerId"`
-	Email       string `json:"email"`
-	DisplayName string `json:"displayName"`
-	PhotoURL    string `json:"photoUrl"`
+	Email       string `json:"email,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	PhotoURL    string `json:"photoUrl,omitempty"`
 }
 
 // ProviderData setter.

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1134,6 +1134,62 @@ func TestSetCustomUserClaims(t *testing.T) {
 	}
 }
 
+func TestUserProvider(t *testing.T) {
+	cases := []struct {
+		provider *UserProvider
+		want     map[string]interface{}
+	}{
+		{
+			provider: &UserProvider{UID: "test", ProviderID: "google.com"},
+			want:     map[string]interface{}{"rawId": "test", "providerId": "google.com"},
+		},
+		{
+			provider: &UserProvider{
+				UID:         "test",
+				ProviderID:  "google.com",
+				DisplayName: "Test User",
+			},
+			want: map[string]interface{}{
+				"rawId":       "test",
+				"providerId":  "google.com",
+				"displayName": "Test User",
+			},
+		},
+		{
+			provider: &UserProvider{
+				UID:         "test",
+				ProviderID:  "google.com",
+				DisplayName: "Test User",
+				Email:       "test@example.com",
+				PhotoURL:    "https://test.com/user.png",
+			},
+			want: map[string]interface{}{
+				"rawId":       "test",
+				"providerId":  "google.com",
+				"displayName": "Test User",
+				"email":       "test@example.com",
+				"photoUrl":    "https://test.com/user.png",
+			},
+		},
+	}
+
+	for idx, tc := range cases {
+		b, err := json.Marshal(tc.provider)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var got map[string]interface{}
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("[%d] UserProvider = %#v; want = %#v", idx, got, tc.want)
+		}
+	}
+}
+
 func TestUserToImport(t *testing.T) {
 	cases := []struct {
 		user *UserToImport


### PR DESCRIPTION
Prevent serializing empty strings for unspecified fields in `auth.UserProvider`. 