### PR TITLE
fix(messaging): correct comment

### DIFF
--- a/messaging/messaging_batch.go
+++ b/messaging/messaging_batch.go
@@ -116,7 +116,7 @@ func (c *fcmClient) SendEachDryRun(ctx context.Context, messages []*Message) (*B
 	return c.sendEachInBatch(ctx, messages, true)
 }
 
-// SendMulticast sends the given multicast message to all the FCM registration tokens specified.
+// SendEachForMulticast sends the given multicast message to all the FCM registration tokens specified.
 //
 // The tokens array in MulticastMessage may contain up to 500 tokens. SendMulticast uses the
 // SendEach() function to send the given message to all the target recipients. The


### PR DESCRIPTION
Correct the comment on `SendEachForMulticast`.