### PR TITLE
[chore] Release 4.14.0

### DIFF
--- a/firebase.go
+++ b/firebase.go
@@ -39,7 +39,7 @@ import (
 var defaultAuthOverrides = make(map[string]interface{})
 
 // Version of the Firebase Go Admin SDK.
-const Version = "4.13.0"
+const Version = "4.14.0"
 
 // firebaseEnvName is the name of the environment variable with the Config.
 const firebaseEnvName = "FIREBASE_CONFIG"


### PR DESCRIPTION
Includes:
- Bumped supported Go versions to 1.20, 1.21, 1.22 #607 
- Upgrade dependencies #609 
- #537 