### PR TITLE
chore: Bumped minimum go version to 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.12, 1.16]
+        go: [1.15, 1.17]
 
     steps:
     - name: Set up Go ${{ matrix.go }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.15, 1.17]
+        go: [1.15, 1.16, 1.17]
 
     steps:
     - name: Set up Go ${{ matrix.go }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.15
 
     - name: Install golint
       run: go get golang.org/x/lint/golint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.12
+        go-version: 1.15
 
     - name: Install golint
       run: go get golang.org/x/lint/golint

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Go Versions
 
-We support Go v1.12 and higher.
+Admin Go SDK is compatible with at least the three most recent, major Go releases.
+We currently support Go v1.15 and higher.
 [Continuous integration](https://github.com/firebase/firebase-admin-go/actions) system
-tests the code on Go v1.12 through v1.14.
+tests the code on Go v1.15 through v1.17.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ requests, code review feedback, and also pull requests.
 
 ## Supported Go Versions
 
-Admin Go SDK is compatible with at least the three most recent, major Go releases.
+The Admin Go SDK is compatible with at least the three most recent, major Go releases.
 We currently support Go v1.15 and higher.
 [Continuous integration](https://github.com/firebase/firebase-admin-go/actions) system
 tests the code on Go v1.15 through v1.17.

--- a/auth/auth_appengine.go
+++ b/auth/auth_appengine.go
@@ -1,3 +1,4 @@
+//go:build appengine
 // +build appengine
 
 // Copyright 2017 Google Inc. All Rights Reserved.

--- a/auth/auth_std.go
+++ b/auth/auth_std.go
@@ -1,3 +1,4 @@
+//go:build !appengine
 // +build !appengine
 
 // Copyright 2017 Google Inc. All Rights Reserved.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module firebase.google.com/go/v4
 
-go 1.11
+go 1.15
 
 require (
 	cloud.google.com/go/firestore v1.5.0


### PR DESCRIPTION
- Supporting the latest go version (1.17) and 2 previous as per policy.
- Restricting build matrix to the oldest and latest go versions we support (1.15 to 1.17).

RELEASE NOTE: Dropped support for Go 1.11 to 1.14. Go Admin SDK now requires Go 1.15 or higher.