### PR TITLE
feat(fcm): SendEach and SendEachForMulticast for FCM batch send

### DIFF
--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -93,7 +93,7 @@ type BatchResponse struct {
 // The messages array may contain up to 500 messages. Unlike `SendAll()`, SendEach sends the entire
 // array of messages by making a single HTTP call for each message. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error
-// from SendEach or a `BatchResponse` with all failures indicates a total failure -- i.e.
+// from SendEach or a `BatchResponse` with all failures indicates a total failure, meaning that
 // none of the messages in the list could be sent. Partial failures or no failures are only
 // indicated by a `BatchResponse` return value.
 func (c *fcmClient) SendEach(ctx context.Context, messages []*Message) (*BatchResponse, error) {
@@ -109,8 +109,8 @@ func (c *fcmClient) SendEach(ctx context.Context, messages []*Message) (*BatchRe
 // The messages array may contain up to 500 messages. Unlike `SendAllDryRun()`, SendEachDryRun sends
 // the entire array of messages by making a single HTTP call for each message. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error
-// from SendEachDryRun or a `BatchResponse` with all failures indicates a total failure -- i.e.
-// none of the messages in the list could be sent. Partial failures or no failures are only
+// from SendEachDryRun or a `BatchResponse` with all failures indicates a total failure, meaning
+// that none of the messages in the list could be sent. Partial failures or no failures are only
 // indicated by a `BatchResponse` return value.
 func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendEachInBatch(ctx, messages, true)
@@ -121,8 +121,8 @@ func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*B
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
 // `SendEach()` function to send the given message to all the target recipients. The
 // responses list obtained from the return value corresponds to the order of the input tokens. An error
-// from SendEachForMulticast or a `BatchResponse` with all failures indicates a total failure -- i.e.
-// none of the messages in the list could be sent. Partial failures or no failures are only
+// from SendEachForMulticast or a `BatchResponse` with all failures indicates a total failure, meaning
+// that none of the messages in the list could be sent. Partial failures or no failures are only
 // indicated by a `BatchResponse` return value.
 func (c *fcmClient) SendEachForMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
@@ -142,8 +142,8 @@ func (c *fcmClient) SendEachForMulticast(ctx context.Context, message *Multicast
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendEachForMulticastDryRunn uses the
 // `SendEachDryRun()` function to send the given message. The responses list obtained from
 // the return value corresponds to the order of the input tokens. An error from SendEachForMulticastDryRun
-// or a `BatchResponse` with all failures indicates a total failure -- i.e.
-// none of the messages in the list could be sent. Partial failures or no failures are only
+// or a `BatchResponse` with all failures indicates a total failure, meaning that of the messages in the
+// list could be sent. Partial failures or no failures are only
 // indicated by a `BatchResponse` return value.
 func (c *fcmClient) SendEachForMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
@@ -216,8 +216,8 @@ func (c *fcmClient) sendEachInBatch(ctx context.Context, messages []*Message, dr
 // array of messages as a single RPC call. Compared to the `Send()` function,
 // this is a significantly more efficient way to send multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
-// SendAll indicates a total failure -- i.e. none of the messages in the array could be sent.
-// Partial failures are indicated by a `BatchResponse` return value.
+// SendAll indicates a total failure, meaning that none of the messages in the array could be
+// sent. Partial failures are indicated by a `BatchResponse` return value.
 //
 // Deprecated: Use SendEach instead.
 func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
@@ -234,8 +234,8 @@ func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchRes
 // entire array of messages as a single RPC call. Compared to the `SendDryRun()` function, this
 // is a significantly more efficient way to validate sending multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
-// SendAllDryRun indicates a total failure -- i.e. none of the messages in the array could be sent
-// for validation. Partial failures are indicated by a `BatchResponse` return value.
+// SendAllDryRun indicates a total failure, meaning that none of the messages in the array could
+// be sent for validation. Partial failures are indicated by a `BatchResponse` return value.
 //
 // Deprecated: Use SendEachDryRun instead.
 func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
@@ -247,8 +247,8 @@ func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*Ba
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
 // `SendAll()` function to send the given message to all the target recipients. The
 // responses list obtained from the return value corresponds to the order of the input tokens. An
-// error from SendMulticast indicates a total failure -- i.e. the message could not be sent to any
-// of the recipients. Partial failures are indicated by a `BatchResponse` return value.
+// error from SendMulticast indicates a total failure, meaning that the message could not be sent
+// to any of the recipients. Partial failures are indicated by a `BatchResponse` return value.
 //
 // Deprecated: Use SendEachForMulticast instead.
 func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
@@ -269,8 +269,8 @@ func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticastDryRun uses the
 // `SendAllDryRun()` function to send the given message. The responses list obtained from
 // the return value corresponds to the order of the input tokens. An error from SendMulticastDryRun
-// indicates a total failure -- i.e. none of the messages were sent to FCM for validation. Partial
-// failures are indicated by a `BatchResponse` return value.
+// indicates a total failure, meaning that none of the messages were sent to FCM for validation.
+// Partial failures are indicated by a `BatchResponse` return value.
 //
 // Deprecated: Use SendEachForMulticastDryRun instead.
 func (c *fcmClient) SendMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {

--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -81,7 +81,7 @@ type SendResponse struct {
 	Error     error
 }
 
-// BatchResponse represents the response from the `SendAll()` and `SendMulticast()` APIs.
+// BatchResponse represents the response from the SendAll() and SendMulticast() APIs.
 type BatchResponse struct {
 	SuccessCount int
 	FailureCount int
@@ -90,12 +90,12 @@ type BatchResponse struct {
 
 // SendEach sends the messages in the given array via Firebase Cloud Messaging.
 //
-// The messages array may contain up to 500 messages. Unlike `SendAll()`, SendEach sends the entire
+// The messages array may contain up to 500 messages. Unlike SendAll(), SendEach sends the entire
 // array of messages by making a single HTTP call for each message. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error
-// from SendEach or a `BatchResponse` with all failures indicates a total failure, meaning that
+// from SendEach or a BatchResponse with all failures indicates a total failure, meaning that
 // none of the messages in the list could be sent. Partial failures or no failures are only
-// indicated by a `BatchResponse` return value.
+// indicated by a BatchResponse return value.
 func (c *fcmClient) SendEach(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendEachInBatch(ctx, messages, false)
 }
@@ -106,12 +106,12 @@ func (c *fcmClient) SendEach(ctx context.Context, messages []*Message) (*BatchRe
 // This function does not actually deliver any messages to target devices. Instead, it performs all
 // the SDK-level and backend validations on the messages, and emulates the send operation.
 //
-// The messages array may contain up to 500 messages. Unlike `SendAllDryRun()`, SendEachDryRun sends
+// The messages array may contain up to 500 messages. Unlike SendAllDryRun(), SendEachDryRun sends
 // the entire array of messages by making a single HTTP call for each message. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error
-// from SendEachDryRun or a `BatchResponse` with all failures indicates a total failure, meaning
+// from SendEachDryRun or a BatchResponse with all failures indicates a total failure, meaning
 // that none of the messages in the list could be sent. Partial failures or no failures are only
-// indicated by a `BatchResponse` return value.
+// indicated by a BatchResponse return value.
 func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendEachInBatch(ctx, messages, true)
 }
@@ -119,11 +119,11 @@ func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*B
 // SendMulticast sends the given multicast message to all the FCM registration tokens specified.
 //
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
-// `SendEach()` function to send the given message to all the target recipients. The
+// SendEach() function to send the given message to all the target recipients. The
 // responses list obtained from the return value corresponds to the order of the input tokens. An error
-// from SendEachForMulticast or a `BatchResponse` with all failures indicates a total failure, meaning
+// from SendEachForMulticast or a BatchResponse with all failures indicates a total failure, meaning
 // that none of the messages in the list could be sent. Partial failures or no failures are only
-// indicated by a `BatchResponse` return value.
+// indicated by a BatchResponse return value.
 func (c *fcmClient) SendEachForMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {
@@ -140,11 +140,11 @@ func (c *fcmClient) SendEachForMulticast(ctx context.Context, message *Multicast
 // the SDK-level and backend validations on the messages, and emulates the send operation.
 //
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendEachForMulticastDryRunn uses the
-// `SendEachDryRun()` function to send the given message. The responses list obtained from
+// SendEachDryRun() function to send the given message. The responses list obtained from
 // the return value corresponds to the order of the input tokens. An error from SendEachForMulticastDryRun
-// or a `BatchResponse` with all failures indicates a total failure, meaning that of the messages in the
+// or a BatchResponse with all failures indicates a total failure, meaning that of the messages in the
 // list could be sent. Partial failures or no failures are only
-// indicated by a `BatchResponse` return value.
+// indicated by a BatchResponse return value.
 func (c *fcmClient) SendEachForMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {
@@ -213,11 +213,11 @@ func (c *fcmClient) sendEachInBatch(ctx context.Context, messages []*Message, dr
 // SendAll sends the messages in the given array via Firebase Cloud Messaging.
 //
 // The messages array may contain up to 500 messages. SendAll employs batching to send the entire
-// array of messages as a single RPC call. Compared to the `Send()` function,
+// array of messages as a single RPC call. Compared to the Send() function,
 // this is a significantly more efficient way to send multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAll indicates a total failure, meaning that none of the messages in the array could be
-// sent. Partial failures are indicated by a `BatchResponse` return value.
+// sent. Partial failures are indicated by a BatchResponse return value.
 //
 // Deprecated: Use SendEach instead.
 func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
@@ -231,11 +231,11 @@ func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchRes
 // the SDK-level and backend validations on the messages, and emulates the send operation.
 //
 // The messages array may contain up to 500 messages. SendAllDryRun employs batching to send the
-// entire array of messages as a single RPC call. Compared to the `SendDryRun()` function, this
+// entire array of messages as a single RPC call. Compared to the SendDryRun() function, this
 // is a significantly more efficient way to validate sending multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAllDryRun indicates a total failure, meaning that none of the messages in the array could
-// be sent for validation. Partial failures are indicated by a `BatchResponse` return value.
+// be sent for validation. Partial failures are indicated by a BatchResponse return value.
 //
 // Deprecated: Use SendEachDryRun instead.
 func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
@@ -245,10 +245,10 @@ func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*Ba
 // SendMulticast sends the given multicast message to all the FCM registration tokens specified.
 //
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
-// `SendAll()` function to send the given message to all the target recipients. The
+// SendAll() function to send the given message to all the target recipients. The
 // responses list obtained from the return value corresponds to the order of the input tokens. An
 // error from SendMulticast indicates a total failure, meaning that the message could not be sent
-// to any of the recipients. Partial failures are indicated by a `BatchResponse` return value.
+// to any of the recipients. Partial failures are indicated by a BatchResponse return value.
 //
 // Deprecated: Use SendEachForMulticast instead.
 func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
@@ -267,10 +267,10 @@ func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage
 // the SDK-level and backend validations on the messages, and emulates the send operation.
 //
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticastDryRun uses the
-// `SendAllDryRun()` function to send the given message. The responses list obtained from
+// SendAllDryRun() function to send the given message. The responses list obtained from
 // the return value corresponds to the order of the input tokens. An error from SendMulticastDryRun
 // indicates a total failure, meaning that none of the messages were sent to FCM for validation.
-// Partial failures are indicated by a `BatchResponse` return value.
+// Partial failures are indicated by a BatchResponse return value.
 //
 // Deprecated: Use SendEachForMulticastDryRun instead.
 func (c *fcmClient) SendMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {

--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -27,6 +27,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"sync"
 
 	"firebase.google.com/go/v4/internal"
 )
@@ -87,14 +88,138 @@ type BatchResponse struct {
 	Responses    []*SendResponse
 }
 
+// SendEach sends the messages in the given array via Firebase Cloud Messaging.
+//
+// The messages array may contain up to 500 messages. Unlike `SendAll()`, SendEach sends the entire
+// array of messages by making a single HTTP call for each message. The responses list
+// obtained from the return value corresponds to the order of the input messages. An error
+// from SendEach or a `BatchResponse` with all failures indicates a total failure -- i.e.
+// none of the messages in the list could be sent. Partial failures or no failures are only
+// indicated by a `BatchResponse` return value.
+func (c *fcmClient) SendEach(ctx context.Context, messages []*Message) (*BatchResponse, error) {
+	return c.sendEachInBatch(ctx, messages, false)
+}
+
+// SendEachDryRun sends the messages in the given array via Firebase Cloud Messaging in the
+// dry run (validation only) mode.
+//
+// This function does not actually deliver any messages to target devices. Instead, it performs all
+// the SDK-level and backend validations on the messages, and emulates the send operation.
+//
+// The messages array may contain up to 500 messages. Unlike `SendAllDryRun()`, SendEachDryRun sends
+// the entire array of messages by making a single HTTP call for each message. The responses list
+// obtained from the return value corresponds to the order of the input messages. An error
+// from SendEachDryRun or a `BatchResponse` with all failures indicates a total failure -- i.e.
+// none of the messages in the list could be sent. Partial failures or no failures are only
+// indicated by a `BatchResponse` return value.
+func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
+	return c.sendEachInBatch(ctx, messages, true)
+}
+
+// SendMulticast sends the given multicast message to all the FCM registration tokens specified.
+//
+// The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
+// `SendEach()` function to send the given message to all the target recipients. The
+// responses list obtained from the return value corresponds to the order of the input tokens. An error
+// from SendEachForMulticast or a `BatchResponse` with all failures indicates a total failure -- i.e.
+// none of the messages in the list could be sent. Partial failures or no failures are only
+// indicated by a `BatchResponse` return value.
+func (c *fcmClient) SendEachForMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
+	messages, err := toMessages(message)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.SendEach(ctx, messages)
+}
+
+// SendEachForMulticastDryRun sends the given multicast message to all the specified FCM registration
+// tokens in the dry run (validation only) mode.
+//
+// This function does not actually deliver any messages to target devices. Instead, it performs all
+// the SDK-level and backend validations on the messages, and emulates the send operation.
+//
+// The tokens array in MulticastMessage may contain up to 500 tokens. SendEachForMulticastDryRunn uses the
+// `SendEachDryRun()` function to send the given message. The responses list obtained from
+// the return value corresponds to the order of the input tokens. An error from SendEachForMulticastDryRun
+// or a `BatchResponse` with all failures indicates a total failure -- i.e.
+// none of the messages in the list could be sent. Partial failures or no failures are only
+// indicated by a `BatchResponse` return value.
+func (c *fcmClient) SendEachForMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
+	messages, err := toMessages(message)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.SendEachDryRun(ctx, messages)
+}
+
+func (c *fcmClient) sendEachInBatch(ctx context.Context, messages []*Message, dryRun bool) (*BatchResponse, error) {
+	if len(messages) == 0 {
+		return nil, errors.New("messages must not be nil or empty")
+	}
+
+	if len(messages) > maxMessages {
+		return nil, fmt.Errorf("messages must not contain more than %d elements", maxMessages)
+	}
+
+	var responses []*SendResponse = make([]*SendResponse, len(messages))
+	var wg sync.WaitGroup
+
+	for idx, m := range messages {
+		if err := validateMessage(m); err != nil {
+			return nil, fmt.Errorf("invalid message at index %d: %v", idx, err)
+		}
+		wg.Add(1)
+		go func(idx int, m *Message, dryRun bool, responses []*SendResponse) {
+			defer wg.Done()
+			var resp string
+			var err error
+			if dryRun {
+				resp, err = c.SendDryRun(ctx, m)
+			} else {
+				resp, err = c.Send(ctx, m)
+			}
+			if err == nil {
+				responses[idx] = &SendResponse{
+					Success:   true,
+					MessageID: resp,
+				}
+			} else {
+				responses[idx] = &SendResponse{
+					Success: false,
+					Error:   err,
+				}
+			}
+		}(idx, m, dryRun, responses)
+	}
+	// Wait for all SendDryRun/Send calls to finish
+	wg.Wait()
+
+	successCount := 0
+	for _, r := range responses {
+		if r.Success {
+			successCount++
+		}
+	}
+
+	return &BatchResponse{
+		Responses:    responses,
+		SuccessCount: successCount,
+		FailureCount: len(responses) - successCount,
+	}, nil
+}
+
 // SendAll sends the messages in the given array via Firebase Cloud Messaging.
 //
 // The messages array may contain up to 500 messages. SendAll employs batching to send the entire
-// array of mssages as a single RPC call. Compared to the `Send()` function,
+// array of messages as a single RPC call. Compared to the `Send()` function,
 // this is a significantly more efficient way to send multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAll indicates a total failure -- i.e. none of the messages in the array could be sent.
 // Partial failures are indicated by a `BatchResponse` return value.
+//
+// Deprecated: Use SendEach instead.
 func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendBatch(ctx, messages, false)
 }
@@ -106,11 +231,13 @@ func (c *fcmClient) SendAll(ctx context.Context, messages []*Message) (*BatchRes
 // the SDK-level and backend validations on the messages, and emulates the send operation.
 //
 // The messages array may contain up to 500 messages. SendAllDryRun employs batching to send the
-// entire array of mssages as a single RPC call. Compared to the `SendDryRun()` function, this
+// entire array of messages as a single RPC call. Compared to the `SendDryRun()` function, this
 // is a significantly more efficient way to validate sending multiple messages. The responses list
 // obtained from the return value corresponds to the order of the input messages. An error from
 // SendAllDryRun indicates a total failure -- i.e. none of the messages in the array could be sent
 // for validation. Partial failures are indicated by a `BatchResponse` return value.
+//
+// Deprecated: Use SendEachDryRun instead.
 func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*BatchResponse, error) {
 	return c.sendBatch(ctx, messages, true)
 }
@@ -122,6 +249,8 @@ func (c *fcmClient) SendAllDryRun(ctx context.Context, messages []*Message) (*Ba
 // responses list obtained from the return value corresponds to the order of the input tokens. An
 // error from SendMulticast indicates a total failure -- i.e. the message could not be sent to any
 // of the recipients. Partial failures are indicated by a `BatchResponse` return value.
+//
+// Deprecated: Use SendEachForMulticast instead.
 func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {
@@ -142,6 +271,8 @@ func (c *fcmClient) SendMulticast(ctx context.Context, message *MulticastMessage
 // the return value corresponds to the order of the input tokens. An error from SendMulticastDryRun
 // indicates a total failure -- i.e. none of the messages were sent to FCM for validation. Partial
 // failures are indicated by a `BatchResponse` return value.
+//
+// Deprecated: Use SendEachForMulticastDryRun instead.
 func (c *fcmClient) SendMulticastDryRun(ctx context.Context, message *MulticastMessage) (*BatchResponse, error) {
 	messages, err := toMessages(message)
 	if err != nil {


### PR DESCRIPTION
- Deprecate `sendAll()` and `sendMulticast()` APIs.
- Add new `sendEach()` and `sendEachForMulticast()` APIs.