### PR TITLE
[chore] Release 4.9.0

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -38,7 +38,7 @@ import (
 var defaultAuthOverrides = make(map[string]interface{})
 
 // Version of the Firebase Go Admin SDK.
-const Version = "4.8.0"
+const Version = "4.9.0"
 
 // firebaseEnvName is the name of the environment variable with the Config.
 const firebaseEnvName = "FIREBASE_CONFIG"


### PR DESCRIPTION
- Bumped version to 4.9.0
- Dropped support for Go versions 1.15 and 1.16. Admin Go SDK now requires Go 1.17 or higher.