### PR TITLE
feat(auth): Add `TotpInfo` field to `UserRecord`

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -703,22 +703,20 @@ func validateAndFormatMfaSettings(mfaSettings MultiFactorSettings, methodType st
 				if err := validatePhone(multiFactorInfo.PhoneMultiFactorInfo.PhoneNumber); err != nil {
 					return nil, fmt.Errorf("the second factor \"phoneNumber\" for \"%s\" must be a non-empty E.164 standard compliant identifier string", multiFactorInfo.PhoneMultiFactorInfo.PhoneNumber)
 				}
-			} else {
+				// No need for the else here since we are returning from the function
+			} else if multiFactorInfo.PhoneNumber != "" {
 				// PhoneMultiFactorInfo is nil, check the deprecated PhoneNumber field
-				if multiFactorInfo.PhoneNumber != "" {
-					if err := validatePhone(multiFactorInfo.PhoneNumber); err != nil {
-						return nil, fmt.Errorf("the second factor \"phoneNumber\" for \"%s\" must be a non-empty E.164 standard compliant identifier string", multiFactorInfo.PhoneNumber)
-					} else {
-						// The PhoneNumber field is deprecated, set it in PhoneMultiFactorInfo and inform about the deprecation.
-						multiFactorInfo.PhoneMultiFactorInfo = &PhoneMultiFactorInfo{
-							PhoneNumber: multiFactorInfo.PhoneNumber,
-						}
-						fmt.Println("`PhoneNumber` is deprecated, use `PhoneMultiFactorInfo` instead")
-					}
-				} else {
-					// Both PhoneMultiFactorInfo and deprecated PhoneNumber are missing.
-					return nil, fmt.Errorf("\"PhoneMultiFactorInfo\" must be defined")
+				if err := validatePhone(multiFactorInfo.PhoneNumber); err != nil {
+					return nil, fmt.Errorf("the second factor \"phoneNumber\" for \"%s\" must be a non-empty E.164 standard compliant identifier string", multiFactorInfo.PhoneNumber)
 				}
+				// The PhoneNumber field is deprecated, set it in PhoneMultiFactorInfo and inform about the deprecation.
+				multiFactorInfo.PhoneMultiFactorInfo = &PhoneMultiFactorInfo{
+					PhoneNumber: multiFactorInfo.PhoneNumber,
+				}
+				fmt.Println("`PhoneNumber` is deprecated, use `PhoneMultiFactorInfo` instead")
+			} else {
+				// Both PhoneMultiFactorInfo and deprecated PhoneNumber are missing.
+				return nil, fmt.Errorf("\"PhoneMultiFactorInfo\" must be defined")
 			}
 		}
 		obj, err := convertMultiFactorInfoToServerFormat(*multiFactorInfo)

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -91,7 +91,7 @@ type MultiFactorInfo struct {
 	DisplayName          string
 	EnrollmentTimestamp  int64
 	FactorID             string
-	PhoneNumber          string `deprecated:"Use PhoneMultiFactorInfo instead"`
+	PhoneNumber          string `Deprecated:"Use PhoneMultiFactorInfo instead"`
 	PhoneMultiFactorInfo *PhoneMultiFactorInfo
 	TOTPMultiFactorInfo  *TOTPMultiFactorInfo
 }
@@ -701,6 +701,13 @@ func validateAndFormatMfaSettings(mfaSettings MultiFactorSettings, methodType st
 			if multiFactorInfo.PhoneMultiFactorInfo != nil {
 				if err := validatePhone(multiFactorInfo.PhoneMultiFactorInfo.PhoneNumber); err != nil {
 					return nil, fmt.Errorf("the second factor \"phoneNumber\" for \"%s\" must be a non-empty E.164 standard compliant identifier string", multiFactorInfo.PhoneMultiFactorInfo.PhoneNumber)
+				}
+			} else if multiFactorInfo.PhoneNumber != "" {
+				if err := validatePhone(multiFactorInfo.PhoneNumber); err != nil {
+					return nil, fmt.Errorf("the second factor \"phoneNumber\" for \"%s\" must be a non-empty E.164 standard compliant identifier string", multiFactorInfo.PhoneNumber)
+				} else {
+					multiFactorInfo.PhoneMultiFactorInfo.PhoneNumber = multiFactorInfo.PhoneNumber
+					fmt.Println("`PhoneNumber` is deprecated, use `PhoneMultiFactorInfo` instead")
 				}
 			} else {
 				return nil, fmt.Errorf("\"PhoneMultiFactorInfo\" must be defined")

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -91,6 +91,7 @@ type MultiFactorInfo struct {
 	DisplayName          string
 	EnrollmentTimestamp  int64
 	FactorID             string
+	PhoneNumber          string `deprecated:"Use PhoneMultiFactorInfo instead"`
 	PhoneMultiFactorInfo *PhoneMultiFactorInfo
 	TOTPMultiFactorInfo  *TOTPMultiFactorInfo
 }

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -356,7 +356,7 @@ func (u *UserToUpdate) validatedRequest() (map[string]interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			// https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/update
+			// Request body ref: https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/update
 			req["mfa"] = multiFactorEnrollments{mfaInfo}
 		} else {
 			req[k] = v

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -70,13 +70,16 @@ type multiFactorInfoResponse struct {
 	EnrolledAt      string    `json:"enrolledAt,omitempty"`
 }
 
-// TOTPInfo describes a user enrolled second totp factor.
+// TOTPInfo describes a server side user enrolled second totp factor.
 type TOTPInfo struct{}
 
 // PhoneMultiFactorInfo describes a user enrolled second phone factor.
 type PhoneMultiFactorInfo struct {
 	PhoneNumber string
 }
+
+// TOTPMultiFactorInfo describes a user enrolled second totp factor.
+type TOTPMultiFactorInfo struct{}
 
 type multiFactorEnrollments struct {
 	Enrollments []*multiFactorInfoResponse `json:"enrollments"`
@@ -89,7 +92,7 @@ type MultiFactorInfo struct {
 	EnrollmentTimestamp  int64
 	FactorID             string
 	PhoneMultiFactorInfo *PhoneMultiFactorInfo
-	TOTPMultiFactorInfo  *TOTPInfo
+	TOTPMultiFactorInfo  *TOTPMultiFactorInfo
 }
 
 // MultiFactorSettings describes the multi-factor related user settings.
@@ -1112,7 +1115,7 @@ func (r *userQueryResponse) makeExportedUserRecord() (*ExportedUserRecord, error
 				DisplayName:         factor.DisplayName,
 				EnrollmentTimestamp: enrollmentTimestamp,
 				FactorID:            totpMultiFactorID,
-				TOTPMultiFactorInfo: &TOTPInfo{},
+				TOTPMultiFactorInfo: &TOTPMultiFactorInfo{},
 			})
 		} else {
 			return nil, fmt.Errorf("unsupported multi-factor auth response: %#v", factor)

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -691,9 +691,6 @@ func validateAndFormatMfaSettings(mfaSettings MultiFactorSettings, methodType st
 				return nil, fmt.Errorf("\"uid\" is not supported when adding second factors via \"createUser()\"")
 			}
 		case updateUserMethod:
-			if multiFactorInfo.UID == "" {
-				return nil, fmt.Errorf("the second factor \"uid\" must be a valid non-empty string when adding second factors via \"updateUser()\"")
-			}
 		default:
 			return nil, fmt.Errorf("unsupported methodType: %s", methodType)
 		}

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -69,11 +69,20 @@ var testUser = &UserRecord{
 	MultiFactor: &MultiFactorSettings{
 		EnrolledFactors: []*MultiFactorInfo{
 			{
-				UID:                 "0aaded3f-5e73-461d-aef9-37b48e3769be",
+				UID:                 "enrolledFactor1",
 				FactorID:            "phone",
 				EnrollmentTimestamp: 1614776780000,
-				PhoneNumber:         "+1234567890",
-				DisplayName:         "My MFA Phone",
+				PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+					PhoneNumber: "+1234567890",
+				},
+				DisplayName: "My MFA Phone",
+			},
+			{
+				UID:                 "enrolledFactor2",
+				FactorID:            "totp",
+				EnrollmentTimestamp: 1614776780000,
+				TOTPMultiFactorInfo: &TOTPInfo{},
+				DisplayName:         "My MFA TOTP",
 			},
 		},
 	},
@@ -646,8 +655,10 @@ func TestInvalidCreateUser(t *testing.T) {
 			(&UserToCreate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						UID:         "EnrollmentID",
-						PhoneNumber: "+11234567890",
+						UID: "EnrollmentID",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
 						DisplayName: "Spouse's phone number",
 						FactorID:    "phone",
 					},
@@ -658,7 +669,9 @@ func TestInvalidCreateUser(t *testing.T) {
 			(&UserToCreate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						PhoneNumber: "invalid",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "invalid",
+						},
 						DisplayName: "Spouse's phone number",
 						FactorID:    "phone",
 					},
@@ -669,7 +682,9 @@ func TestInvalidCreateUser(t *testing.T) {
 			(&UserToCreate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						PhoneNumber:         "+11234567890",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
 						DisplayName:         "Spouse's phone number",
 						FactorID:            "phone",
 						EnrollmentTimestamp: time.Now().UTC().Unix(),
@@ -681,7 +696,9 @@ func TestInvalidCreateUser(t *testing.T) {
 			(&UserToCreate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						PhoneNumber: "+11234567890",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
 						DisplayName: "Spouse's phone number",
 						FactorID:    "",
 					},
@@ -692,8 +709,10 @@ func TestInvalidCreateUser(t *testing.T) {
 			(&UserToCreate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						PhoneNumber: "+11234567890",
-						FactorID:    "phone",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
+						FactorID: "phone",
 					},
 				},
 			}),
@@ -773,7 +792,9 @@ var createUserCases = []struct {
 		(&UserToCreate{}).MFASettings(MultiFactorSettings{
 			EnrolledFactors: []*MultiFactorInfo{
 				{
-					PhoneNumber: "+11234567890",
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
 					DisplayName: "Spouse's phone number",
 					FactorID:    "phone",
 				},
@@ -790,12 +811,16 @@ var createUserCases = []struct {
 		(&UserToCreate{}).MFASettings(MultiFactorSettings{
 			EnrolledFactors: []*MultiFactorInfo{
 				{
-					PhoneNumber: "+11234567890",
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
 					DisplayName: "number1",
 					FactorID:    "phone",
 				},
 				{
-					PhoneNumber: "+11234567890",
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
 					DisplayName: "number2",
 					FactorID:    "phone",
 				},
@@ -875,9 +900,11 @@ func TestInvalidUpdateUser(t *testing.T) {
 			(&UserToUpdate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						UID:         "enrolledSecondFactor1",
-						PhoneNumber: "+11234567890",
-						FactorID:    "phone",
+						UID: "enrolledSecondFactor1",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
+						FactorID: "phone",
 					},
 				},
 			}),
@@ -886,8 +913,10 @@ func TestInvalidUpdateUser(t *testing.T) {
 			(&UserToUpdate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						UID:         "enrolledSecondFactor1",
-						PhoneNumber: "invalid",
+						UID: "enrolledSecondFactor1",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "invalid",
+						},
 						DisplayName: "Spouse's phone number",
 						FactorID:    "phone",
 					},
@@ -898,7 +927,9 @@ func TestInvalidUpdateUser(t *testing.T) {
 			(&UserToUpdate{}).MFASettings(MultiFactorSettings{
 				EnrolledFactors: []*MultiFactorInfo{
 					{
-						PhoneNumber: "+11234567890",
+						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+							PhoneNumber: "+11234567890",
+						},
 						FactorID:    "phone",
 						DisplayName: "Spouse's phone number",
 					},
@@ -1049,14 +1080,18 @@ var updateUserCases = []struct {
 		(&UserToUpdate{}).MFASettings(MultiFactorSettings{
 			EnrolledFactors: []*MultiFactorInfo{
 				{
-					UID:                 "enrolledSecondFactor1",
-					PhoneNumber:         "+11234567890",
+					UID: "enrolledSecondFactor1",
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
 					DisplayName:         "Spouse's phone number",
 					FactorID:            "phone",
 					EnrollmentTimestamp: time.Now().Unix(),
 				}, {
-					UID:         "enrolledSecondFactor2",
-					PhoneNumber: "+11234567890",
+					UID: "enrolledSecondFactor2",
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
 					DisplayName: "Spouse's phone number",
 					FactorID:    "phone",
 				},
@@ -1886,8 +1921,14 @@ func TestMakeExportedUser(t *testing.T) {
 		MFAInfo: []*multiFactorInfoResponse{
 			{
 				PhoneInfo:       "+1234567890",
-				MFAEnrollmentID: "0aaded3f-5e73-461d-aef9-37b48e3769be",
+				MFAEnrollmentID: "enrolledFactor1",
 				DisplayName:     "My MFA Phone",
+				EnrolledAt:      "2021-03-03T13:06:20.542896Z",
+			},
+			{
+				TOTPInfo:        &TOTPInfo{},
+				MFAEnrollmentID: "enrolledFactor2",
+				DisplayName:     "My MFA TOTP",
 				EnrolledAt:      "2021-03-03T13:06:20.542896Z",
 			},
 		},

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -69,7 +69,7 @@ var testUser = &UserRecord{
 	MultiFactor: &MultiFactorSettings{
 		EnrolledFactors: []*MultiFactorInfo{
 			{
-				UID:                 "enrolledFactor1",
+				UID:                 "enrolledPhoneFactor",
 				FactorID:            "phone",
 				EnrollmentTimestamp: 1614776780000,
 				PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
@@ -78,7 +78,7 @@ var testUser = &UserRecord{
 				DisplayName: "My MFA Phone",
 			},
 			{
-				UID:                 "enrolledFactor2",
+				UID:                 "enrolledTOTPFactor",
 				FactorID:            "totp",
 				EnrollmentTimestamp: 1614776780000,
 				TOTPMultiFactorInfo: &TOTPInfo{},
@@ -1918,13 +1918,13 @@ func TestMakeExportedUser(t *testing.T) {
 		MFAInfo: []*multiFactorInfoResponse{
 			{
 				PhoneInfo:       "+1234567890",
-				MFAEnrollmentID: "enrolledFactor1",
+				MFAEnrollmentID: "enrolledPhoneFactor",
 				DisplayName:     "My MFA Phone",
 				EnrolledAt:      "2021-03-03T13:06:20.542896Z",
 			},
 			{
 				TOTPInfo:        &TOTPInfo{},
-				MFAEnrollmentID: "enrolledFactor2",
+				MFAEnrollmentID: "enrolledTOTPFactor",
 				DisplayName:     "My MFA TOTP",
 				EnrolledAt:      "2021-03-03T13:06:20.542896Z",
 			},

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -924,19 +924,6 @@ func TestInvalidUpdateUser(t *testing.T) {
 			}),
 			`the second factor "phoneNumber" for "invalid" must be a non-empty E.164 standard compliant identifier string`,
 		}, {
-			(&UserToUpdate{}).MFASettings(MultiFactorSettings{
-				EnrolledFactors: []*MultiFactorInfo{
-					{
-						PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
-							PhoneNumber: "+11234567890",
-						},
-						FactorID:    "phone",
-						DisplayName: "Spouse's phone number",
-					},
-				},
-			}),
-			`the second factor "uid" must be a valid non-empty string when adding second factors via "updateUser()"`,
-		}, {
 			(&UserToUpdate{}).ProviderToLink(&UserProvider{UID: "google_uid"}),
 			"user provider must specify a provider ID",
 		}, {
@@ -1094,10 +1081,16 @@ var updateUserCases = []struct {
 					},
 					DisplayName: "Spouse's phone number",
 					FactorID:    "phone",
+				}, {
+					PhoneMultiFactorInfo: &PhoneMultiFactorInfo{
+						PhoneNumber: "+11234567890",
+					},
+					DisplayName: "Spouse's phone number",
+					FactorID:    "phone",
 				},
 			},
 		}),
-		map[string]interface{}{"mfaInfo": []*multiFactorInfoResponse{
+		map[string]interface{}{"mfa": multiFactorEnrollments{Enrollments: []*multiFactorInfoResponse{
 			{
 				MFAEnrollmentID: "enrolledSecondFactor1",
 				PhoneInfo:       "+11234567890",
@@ -1109,12 +1102,16 @@ var updateUserCases = []struct {
 				DisplayName:     "Spouse's phone number",
 				PhoneInfo:       "+11234567890",
 			},
-		},
+			{
+				DisplayName: "Spouse's phone number",
+				PhoneInfo:   "+11234567890",
+			},
+		}},
 		},
 	},
 	{
 		(&UserToUpdate{}).MFASettings(MultiFactorSettings{}),
-		map[string]interface{}{"mfaInfo": nil},
+		map[string]interface{}{"mfa": multiFactorEnrollments{Enrollments: nil}},
 	},
 	{
 		(&UserToUpdate{}).ProviderToLink(&UserProvider{

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -81,7 +81,7 @@ var testUser = &UserRecord{
 				UID:                 "enrolledTOTPFactor",
 				FactorID:            "totp",
 				EnrollmentTimestamp: 1614776780000,
-				TOTPMultiFactorInfo: &TOTPInfo{},
+				TOTPMultiFactorInfo: &TOTPMultiFactorInfo{},
 				DisplayName:         "My MFA TOTP",
 			},
 		},

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -434,7 +434,9 @@ func TestCreateUserMFA(t *testing.T) {
 	tc.MFASettings(auth.MultiFactorSettings{
 		EnrolledFactors: []*auth.MultiFactorInfo{
 			{
-				PhoneNumber: "+11234567890",
+				PhoneMultiFactorInfo: &auth.PhoneMultiFactorInfo{
+					PhoneNumber: "+11234567890",
+				},
 				DisplayName: "Spouse's phone number",
 				FactorID:    "phone",
 			},
@@ -447,10 +449,12 @@ func TestCreateUserMFA(t *testing.T) {
 	defer deleteUser(user.UID)
 	var factor []*auth.MultiFactorInfo = []*auth.MultiFactorInfo{
 		{
-			UID:                 user.MultiFactor.EnrolledFactors[0].UID,
-			DisplayName:         "Spouse's phone number",
-			FactorID:            "phone",
-			PhoneNumber:         "+11234567890",
+			UID:         user.MultiFactor.EnrolledFactors[0].UID,
+			DisplayName: "Spouse's phone number",
+			FactorID:    "phone",
+			PhoneMultiFactorInfo: &auth.PhoneMultiFactorInfo{
+				PhoneNumber: "+11234567890",
+			},
 			EnrollmentTimestamp: user.MultiFactor.EnrolledFactors[0].EnrollmentTimestamp,
 		},
 	}

--- a/testdata/get_user.json
+++ b/testdata/get_user.json
@@ -35,8 +35,14 @@
       "mfaInfo": [
         {
           "phoneInfo": "+1234567890",
-          "mfaEnrollmentId": "0aaded3f-5e73-461d-aef9-37b48e3769be",
+          "mfaEnrollmentId": "enrolledFactor1",
           "displayName": "My MFA Phone",
+          "enrolledAt": "2021-03-03T13:06:20.542896Z"
+        },
+        {
+          "totpInfo": {},
+          "mfaEnrollmentId": "enrolledFactor2",
+          "displayName": "My MFA TOTP",
           "enrolledAt": "2021-03-03T13:06:20.542896Z"
         }
       ]

--- a/testdata/get_user.json
+++ b/testdata/get_user.json
@@ -35,13 +35,13 @@
       "mfaInfo": [
         {
           "phoneInfo": "+1234567890",
-          "mfaEnrollmentId": "enrolledFactor1",
+          "mfaEnrollmentId": "enrolledPhoneFactor",
           "displayName": "My MFA Phone",
           "enrolledAt": "2021-03-03T13:06:20.542896Z"
         },
         {
           "totpInfo": {},
-          "mfaEnrollmentId": "enrolledFactor2",
+          "mfaEnrollmentId": "enrolledTOTPFactor",
           "displayName": "My MFA TOTP",
           "enrolledAt": "2021-03-03T13:06:20.542896Z"
         }

--- a/testdata/list_users.json
+++ b/testdata/list_users.json
@@ -33,12 +33,18 @@
             "customAttributes": "{\"admin\": true, \"package\": \"gold\"}",
             "tenantId": "testTenant",
             "mfaInfo": [
-              {
-                "phoneInfo": "+1234567890",
-                "mfaEnrollmentId": "0aaded3f-5e73-461d-aef9-37b48e3769be",
-                "displayName": "My MFA Phone",
-                "enrolledAt": "2021-03-03T13:06:20.542896Z"
-              }
+                {
+                    "phoneInfo": "+1234567890",
+                    "mfaEnrollmentId": "enrolledFactor1",
+                    "displayName": "My MFA Phone",
+                    "enrolledAt": "2021-03-03T13:06:20.542896Z"
+                },
+                {
+                    "totpInfo": {},
+                    "mfaEnrollmentId": "enrolledFactor2",
+                    "displayName": "My MFA TOTP",
+                    "enrolledAt": "2021-03-03T13:06:20.542896Z"
+                }
             ]
         },
         {
@@ -73,12 +79,18 @@
             "customAttributes": "{\"admin\": true, \"package\": \"gold\"}",
             "tenantId": "testTenant",
             "mfaInfo": [
-              {
-                "phoneInfo": "+1234567890",
-                "mfaEnrollmentId": "0aaded3f-5e73-461d-aef9-37b48e3769be",
-                "displayName": "My MFA Phone",
-                "enrolledAt": "2021-03-03T13:06:20.542896Z"
-              }
+                {
+                    "phoneInfo": "+1234567890",
+                    "mfaEnrollmentId": "enrolledFactor1",
+                    "displayName": "My MFA Phone",
+                    "enrolledAt": "2021-03-03T13:06:20.542896Z"
+                },
+                {
+                    "totpInfo": {},
+                    "mfaEnrollmentId": "enrolledFactor2",
+                    "displayName": "My MFA TOTP",
+                    "enrolledAt": "2021-03-03T13:06:20.542896Z"
+                }
             ]
         },
         {

--- a/testdata/list_users.json
+++ b/testdata/list_users.json
@@ -35,13 +35,13 @@
             "mfaInfo": [
                 {
                     "phoneInfo": "+1234567890",
-                    "mfaEnrollmentId": "enrolledFactor1",
+                    "mfaEnrollmentId": "enrolledPhoneFactor",
                     "displayName": "My MFA Phone",
                     "enrolledAt": "2021-03-03T13:06:20.542896Z"
                 },
                 {
                     "totpInfo": {},
-                    "mfaEnrollmentId": "enrolledFactor2",
+                    "mfaEnrollmentId": "enrolledTOTPFactor",
                     "displayName": "My MFA TOTP",
                     "enrolledAt": "2021-03-03T13:06:20.542896Z"
                 }
@@ -81,13 +81,13 @@
             "mfaInfo": [
                 {
                     "phoneInfo": "+1234567890",
-                    "mfaEnrollmentId": "enrolledFactor1",
+                    "mfaEnrollmentId": "enrolledPhoneFactor",
                     "displayName": "My MFA Phone",
                     "enrolledAt": "2021-03-03T13:06:20.542896Z"
                 },
                 {
                     "totpInfo": {},
-                    "mfaEnrollmentId": "enrolledFactor2",
+                    "mfaEnrollmentId": "enrolledTOTPFactor",
                     "displayName": "My MFA TOTP",
                     "enrolledAt": "2021-03-03T13:06:20.542896Z"
                 }


### PR DESCRIPTION
Adding a `TotpInfo` field to `UserRecord` for Admin users to view a user's MFA configuration. TOTP enrollment for users is enabled via client SDKs only.
Testing was done by manually enrolling a user on TOTP using curl and creating a test app to get the corresponding user's UserRecord configuration
Manual testing output: 
```
{
  "MultiFactor": {
    "EnrolledFactors": [
      {
        "UID": "d3dc0070-665b-42e1-b3ec-18f98af224fb",
        "DisplayName": "totp-enroll-test",
        "EnrollmentTimestamp": 1685671931000,
        "FactorID": "totp",
        "PhoneMultiFactorInfo": null,
        "TOTPMultiFactorInfo": {}
      }
    ]
  }
}
```

