### PR TITLE
fix(auth): Fixed auth error code parsing

### DIFF
--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1510,7 +1510,7 @@ func parseErrorResponse(resp *internal.Response) (string, string) {
 	idx := strings.Index(code, ":")
 	if idx != -1 {
 		detail = strings.TrimSpace(code[idx+1:])
-		code = code[:idx]
+		code = strings.TrimSpace(code[:idx])
 	}
 
 	return code, detail

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -2191,7 +2191,7 @@ func TestHTTPErrorWithCode(t *testing.T) {
 }
 
 func TestAuthErrorWithCodeAndDetails(t *testing.T) {
-	resp := []byte(`{"error":{"message":"USER_NOT_FOUND: extra details"}}`)
+	resp := []byte(`{"error":{"message":"USER_NOT_FOUND : extra details"}}`)
 	s := echoServer(resp, t)
 	defer s.Close()
 	s.Client.baseClient.httpClient.RetryConfig = nil

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -1305,8 +1305,8 @@ func TestAuthErrorParse(t *testing.T) {
 		URL:             invalidContinueURL,
 		HandleCodeInApp: false,
 	})
-	want := "domain of the continue url is not whitelisted: Domain not whitelisted by project"
-	if err == nil || !auth.IsUnauthorizedContinueURI(err) || err.Error() != want {
+	want := "domain of the continue url is not whitelisted: "
+	if err == nil || !auth.IsUnauthorizedContinueURI(err) || !strings.HasPrefix(err.Error(), want) {
 		t.Errorf("EmailSignInLink() expected error, got: %s, want: %s", err, want)
 	}
 }

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	continueURL        = "http://localhost/?a=1&b=2#c=3"
+	invalidContinueURL = "http://www.localhost/?a=1&b=2#c=3"
 	continueURLKey     = "continueUrl"
 	oobCodeKey         = "oobCode"
 	modeKey            = "mode"
@@ -1294,6 +1295,19 @@ func TestEmailSignInLink(t *testing.T) {
 	}
 	if !user.EmailVerified {
 		t.Error("EmailSignInLink() EmailVerified = false; want = true")
+	}
+}
+
+func TestAuthErrorParse(t *testing.T) {
+	user := newUserWithParams(t)
+	defer deleteUser(user.UID)
+	_, err := client.EmailSignInLink(context.Background(), user.Email, &auth.ActionCodeSettings{
+		URL:             invalidContinueURL,
+		HandleCodeInApp: false,
+	})
+	want := "domain of the continue url is not whitelisted: Domain not whitelisted by project"
+	if err == nil || !auth.IsUnauthorizedContinueURI(err) || err.Error() != want {
+		t.Errorf("EmailSignInLink() expected error, got: %s, want: %s", err, want)
 	}
 }
 


### PR DESCRIPTION
The auth error code parser incorrectly mapped known error codes to unknown errors due to additional whitespace from the expected auth error message. This whitespace is now trimmed and correctly mapped to the corresponding auth error code.