### PR TITLE
[chore] Update Github action workflows to fix node version and set-output deprecation warnings

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -64,7 +64,7 @@ if [[ ! "${RELEASE_VERSION}" =~ ^([0-9]*)\.([0-9]*)\.([0-9]*)$ ]]; then
 fi
 
 echo_info "Extracted release version: ${RELEASE_VERSION}"
-echo "::set-output name=version::v${RELEASE_VERSION}"
+echo "version=v${RELEASE_VERSION}" >> $GITHUB_OUTPUT
 
 
 echo_info ""
@@ -108,13 +108,13 @@ readonly CHANGELOG=`${CURRENT_DIR}/generate_changelog.sh`
 echo "$CHANGELOG"
 
 # Parse and preformat the text to handle multi-line output.
-# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+# See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+# and https://github.com/github/docs/issues/21529#issue-1418590935
 FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"`
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//'%'/'%25'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\n'/'%0A'}"
-FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\r'/'%0D'}"
-echo "::set-output name=changelog::${FILTERED_CHANGELOG}"
-
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\''/'"'}"
+echo "changelog<<CHANGELOGEOF" >> $GITHUB_OUTPUT
+echo -e "$FILTERED_CHANGELOG" >> $GITHUB_OUTPUT
+echo "CHANGELOGEOF" >> $GITHUB_OUTPUT
 
 echo ""
 echo_info "--------------------------------------------"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
         go: [1.17, 1.18, 1.19]
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Go ${{ matrix.go }}
       uses: actions/setup-go@v5
       with:
@@ -18,9 +21,6 @@ jobs:
 
     - name: Install golint
       run: go install golang.org/x/lint/golint@latest
-
-    - name: Check out code
-      uses: actions/checkout@v4
 
     - name: Run Linter
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Set up Go ${{ matrix.go }}
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
 
@@ -20,7 +20,7 @@ jobs:
       run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run Linter
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 1.17
 
@@ -37,7 +37,7 @@ jobs:
       run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.client_payload.ref || github.ref }}
+        
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -35,11 +40,6 @@ jobs:
 
     - name: Install golint
       run: go install golang.org/x/lint/golint@latest
-
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Run Linter
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     # via the 'ref' client parameter.
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 1.17
 
@@ -48,7 +48,7 @@ jobs:
       run: go install golang.org/x/lint/golint@latest
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
@@ -79,7 +79,7 @@ jobs:
 
     steps:
     - name: Checkout source for publish
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
 
     # We authorize this step with an access token that has write access to the master branch.
     - name: Merge to master
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.FIREBASE_GITHUB_TOKEN }}
         script: |
@@ -100,20 +100,14 @@ jobs:
               head: 'dev'
             })
 
-    # We pull this action from a custom fork of a contributor until
-    # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
-    # this action does not support the "body" parameter.
+    # See: https://cli.github.com/manual/gh_release_create
     - name: Create release tag
-      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.preflight.outputs.version }}
-        release_name: Firebase Admin Go SDK ${{ steps.preflight.outputs.version }}
-        body: ${{ steps.preflight.outputs.changelog }}
-        commitish: master
-        draft: false
-        prerelease: false
+      run: gh release create ${{ steps.preflight.outputs.version }}
+            --title "Firebase Admin Go SDK ${{ steps.preflight.outputs.version }}"
+            --notes '${{ steps.preflight.outputs.changelog }}'
+            --target "master"
 
     # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
     - name: Post to Twitter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ jobs:
     # When manually triggering the build, the requester can specify a target branch or a tag
     # via the 'ref' client parameter.
     steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.client_payload.ref || github.ref }}
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
@@ -46,11 +51,6 @@ jobs:
 
     - name: Install golint
       run: go install golang.org/x/lint/golint@latest
-
-    - name: Check out code
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.client_payload.ref || github.ref }}
 
     - name: Run Linter
       run: |


### PR DESCRIPTION
- `actions/setup-go` v3 -> v5
  - Enables caching
- `actions/checkout` v2 -> v4
- `actions/github-script` 0.9.0 -> v7
- Replaced `set-output` with `GITHUB_OUTPUT`
- Swapped order of `checkout` and `setup-go` steps to allow for cache to be loaded from `go.sum`: https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs