### PR TITLE
fix: Map Firebase `FIREBASE_STORAGE_EMULATOR_HOST` to the Cloud API `STORAGE_EMULATOR_HOST`

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -18,6 +18,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"os"
 
 	"cloud.google.com/go/storage"
 	"firebase.google.com/go/v4/internal"
@@ -34,6 +35,9 @@ type Client struct {
 // This function can only be invoked from within the SDK. Client applications should access the
 // the Storage service through firebase.App.
 func NewClient(ctx context.Context, c *internal.StorageConfig) (*Client, error) {
+	if os.Getenv("STORAGE_EMULATOR_HOST") == "" && os.Getenv("FIREBASE_STORAGE_EMULATOR_HOST") != "" {
+		os.Setenv("STORAGE_EMULATOR_HOST", os.Getenv("FIREBASE_STORAGE_EMULATOR_HOST"))
+	}
 	client, err := storage.NewClient(ctx, c.Opts...)
 	if err != nil {
 		return nil, err

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"firebase.google.com/go/v4/internal"
@@ -35,6 +36,23 @@ func TestNewClientError(t *testing.T) {
 	})
 	if client != nil || err == nil {
 		t.Errorf("NewClient() = (%v, %v); want (nil, error)", client, err)
+	}
+}
+
+func TestNewClientEmulatorHostEnvVar(t *testing.T) {
+	emulatorHost := "localhost:9099"
+	os.Setenv("FIREBASE_STORAGE_EMULATOR_HOST", emulatorHost)
+	defer os.Unsetenv("FIREBASE_STORAGE_EMULATOR_HOST")
+
+	_, err := NewClient(context.Background(), &internal.StorageConfig{
+		Opts: opts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if host := os.Getenv("STORAGE_EMULATOR_HOST"); host != emulatorHost {
+		t.Errorf("emulator host: %q; want: %q", host, emulatorHost)
 	}
 }
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -43,6 +43,7 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	emulatorHost := "localhost:9099"
 	os.Setenv("FIREBASE_STORAGE_EMULATOR_HOST", emulatorHost)
 	defer os.Unsetenv("FIREBASE_STORAGE_EMULATOR_HOST")
+	defer os.Unsetenv("STORAGE_EMULATOR_HOST")
 
 	_, err := NewClient(context.Background(), &internal.StorageConfig{
 		Opts: opts,

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -43,6 +43,7 @@ func TestNewClientEmulatorHostEnvVar(t *testing.T) {
 	emulatorHost := "localhost:9099"
 	os.Setenv("FIREBASE_STORAGE_EMULATOR_HOST", emulatorHost)
 	defer os.Unsetenv("FIREBASE_STORAGE_EMULATOR_HOST")
+	os.Unsetenv("STORAGE_EMULATOR_HOST")
 	defer os.Unsetenv("STORAGE_EMULATOR_HOST")
 
 	_, err := NewClient(context.Background(), &internal.StorageConfig{


### PR DESCRIPTION
Map Firebase `FIREBASE_STORAGE_EMULATOR_HOST` to the Cloud API `STORAGE_EMULATOR_HOST` environment variable to properly acknowledge storage emulation.