### PR TITLE
[chore] Release 4.12.1 take 3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,83 +70,62 @@ jobs:
     #   2. to the dev branch
     #   3. with the label 'release:publish', and
     #   4. the title prefix '[chore] Release '.
-#    if: github.event.pull_request.merged &&
-#      github.ref == 'dev' &&
-#      contains(github.event.pull_request.labels.*.name, 'release:publish') &&
-#      startsWith(github.event.pull_request.title, '[chore] Release ')
-#
+    if: github.event.pull_request.merged &&
+      github.ref == 'refs/heads/dev' &&
+      contains(github.event.pull_request.labels.*.name, 'release:publish') &&
+      startsWith(github.event.pull_request.title, '[chore] Release ')
 
     runs-on: ubuntu-latest
 
     steps:
-    - name: github.ref
-      run: echo ${{ github.ref }}
+    - name: Checkout source for publish
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
 
-    - name: github.event.pull_request.merged
-      run: echo ${{ github.event.pull_request.merged }}
-
-    - name: contains(github.event.pull_request.labels.*.name, 'release:publish')
-      run: echo ${{ contains(github.event.pull_request.labels.*.name, 'release:publish') }}
-
-    - name: startsWith(github.event.pull_request.title, '[chore] Release ')
-      run: echo ${{ startsWith(github.event.pull_request.title, '[chore] Release ') }}
-
-    - name: check all conditions
-      run: echo 'all true'
-      if: github.event.pull_request.merged &&
-        github.ref == 'dev' &&
-        contains(github.event.pull_request.labels.*.name, 'release:publish') &&
-        startsWith(github.event.pull_request.title, '[chore] Release ')
-
-#    steps:
-#    - name: Checkout source for publish
-#      uses: actions/checkout@v2
-#      with:
-#        persist-credentials: false
-
-#    - name: Publish preflight check
-#      id: preflight
-#      run: ./.github/scripts/publish_preflight_check.sh
+    - name: Publish preflight check
+      id: preflight
+      run: ./.github/scripts/publish_preflight_check.sh
 
     # We authorize this step with an access token that has write access to the master branch.
-#    - name: Merge to master
-#      uses: actions/github-script@0.9.0
-#      with:
-#        github-token: ${{ secrets.FIREBASE_GITHUB_TOKEN }}
-#        script: |
-#            github.repos.merge({
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              base: 'master',
-#              head: 'dev'
-#            })
+    - name: Merge to master
+      uses: actions/github-script@0.9.0
+      with:
+        github-token: ${{ secrets.FIREBASE_GITHUB_TOKEN }}
+        script: |
+            github.repos.merge({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: 'master',
+              head: 'dev'
+            })
 
     # We pull this action from a custom fork of a contributor until
     # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
     # this action does not support the "body" parameter.
-#    - name: Create release tag
-#      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        tag_name: ${{ steps.preflight.outputs.version }}
-#        release_name: Firebase Admin Go SDK ${{ steps.preflight.outputs.version }}
-#        body: ${{ steps.preflight.outputs.changelog }}
-#        commitish: master
-#        draft: false
-#        prerelease: false
+    - name: Create release tag
+      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.preflight.outputs.version }}
+        release_name: Firebase Admin Go SDK ${{ steps.preflight.outputs.version }}
+        body: ${{ steps.preflight.outputs.changelog }}
+        commitish: master
+        draft: false
+        prerelease: false
 
     # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
-#    - name: Post to Twitter
-#      if: success() &&
-#        contains(github.event.pull_request.labels.*.name, 'release:tweet')
-#      uses: firebase/firebase-admin-node/.github/actions/send-tweet@master
-#      with:
-#        status: >
-#          ${{ steps.preflight.outputs.version }} of @Firebase Admin Go SDK is available.
-#          https://github.com/firebase/firebase-admin-go/releases/tag/${{ steps.preflight.outputs.version }}
-#        consumer-key: ${{ secrets.FIREBASE_TWITTER_CONSUMER_KEY }}
-#        consumer-secret: ${{ secrets.FIREBASE_TWITTER_CONSUMER_SECRET }}
-#        access-token: ${{ secrets.FIREBASE_TWITTER_ACCESS_TOKEN }}
-#        access-token-secret: ${{ secrets.FIREBASE_TWITTER_ACCESS_TOKEN_SECRET }}
-#      continue-on-error: true
+    - name: Post to Twitter
+      if: success() &&
+        contains(github.event.pull_request.labels.*.name, 'release:tweet')
+      uses: firebase/firebase-admin-node/.github/actions/send-tweet@master
+      with:
+        status: >
+          ${{ steps.preflight.outputs.version }} of @Firebase Admin Go SDK is available.
+          https://github.com/firebase/firebase-admin-go/releases/tag/${{ steps.preflight.outputs.version }}
+        consumer-key: ${{ secrets.FIREBASE_TWITTER_CONSUMER_KEY }}
+        consumer-secret: ${{ secrets.FIREBASE_TWITTER_CONSUMER_SECRET }}
+        access-token: ${{ secrets.FIREBASE_TWITTER_ACCESS_TOKEN }}
+        access-token-secret: ${{ secrets.FIREBASE_TWITTER_ACCESS_TOKEN_SECRET }}
+      continue-on-error: true


### PR DESCRIPTION
- Fixes the release workflow to match the updates to`github.ref`.
- `github.ref` now returns a fully-formed value `refs/heads/dev` instead of just `dev`.
- See https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/

