### PR TITLE
Add LinkDomain to ActionCodeSettings

### DIFF
--- a/auth/email_action_links.go
+++ b/auth/email_action_links.go
@@ -31,6 +31,7 @@ type ActionCodeSettings struct {
 	AndroidPackageName    string `json:"androidPackageName,omitempty"`
 	AndroidMinimumVersion string `json:"androidMinimumVersion,omitempty"`
 	AndroidInstallApp     bool   `json:"androidInstallApp,omitempty"`
+	LinkDomain            string `json:"linkDomain,omitempty"`
 	DynamicLinkDomain     string `json:"dynamicLinkDomain,omitempty"`
 }
 

--- a/auth/email_action_links_test.go
+++ b/auth/email_action_links_test.go
@@ -35,6 +35,7 @@ var testActionLinkResponse = []byte(fmt.Sprintf(testActionLinkFormat, testAction
 var testActionCodeSettings = &ActionCodeSettings{
 	URL:                   "https://example.dynamic.link",
 	HandleCodeInApp:       true,
+	LinkDomain:            "hosted.page.link",
 	DynamicLinkDomain:     "custom.page.link",
 	IOSBundleID:           "com.example.ios",
 	AndroidPackageName:    "com.example.android",
@@ -44,6 +45,7 @@ var testActionCodeSettings = &ActionCodeSettings{
 var testActionCodeSettingsMap = map[string]interface{}{
 	"continueUrl":           "https://example.dynamic.link",
 	"canHandleCodeInApp":    true,
+	"linkDomain":            "hosted.page.link",
 	"dynamicLinkDomain":     "custom.page.link",
 	"iOSBundleId":           "com.example.ios",
 	"androidPackageName":    "com.example.android",


### PR DESCRIPTION
### Discussion

Add the `LinkDomain` field to the `ActionCodeSettings` struct, this new field enables migrating off of firebase dynamic links, which is deprecated and will be unsupported soon. 

See #681, I was asked to create a second PR targeting master branch. Original PR is #682