### PR TITLE
adding empty AuthConfig when calling auth.NewClient on emulator mode

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -77,6 +77,7 @@ func NewClient(ctx context.Context, conf *internal.AuthConfig) (*Client, error) 
 	if authEmulatorHost != "" {
 		isEmulator = true
 		signer = emulatedSigner{}
+		conf = &internal.AuthConfig{}
 	}
 
 	if signer == nil {


### PR DESCRIPTION
the AuthConfig is an internal package so it can't be imported at a higher level  if using auth emulator the client will leave the config empty and then will have a nil pointer error
