### PR TITLE
chore: Upgrade Go version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.20', '1.21', '1.22']
+        go: ['1.21', '1.22', '1.23']
 
     steps:
     - name: Check out code

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Install golint
       run: go install golang.org/x/lint/golint@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Install golint
       run: go install golang.org/x/lint/golint@latest

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ requests, code review feedback, and also pull requests.
 ## Supported Go Versions
 
 The Admin Go SDK is compatible with at least the three most recent, major Go releases.
-We currently support Go v1.20 and higher.
+We currently support Go v1.21 and higher.
 [Continuous integration](https://github.com/firebase/firebase-admin-go/actions) system
-tests the code on Go v1.20 through v1.22.
+tests the code on Go v1.21 through v1.23.
 
 ## Documentation
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module firebase.google.com/go/v4
 
-go 1.20
+go 1.21
 
 require (
 	cloud.google.com/go/firestore v1.15.0


### PR DESCRIPTION
- Added support for Go 1.21, 1.22, and 1.23
- Dropped support for Go 1.20