### PR TITLE
Support sign_in_attributes for SAML

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -266,9 +266,10 @@ type Token struct {
 //
 // This data is provided by the Firebase Auth service and is a reserved claim in the ID token.
 type FirebaseInfo struct {
-	SignInProvider string                 `json:"sign_in_provider"`
-	Tenant         string                 `json:"tenant"`
-	Identities     map[string]interface{} `json:"identities"`
+	SignInProvider   string                 `json:"sign_in_provider"`
+	SignInAttributes map[string]interface{} `json:"sign_in_attributes"`
+	Tenant           string                 `json:"tenant"`
+	Identities       map[string]interface{} `json:"identities"`
 }
 
 // baseClient exposes the APIs common to both auth.Client and auth.TenantClient.

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -1362,8 +1362,9 @@ func getIDTokenWithSignerAndKid(signer cryptoSigner, kid string, p mockIDTokenPa
 		"auth_time": testClock.Now().Unix() - 100,
 		"sub":       "1234567890",
 		"firebase": map[string]interface{}{
-			"identities":       map[string]interface{}{},
-			"sign_in_provider": "custom",
+			"identities":         map[string]interface{}{},
+			"sign_in_provider":   "custom",
+			"sign_in_attributes": map[string]interface{}{},
 		},
 		"admin": true,
 	}


### PR DESCRIPTION
The document ([Signing in users with SAML](https://cloud.google.com/identity-platform/docs/web/saml) )  states the following:

> To retrieve the user attributes associated with the SAML provider, use the firebase.sign_in_attributes claim in the ID token. Make sure to verify the ID token using the Admin SDK when you send it to your server.

So, in this PR, `firebase-admin-go` supports `sign_in_attributes`.