### PR TITLE
use go install to install golint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.15, 1.16, 1.17]
+        go:
+          - "1.15"
+          - "1.16"
+          - "1.17"
+          - "1.18"
 
     steps:
     - name: Set up Go ${{ matrix.go }}
@@ -17,15 +21,14 @@ jobs:
         go-version: ${{ matrix.go }}
 
     - name: Install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
       uses: actions/checkout@v2
 
     - name: Run Linter
       run: |
-        GOLINT=`go list -f {{.Target}} golang.org/x/lint/golint`
-        $GOLINT -set_exit_status ./...
+        golint -set_exit_status ./...
 
     - name: Run Unit Tests
       if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
 
@@ -54,7 +54,7 @@ jobs:
 
     steps:
     - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.16
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - "1.15"
           - "1.16"
           - "1.17"
           - "1.18"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: "1.18"
 
     - name: Install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
       uses: actions/checkout@v2
@@ -43,8 +43,7 @@ jobs:
 
     - name: Run Linter
       run: |
-        GOLINT=`go list -f {{.Target}} golang.org/x/lint/golint`
-        $GOLINT -set_exit_status ./...
+        golint -set_exit_status ./...
 
     - name: Run Tests
       run: ./.github/scripts/run_all_tests.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: "1.18"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     # via the 'ref' client parameter.
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: "1.18"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: "1.18"
 
     - name: Install golint
-      run: go get golang.org/x/lint/golint
+      run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
       uses: actions/checkout@v2
@@ -54,8 +54,7 @@ jobs:
 
     - name: Run Linter
       run: |
-        GOLINT=`go list -f {{.Target}} golang.org/x/lint/golint`
-        $GOLINT -set_exit_status ./...
+        golint -set_exit_status ./...
 
     - name: Run Tests
       run: ./.github/scripts/run_all_tests.sh


### PR DESCRIPTION
use of go get to build and install packages is deprecated.

FYI, golint is also deprecated https://github.com/golang/go/issues/38968
