### PR TITLE
fix(fcm): Change `DirectBootOK` per Go initialisms

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -121,7 +121,7 @@ type AndroidConfig struct {
 	Data                  map[string]string    `json:"data,omitempty"` // if specified, overrides the Data field on Message type
 	Notification          *AndroidNotification `json:"notification,omitempty"`
 	FCMOptions            *AndroidFCMOptions   `json:"fcm_options,omitempty"`
-	DirectBootOk          bool                 `json:"direct_boot_ok,omitempty"`
+	DirectBootOK          bool                 `json:"direct_boot_ok,omitempty"`
 }
 
 // MarshalJSON marshals an AndroidConfig into JSON (for internal use only).

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -148,7 +148,7 @@ var validMessages = []struct {
 		name: "AndroidDataMessage",
 		req: &Message{
 			Android: &AndroidConfig{
-				DirectBootOk: true,
+				DirectBootOK: true,
 				CollapseKey:  "ck",
 				Data: map[string]string{
 					"k1": "v1",


### PR DESCRIPTION
* Change `DirectBootOk` to `DirectBootOK` per Go initialisms
* A followup of #638 

go/admin-fcm-directboot