### PR TITLE
Fix (#688): Updated JSON tag for ChannelID field in AndroidConfig.Notification

### DIFF
--- a/messaging/messaging.go
+++ b/messaging/messaging.go
@@ -177,7 +177,7 @@ type AndroidNotification struct {
 	BodyLocArgs           []string                      `json:"body_loc_args,omitempty"`
 	TitleLocKey           string                        `json:"title_loc_key,omitempty"`
 	TitleLocArgs          []string                      `json:"title_loc_args,omitempty"`
-	ChannelID             string                        `json:"channel_id,omitempty"`
+	ChannelID             string                        `json:"channelId,omitempty"`
 	ImageURL              string                        `json:"image,omitempty"`
 	Ticker                string                        `json:"ticker,omitempty"`
 	Sticky                bool                          `json:"sticky,omitempty"`

--- a/messaging/messaging_test.go
+++ b/messaging/messaging_test.go
@@ -224,7 +224,7 @@ var validMessages = []struct {
 					"title_loc_args":          []interface{}{"t1", "t2"},
 					"body_loc_key":            "blk",
 					"body_loc_args":           []interface{}{"b1", "b2"},
-					"channel_id":              "channel",
+					"channelId":               "channel",
 					"image":                   "http://image.jpg",
 					"ticker":                  "tkr",
 					"sticky":                  true,


### PR DESCRIPTION
In the try it out [example](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages/send) in , we can see that the `channelId` field in `android.notification` is in camel case, 
```bash
{
  message: {
      android: {
          notification: {
              channelId: ""
          }
      }
  }
}
```

While in the SDK, the json tag for that field is set to the following
```go
ype AndroidNotification struct {
        // ... other fields
	ChannelID             string                        `json:"channel_id,omitempty"`
}
```

FIx: 
Modified the occurances of this fields

https://github.com/firebase/firebase-admin-go/blob/570427a0f270b9adb061f54187a2b033548c3c9e/messaging/messaging.go#L180

and

https://github.com/firebase/firebase-admin-go/blob/570427a0f270b9adb061f54187a2b033548c3c9e/messaging/messaging_test.go#L227
