### PR TITLE
Update messaging.go

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -177,7 +177,7 @@ type AndroidNotification struct {
 	BodyLocArgs           []string                      `json:"body_loc_args,omitempty"`
 	TitleLocKey           string                        `json:"title_loc_key,omitempty"`
 	TitleLocArgs          []string                      `json:"title_loc_args,omitempty"`
-	ChannelID             string                        `json:"channel_id,omitempty"`
+	ChannelID             string                        `json:"channelId,omitempty"`
 	ImageURL              string                        `json:"image,omitempty"`
 	Ticker                string                        `json:"ticker,omitempty"`
 	Sticky                bool                          `json:"sticky,omitempty"`


### PR DESCRIPTION
fix(messaging): correct AndroidConfig.Notification.ChannelId field mapping

Problem:
- In the REST API documentation (projects.messages/send), the JSON field for  AndroidConfig.Notification.ChannelId is defined as "channelId"
- In the Go SDK, this field was mapped as "channel_id"
- This inconsistency prevented the notification channel ID from being properly  transmitted, making it impossible to change notification sounds

Change:
- Updated the json tag in AndroidConfig.Notification structure from "channel_id" to "channelId"
- Added necessary tests to ensure backward compatibility

Reference: https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send

Hey there! So you want to contribute to a Firebase SDK? 
Before you file this pull request, please read these guidelines:

### Discussion

  * Read the contribution guidelines (CONTRIBUTING.md).
  * If this has been discussed in an issue, make sure to link to the issue here. 
    If not, go file an issue about this **before creating a pull request** to discuss.

### Testing

  * Make sure all existing tests in the repository pass after your change.
  * If you fixed a bug or added a feature, add a new test to cover your code.

### API Changes

  * At this time we cannot accept changes that affect the public API.  If you'd like to help 
    us make Firebase APIs better, please propose your change in an issue so that we 
    can discuss it together.
