### PR TITLE
[chore] Release 4.14.0 Take 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         github-token: ${{ secrets.FIREBASE_GITHUB_TOKEN }}
         script: |
-            github.repos.merge({
+            github.rest.repos.merge({
               owner: context.repo.owner,
               repo: context.repo.repo,
               base: 'master',


### PR DESCRIPTION
- `github-script` v7 needs REST APIs to be called with `github.rest` instead of `github`.

https://github.com/firebase/firebase-js-sdk/pull/6247