### PR TITLE
feat(auth): Add `QueryUsers` API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ The Firebase Admin Go SDK enables server-side (backend) applications to interact
 
 -   **DO:** Use the centralized HTTP client in `internal/http_client.go` for all network calls.
 -   **DO:** Pass `context.Context` as the first argument to all functions that perform I/O or other blocking operations.
+-   **DO:** Run `go fmt` after implementing a change and fix any linting errors.
 -   **DON'T:** Expose types or functions from the `internal/` directory in the public API.
 -   **DON'T:** Introduce new third-party dependencies without a strong, documented justification and team consensus.
 

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -90,6 +90,34 @@ func TestTenantGetUser(t *testing.T) {
 	}
 }
 
+func TestTenantQueryUsers(t *testing.T) {
+	resp := `{
+		"usersInfo": [],
+		"recordsCount": "0"
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	tenantClient, err := s.Client.TenantManager.AuthForTenant("test-tenant")
+	if err != nil {
+		t.Fatalf("Failed to create tenant client: %v", err)
+	}
+
+	query := &QueryUsersRequest{
+		ReturnUserInfo: true,
+	}
+
+	_, err = tenantClient.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() with tenant client = %v", err)
+	}
+
+	wantPath := "/projects/mock-project-id/tenants/test-tenant/accounts:query"
+	if s.Req[0].RequestURI != wantPath {
+		t.Errorf("QueryUsers() URL = %q; want = %q", s.Req[0].RequestURI, wantPath)
+	}
+}
+
 func TestTenantGetUserByEmail(t *testing.T) {
 	s := echoServer(testGetUserResponse, t)
 	defer s.Close()

--- a/auth/tenant_mgt_test.go
+++ b/auth/tenant_mgt_test.go
@@ -103,8 +103,9 @@ func TestTenantQueryUsers(t *testing.T) {
 		t.Fatalf("Failed to create tenant client: %v", err)
 	}
 
+	returnUserInfo := true
 	query := &QueryUsersRequest{
-		ReturnUserInfo: true,
+		ReturnUserInfo: &returnUserInfo,
 	}
 
 	_, err = tenantClient.QueryUsers(context.Background(), query)

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1048,7 +1048,7 @@ func (c *baseClient) GetUsers(
 	return &GetUsersResult{userRecords, notFound}, nil
 }
 
-// QueryUserInfoResponse is the response structure for the accounts:query endpoint.
+// QueryUserInfoResponse is the response structure for the QueryUsers function.
 type QueryUserInfoResponse struct {
 	Users []*UserRecord
 	Count int64
@@ -1060,21 +1060,38 @@ type queryUsersResponse struct {
 }
 
 // Expression is a query condition used to filter results.
+//
+// Only one of Email, PhoneNumber, or UID should be specified.
+// If more than one is specified, only the first (in the order of Email, PhoneNumber, UID) will be applied.
 type Expression struct {
-	Email       string `json:"email,omitempty"`
-	UID         string `json:"userId,omitempty"`
+	// Email is a case insensitive string that the account's email should match.
+	Email string `json:"email,omitempty"`
+	// PhoneNumber is a string that the account's phone number should match.
 	PhoneNumber string `json:"phoneNumber,omitempty"`
+	// UID is a string that the account's local ID should match.
+	UID string `json:"userId,omitempty"`
 }
 
-// QueryUsersRequest is the request structure for the accounts:query endpoint.
+// QueryUsersRequest is the request structure for the QueryUsers function.
 type QueryUsersRequest struct {
-	ReturnUserInfo *bool         `json:"returnUserInfo,omitempty"`
-	Limit          int64         `json:"limit,string,omitempty"`
-	Offset         int64         `json:"offset,string,omitempty"`
-	SortBy         SortBy        `json:"-"`
-	Order          Order         `json:"-"`
-	TenantID       string        `json:"tenantId,omitempty"`
-	Expression     []*Expression `json:"expression,omitempty"`
+	// ReturnUserInfo indicates whether to return the accounts matching the query.
+	// If false, only the count of accounts matching the query will be returned.
+	// Defaults to true.
+	ReturnUserInfo *bool `json:"returnUserInfo,omitempty"`
+	// Limit is the maximum number of accounts to return with an upper limit of 500.
+	// Defaults to 500. Only valid when ReturnUserInfo is set to true.
+	Limit int64 `json:"limit,string,omitempty"`
+	// Offset is the number of accounts to skip from the beginning of matching records.
+	// Only valid when ReturnUserInfo is set to true.
+	Offset int64 `json:"offset,string,omitempty"`
+	// SortBy is the field to use for sorting user accounts.
+	SortBy SortBy `json:"-"`
+	// Order is the order for sorting query results.
+	Order Order `json:"-"`
+	// TenantID is the ID of the tenant to which the result is scoped.
+	TenantID string `json:"tenantId,omitempty"`
+	// Expression is a list of query conditions used to filter results.
+	Expression []*Expression `json:"expression,omitempty"`
 }
 
 // build builds the query request (for internal use only).
@@ -1118,6 +1135,33 @@ func (q *QueryUsersRequest) build() interface{} {
 	}
 }
 
+func (q *QueryUsersRequest) validate() error {
+	if q.Limit != 0 && (q.Limit < 1 || q.Limit > 500) {
+		return fmt.Errorf("limit must be between 1 and 500")
+	}
+	if q.Offset < 0 {
+		return fmt.Errorf("offset must be non-negative")
+	}
+	for _, exp := range q.Expression {
+		if exp.Email != "" {
+			if err := validateEmail(exp.Email); err != nil {
+				return err
+			}
+		}
+		if exp.PhoneNumber != "" {
+			if err := validatePhone(exp.PhoneNumber); err != nil {
+				return err
+			}
+		}
+		if exp.UID != "" {
+			if err := validateUID(exp.UID); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // SortBy is a field to use for sorting user accounts.
 type SortBy int
 
@@ -1150,6 +1194,9 @@ const (
 func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (*QueryUserInfoResponse, error) {
 	if query == nil {
 		return nil, fmt.Errorf("query request must not be nil")
+	}
+	if err := query.validate(); err != nil {
+		return nil, err
 	}
 
 	var parsed queryUsersResponse

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1158,8 +1158,6 @@ func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (
 		return nil, err
 	}
 
-	//log.Printf("QueryUsers() with response = %d, %d", parsed.Count, len(parsed.Users))
-
 	var userRecords []*UserRecord
 	for _, user := range parsed.Users {
 		userRecord, err := user.makeUserRecord()
@@ -1525,8 +1523,6 @@ func (c *baseClient) post(
 		URL:    url,
 		Body:   internal.NewJSONEntity(payload),
 	}
-	//log.Printf("%+v \n", req.Body)
-	//log.Printf("%+v \n", resp)
 	return c.httpClient.DoAndUnmarshal(ctx, req, resp)
 }
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1048,7 +1048,7 @@ func (c *baseClient) GetUsers(
 	return &GetUsersResult{userRecords, notFound}, nil
 }
 
-// QueryUserInfoResponse is the response structure for the QueryUsers function.
+// QueryUserInfoResponse is the response from the QueryUsers function.
 type QueryUserInfoResponse struct {
 	Users []*UserRecord
 	Count int64
@@ -1059,38 +1059,38 @@ type queryUsersResponse struct {
 	Count int64                `json:"recordsCount,string,omitempty"`
 }
 
-// Expression is a query condition used to filter results.
+// Expression represents a query condition used to filter results.
 //
-// Only one of Email, PhoneNumber, or UID should be specified.
-// If more than one is specified, only the first (in the order of Email, PhoneNumber, UID) will be applied.
+// Specify only one of Email, PhoneNumber, or UID. If you specify more than one,
+// only the first (in order of Email, PhoneNumber, then UID) is applied.
 type Expression struct {
-	// Email is a case insensitive string that the account's email should match.
+	// Email is a case-insensitive string that the account's email must match.
 	Email string `json:"email,omitempty"`
-	// PhoneNumber is a string that the account's phone number should match.
+	// PhoneNumber is a string that the account's phone number must match.
 	PhoneNumber string `json:"phoneNumber,omitempty"`
-	// UID is a string that the account's local ID should match.
+	// UID is a string that the account's local ID must match.
 	UID string `json:"userId,omitempty"`
 }
 
 // QueryUsersRequest is the request structure for the QueryUsers function.
 type QueryUsersRequest struct {
-	// ReturnUserInfo indicates whether to return the accounts matching the query.
-	// If false, only the count of accounts matching the query will be returned.
+	// ReturnUserInfo specifies whether to return user accounts that match the query.
+	// If set to false, only the count of matching accounts is returned.
 	// Defaults to true.
 	ReturnUserInfo *bool `json:"returnUserInfo,omitempty"`
 	// Limit is the maximum number of accounts to return with an upper limit of 500.
-	// Defaults to 500. Only valid when ReturnUserInfo is set to true.
+	// Defaults to 500. This field is valid only when ReturnUserInfo is true.
 	Limit int64 `json:"limit,string,omitempty"`
 	// Offset is the number of accounts to skip from the beginning of matching records.
-	// Only valid when ReturnUserInfo is set to true.
+	// This field is valid only when ReturnUserInfo is true.
 	Offset int64 `json:"offset,string,omitempty"`
 	// SortBy is the field to use for sorting user accounts.
 	SortBy SortBy `json:"-"`
-	// Order is the order for sorting query results.
+	// Order is the sort order for the query results.
 	Order Order `json:"-"`
-	// TenantID is the ID of the tenant to which the result is scoped.
+	// TenantID is the ID of the tenant to which the results are scoped.
 	TenantID string `json:"tenantId,omitempty"`
-	// Expression is a list of query conditions used to filter results.
+	// Expression is a list of query conditions used to filter the results.
 	Expression []*Expression `json:"expression,omitempty"`
 }
 
@@ -1162,31 +1162,31 @@ func (q *QueryUsersRequest) validate() error {
 	return nil
 }
 
-// SortBy is a field to use for sorting user accounts.
+// SortBy defines the fields available for sorting user accounts.
 type SortBy int
 
 const (
 	sortByUnspecified SortBy = iota
-	// UID sorts results by userId.
+	// UID sorts results by user ID.
 	UID
 	// Name sorts results by name.
 	Name
-	// CreatedAt sorts results by createdAt.
+	// CreatedAt sorts results by creation time.
 	CreatedAt
-	// LastLoginAt sorts results by lastLoginAt.
+	// LastLoginAt sorts results by the last login time.
 	LastLoginAt
-	// UserEmail sorts results by userEmail.
+	// UserEmail sorts results by user email.
 	UserEmail
 )
 
-// Order is an order for sorting query results.
+// Order defines the sort order for query results.
 type Order int
 
 const (
 	orderUnspecified Order = iota
-	// Asc sorts in ascending order.
+	// Asc sorts results in ascending order.
 	Asc
-	// Desc sorts in descending order.
+	// Desc sorts results in descending order.
 	Desc
 )
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -838,6 +838,61 @@ type getAccountInfoResponse struct {
 	Users []*userQueryResponse `json:"users"`
 }
 
+// QueryUserInfoResponse is the response structure for the accounts:query endpoint.
+type QueryUserInfoResponse struct {
+	Users []*UserRecord
+	Count string
+}
+
+type queryUsersResponse struct {
+	Users []*userQueryResponse `json:"usersInfo,omitempty"`
+	Count string               `json:"recordsCount,omitempty"`
+}
+
+// SqlExpression is a query condition used to filter results.
+type SqlExpression struct {
+	Email       string `json:"email,omitempty"`
+	UserID      string `json:"userId,omitempty"`
+	PhoneNumber string `json:"phoneNumber,omitempty"`
+}
+
+// QueryUsersRequest is the request structure for the accounts:query endpoint.
+type QueryUsersRequest struct {
+	ReturnUserInfo bool             `json:"returnUserInfo"`
+	Limit          string           `json:"limit,omitempty"`
+	Offset         string           `json:"offset,omitempty"`
+	SortBy         string           `json:"sortBy,omitempty"`
+	Order          string           `json:"order,omitempty"`
+	TenantID       string           `json:"tenantId,omitempty"`
+	Expression     []*SqlExpression `json:"expression,omitempty"`
+}
+
+// SortByField is a field to use for sorting user accounts.
+type SortByField string
+
+const (
+	// UserID sorts results by userId.
+	UserID SortByField = "USER_ID"
+	// Name sorts results by name.
+	Name SortByField = "NAME"
+	// CreatedAt sorts results by createdAt.
+	CreatedAt SortByField = "CREATED_AT"
+	// LastLoginAt sorts results by lastLoginAt.
+	LastLoginAt SortByField = "LAST_LOGIN_AT"
+	// UserEmail sorts results by userEmail.
+	UserEmail SortByField = "USER_EMAIL"
+)
+
+// Order is an order for sorting query results.
+type Order string
+
+const (
+	// Asc sorts in ascending order.
+	Asc Order = "ASC"
+	// Desc sorts in descending order.
+	Desc Order = "DESC"
+)
+
 func (c *baseClient) getUser(ctx context.Context, query *userQuery) (*UserRecord, error) {
 	var parsed getAccountInfoResponse
 	resp, err := c.post(ctx, "/accounts:lookup", query.build(), &parsed)
@@ -1311,6 +1366,33 @@ type DeleteUsersErrorInfo struct {
 // array of errors that correspond to the failed deletions. An error is
 // returned if any of the identifiers are invalid or if more than 1000
 // identifiers are specified.
+// QueryUsers queries for user accounts based on the provided query configuration.
+func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (*QueryUserInfoResponse, error) {
+	if query == nil {
+		return nil, fmt.Errorf("query request must not be nil")
+	}
+
+	var parsed queryUsersResponse
+	_, err := c.post(ctx, "/accounts:query", query, &parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	var userRecords []*UserRecord
+	for _, user := range parsed.Users {
+		userRecord, err := user.makeUserRecord()
+		if err != nil {
+			return nil, fmt.Errorf("error while parsing response: %w", err)
+		}
+		userRecords = append(userRecords, userRecord)
+	}
+
+	return &QueryUserInfoResponse{
+		Users: userRecords,
+		Count: parsed.Count,
+	}, nil
+}
+
 func (c *baseClient) DeleteUsers(ctx context.Context, uids []string) (*DeleteUsersResult, error) {
 	if len(uids) == 0 {
 		return &DeleteUsersResult{}, nil

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1071,7 +1071,7 @@ type QueryUsersRequest struct {
 	ReturnUserInfo bool             `json:"returnUserInfo"`
 	Limit          int64            `json:"limit,string,omitempty"`
 	Offset         int64            `json:"offset,string,omitempty"`
-	SortBy         SortByField      `json:"-"`
+	SortBy         SortBy           `json:"-"`
 	Order          Order            `json:"-"`
 	TenantID       string           `json:"tenantId,omitempty"`
 	Expression     []*SQLExpression `json:"expression,omitempty"`
@@ -1081,7 +1081,7 @@ type QueryUsersRequest struct {
 func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
 	var sortBy string
 	if q.SortBy != sortByUnspecified {
-		sortBys := map[SortByField]string{
+		sortBys := map[SortBy]string{
 			UID:         "USER_ID",
 			Name:        "NAME",
 			CreatedAt:   "CREATED_AT",
@@ -1113,11 +1113,11 @@ func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
 	return json.Marshal(temp)
 }
 
-// SortByField is a field to use for sorting user accounts.
-type SortByField int
+// SortBy is a field to use for sorting user accounts.
+type SortBy int
 
 const (
-	sortByUnspecified SortByField = iota
+	sortByUnspecified SortBy = iota
 	// UID sorts results by userId.
 	UID
 	// Name sorts results by name.

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1062,7 +1062,7 @@ type queryUsersResponse struct {
 // SQLExpression is a query condition used to filter results.
 type SQLExpression struct {
 	Email       string `json:"email,omitempty"`
-	UID      string `json:"userId,omitempty"`
+	UID         string `json:"userId,omitempty"`
 	PhoneNumber string `json:"phoneNumber,omitempty"`
 }
 
@@ -1082,7 +1082,7 @@ func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
 	var sortBy string
 	if q.SortBy != sortByUnspecified {
 		sortBys := map[SortByField]string{
-			UID:      "USER_ID",
+			UID:         "USER_ID",
 			Name:        "NAME",
 			CreatedAt:   "CREATED_AT",
 			LastLoginAt: "LAST_LOGIN_AT",
@@ -1169,7 +1169,6 @@ func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (
 		Count: parsed.Count,
 	}, nil
 }
-
 
 type userQueryResponse struct {
 	UID                string                     `json:"localId,omitempty"`

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -841,12 +841,12 @@ type getAccountInfoResponse struct {
 // QueryUserInfoResponse is the response structure for the accounts:query endpoint.
 type QueryUserInfoResponse struct {
 	Users []*UserRecord
-	Count string
+	Count int64
 }
 
 type queryUsersResponse struct {
-	Users []*userQueryResponse `json:"usersInfo,omitempty"`
-	Count string               `json:"recordsCount,omitempty"`
+	Users []*userQueryResponse `json:"userInfo"`
+	Count int64                `json:"recordsCount,string,omitempty"`
 }
 
 // SQLExpression is a query condition used to filter results.
@@ -859,8 +859,8 @@ type SQLExpression struct {
 // QueryUsersRequest is the request structure for the accounts:query endpoint.
 type QueryUsersRequest struct {
 	ReturnUserInfo bool             `json:"returnUserInfo"`
-	Limit          string           `json:"limit,omitempty"`
-	Offset         string           `json:"offset,omitempty"`
+	Limit          int64            `json:"limit,string,omitempty"`
+	Offset         int64            `json:"offset,string,omitempty"`
 	SortBy         string           `json:"sortBy,omitempty"`
 	Order          string           `json:"order,omitempty"`
 	TenantID       string           `json:"tenantId,omitempty"`
@@ -1378,6 +1378,8 @@ func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (
 		return nil, err
 	}
 
+	//log.Printf("QueryUsers() with response = %d, %d", parsed.Count, len(parsed.Users))
+
 	var userRecords []*UserRecord
 	for _, user := range parsed.Users {
 		userRecord, err := user.makeUserRecord()
@@ -1480,6 +1482,8 @@ func (c *baseClient) post(
 		URL:    url,
 		Body:   internal.NewJSONEntity(payload),
 	}
+	//log.Printf("%+v \n", req.Body)
+	//log.Printf("%+v \n", resp)
 	return c.httpClient.DoAndUnmarshal(ctx, req, resp)
 }
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1068,7 +1068,7 @@ type Expression struct {
 
 // QueryUsersRequest is the request structure for the accounts:query endpoint.
 type QueryUsersRequest struct {
-	ReturnUserInfo bool          `json:"returnUserInfo"`
+	ReturnUserInfo *bool         `json:"returnUserInfo,omitempty"`
 	Limit          int64         `json:"limit,string,omitempty"`
 	Offset         int64         `json:"offset,string,omitempty"`
 	SortBy         SortBy        `json:"-"`
@@ -1101,6 +1101,12 @@ func (q *QueryUsersRequest) build() interface{} {
 	}
 
 	type queryUsersRequestInternal QueryUsersRequest
+	internal := (*queryUsersRequestInternal)(q)
+	if internal.ReturnUserInfo == nil {
+		t := true
+		internal.ReturnUserInfo = &t
+	}
+
 	return &struct {
 		SortBy string `json:"sortBy,omitempty"`
 		Order  string `json:"order,omitempty"`
@@ -1108,7 +1114,7 @@ func (q *QueryUsersRequest) build() interface{} {
 	}{
 		SortBy:                    sortBy,
 		Order:                     order,
-		queryUsersRequestInternal: (*queryUsersRequestInternal)(q),
+		queryUsersRequestInternal: internal,
 	}
 }
 

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1077,8 +1077,8 @@ type QueryUsersRequest struct {
 	Expression     []*Expression `json:"expression,omitempty"`
 }
 
-// MarshalJSON marshals a QueryUsersRequest into JSON (for internal use only).
-func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
+// build builds the query request (for internal use only).
+func (q *QueryUsersRequest) build() interface{} {
 	var sortBy string
 	if q.SortBy != sortByUnspecified {
 		sortBys := map[SortBy]string{
@@ -1101,7 +1101,7 @@ func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
 	}
 
 	type queryUsersRequestInternal QueryUsersRequest
-	temp := &struct {
+	return &struct {
 		SortBy string `json:"sortBy,omitempty"`
 		Order  string `json:"order,omitempty"`
 		*queryUsersRequestInternal
@@ -1110,7 +1110,6 @@ func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
 		Order:                     order,
 		queryUsersRequestInternal: (*queryUsersRequestInternal)(q),
 	}
-	return json.Marshal(temp)
 }
 
 // SortBy is a field to use for sorting user accounts.
@@ -1148,7 +1147,7 @@ func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (
 	}
 
 	var parsed queryUsersResponse
-	_, err := c.post(ctx, "/accounts:query", query, &parsed)
+	_, err := c.post(ctx, "/accounts:query", query.build(), &parsed)
 	if err != nil {
 		return nil, err
 	}

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -1059,8 +1059,8 @@ type queryUsersResponse struct {
 	Count int64                `json:"recordsCount,string,omitempty"`
 }
 
-// SQLExpression is a query condition used to filter results.
-type SQLExpression struct {
+// Expression is a query condition used to filter results.
+type Expression struct {
 	Email       string `json:"email,omitempty"`
 	UID         string `json:"userId,omitempty"`
 	PhoneNumber string `json:"phoneNumber,omitempty"`
@@ -1068,13 +1068,13 @@ type SQLExpression struct {
 
 // QueryUsersRequest is the request structure for the accounts:query endpoint.
 type QueryUsersRequest struct {
-	ReturnUserInfo bool             `json:"returnUserInfo"`
-	Limit          int64            `json:"limit,string,omitempty"`
-	Offset         int64            `json:"offset,string,omitempty"`
-	SortBy         SortBy           `json:"-"`
-	Order          Order            `json:"-"`
-	TenantID       string           `json:"tenantId,omitempty"`
-	Expression     []*SQLExpression `json:"expression,omitempty"`
+	ReturnUserInfo bool          `json:"returnUserInfo"`
+	Limit          int64         `json:"limit,string,omitempty"`
+	Offset         int64         `json:"offset,string,omitempty"`
+	SortBy         SortBy        `json:"-"`
+	Order          Order         `json:"-"`
+	TenantID       string        `json:"tenantId,omitempty"`
+	Expression     []*Expression `json:"expression,omitempty"`
 }
 
 // MarshalJSON marshals a QueryUsersRequest into JSON (for internal use only).

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -838,61 +838,6 @@ type getAccountInfoResponse struct {
 	Users []*userQueryResponse `json:"users"`
 }
 
-// QueryUserInfoResponse is the response structure for the accounts:query endpoint.
-type QueryUserInfoResponse struct {
-	Users []*UserRecord
-	Count int64
-}
-
-type queryUsersResponse struct {
-	Users []*userQueryResponse `json:"userInfo"`
-	Count int64                `json:"recordsCount,string,omitempty"`
-}
-
-// SQLExpression is a query condition used to filter results.
-type SQLExpression struct {
-	Email       string `json:"email,omitempty"`
-	UserID      string `json:"userId,omitempty"`
-	PhoneNumber string `json:"phoneNumber,omitempty"`
-}
-
-// QueryUsersRequest is the request structure for the accounts:query endpoint.
-type QueryUsersRequest struct {
-	ReturnUserInfo bool             `json:"returnUserInfo"`
-	Limit          int64            `json:"limit,string,omitempty"`
-	Offset         int64            `json:"offset,string,omitempty"`
-	SortBy         string           `json:"sortBy,omitempty"`
-	Order          string           `json:"order,omitempty"`
-	TenantID       string           `json:"tenantId,omitempty"`
-	Expression     []*SQLExpression `json:"expression,omitempty"`
-}
-
-// SortByField is a field to use for sorting user accounts.
-type SortByField string
-
-const (
-	// UserID sorts results by userId.
-	UserID SortByField = "USER_ID"
-	// Name sorts results by name.
-	Name SortByField = "NAME"
-	// CreatedAt sorts results by createdAt.
-	CreatedAt SortByField = "CREATED_AT"
-	// LastLoginAt sorts results by lastLoginAt.
-	LastLoginAt SortByField = "LAST_LOGIN_AT"
-	// UserEmail sorts results by userEmail.
-	UserEmail SortByField = "USER_EMAIL"
-)
-
-// Order is an order for sorting query results.
-type Order string
-
-const (
-	// Asc sorts in ascending order.
-	Asc Order = "ASC"
-	// Desc sorts in descending order.
-	Desc Order = "DESC"
-)
-
 func (c *baseClient) getUser(ctx context.Context, query *userQuery) (*UserRecord, error) {
 	var parsed getAccountInfoResponse
 	resp, err := c.post(ctx, "/accounts:lookup", query.build(), &parsed)
@@ -1102,6 +1047,129 @@ func (c *baseClient) GetUsers(
 
 	return &GetUsersResult{userRecords, notFound}, nil
 }
+
+// QueryUserInfoResponse is the response structure for the accounts:query endpoint.
+type QueryUserInfoResponse struct {
+	Users []*UserRecord
+	Count int64
+}
+
+type queryUsersResponse struct {
+	Users []*userQueryResponse `json:"userInfo"`
+	Count int64                `json:"recordsCount,string,omitempty"`
+}
+
+// SQLExpression is a query condition used to filter results.
+type SQLExpression struct {
+	Email       string `json:"email,omitempty"`
+	UID      string `json:"userId,omitempty"`
+	PhoneNumber string `json:"phoneNumber,omitempty"`
+}
+
+// QueryUsersRequest is the request structure for the accounts:query endpoint.
+type QueryUsersRequest struct {
+	ReturnUserInfo bool             `json:"returnUserInfo"`
+	Limit          int64            `json:"limit,string,omitempty"`
+	Offset         int64            `json:"offset,string,omitempty"`
+	SortBy         SortByField      `json:"-"`
+	Order          Order            `json:"-"`
+	TenantID       string           `json:"tenantId,omitempty"`
+	Expression     []*SQLExpression `json:"expression,omitempty"`
+}
+
+// MarshalJSON marshals a QueryUsersRequest into JSON (for internal use only).
+func (q *QueryUsersRequest) MarshalJSON() ([]byte, error) {
+	var sortBy string
+	if q.SortBy != sortByUnspecified {
+		sortBys := map[SortByField]string{
+			UID:      "USER_ID",
+			Name:        "NAME",
+			CreatedAt:   "CREATED_AT",
+			LastLoginAt: "LAST_LOGIN_AT",
+			UserEmail:   "USER_EMAIL",
+		}
+		sortBy = sortBys[q.SortBy]
+	}
+
+	var order string
+	if q.Order != orderUnspecified {
+		orders := map[Order]string{
+			Asc:  "ASC",
+			Desc: "DESC",
+		}
+		order = orders[q.Order]
+	}
+
+	type queryUsersRequestInternal QueryUsersRequest
+	temp := &struct {
+		SortBy string `json:"sortBy,omitempty"`
+		Order  string `json:"order,omitempty"`
+		*queryUsersRequestInternal
+	}{
+		SortBy:                    sortBy,
+		Order:                     order,
+		queryUsersRequestInternal: (*queryUsersRequestInternal)(q),
+	}
+	return json.Marshal(temp)
+}
+
+// SortByField is a field to use for sorting user accounts.
+type SortByField int
+
+const (
+	sortByUnspecified SortByField = iota
+	// UID sorts results by userId.
+	UID
+	// Name sorts results by name.
+	Name
+	// CreatedAt sorts results by createdAt.
+	CreatedAt
+	// LastLoginAt sorts results by lastLoginAt.
+	LastLoginAt
+	// UserEmail sorts results by userEmail.
+	UserEmail
+)
+
+// Order is an order for sorting query results.
+type Order int
+
+const (
+	orderUnspecified Order = iota
+	// Asc sorts in ascending order.
+	Asc
+	// Desc sorts in descending order.
+	Desc
+)
+
+// QueryUsers queries for user accounts based on the provided query configuration.
+func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (*QueryUserInfoResponse, error) {
+	if query == nil {
+		return nil, fmt.Errorf("query request must not be nil")
+	}
+
+	var parsed queryUsersResponse
+	_, err := c.post(ctx, "/accounts:query", query, &parsed)
+	if err != nil {
+		return nil, err
+	}
+
+	//log.Printf("QueryUsers() with response = %d, %d", parsed.Count, len(parsed.Users))
+
+	var userRecords []*UserRecord
+	for _, user := range parsed.Users {
+		userRecord, err := user.makeUserRecord()
+		if err != nil {
+			return nil, fmt.Errorf("error while parsing response: %w", err)
+		}
+		userRecords = append(userRecords, userRecord)
+	}
+
+	return &QueryUserInfoResponse{
+		Users: userRecords,
+		Count: parsed.Count,
+	}, nil
+}
+
 
 type userQueryResponse struct {
 	UID                string                     `json:"localId,omitempty"`
@@ -1366,35 +1434,6 @@ type DeleteUsersErrorInfo struct {
 // array of errors that correspond to the failed deletions. An error is
 // returned if any of the identifiers are invalid or if more than 1000
 // identifiers are specified.
-// QueryUsers queries for user accounts based on the provided query configuration.
-func (c *baseClient) QueryUsers(ctx context.Context, query *QueryUsersRequest) (*QueryUserInfoResponse, error) {
-	if query == nil {
-		return nil, fmt.Errorf("query request must not be nil")
-	}
-
-	var parsed queryUsersResponse
-	_, err := c.post(ctx, "/accounts:query", query, &parsed)
-	if err != nil {
-		return nil, err
-	}
-
-	//log.Printf("QueryUsers() with response = %d, %d", parsed.Count, len(parsed.Users))
-
-	var userRecords []*UserRecord
-	for _, user := range parsed.Users {
-		userRecord, err := user.makeUserRecord()
-		if err != nil {
-			return nil, fmt.Errorf("error while parsing response: %w", err)
-		}
-		userRecords = append(userRecords, userRecord)
-	}
-
-	return &QueryUserInfoResponse{
-		Users: userRecords,
-		Count: parsed.Count,
-	}, nil
-}
-
 func (c *baseClient) DeleteUsers(ctx context.Context, uids []string) (*DeleteUsersResult, error) {
 	if len(uids) == 0 {
 		return &DeleteUsersResult{}, nil

--- a/auth/user_mgt.go
+++ b/auth/user_mgt.go
@@ -849,8 +849,8 @@ type queryUsersResponse struct {
 	Count string               `json:"recordsCount,omitempty"`
 }
 
-// SqlExpression is a query condition used to filter results.
-type SqlExpression struct {
+// SQLExpression is a query condition used to filter results.
+type SQLExpression struct {
 	Email       string `json:"email,omitempty"`
 	UserID      string `json:"userId,omitempty"`
 	PhoneNumber string `json:"phoneNumber,omitempty"`
@@ -864,7 +864,7 @@ type QueryUsersRequest struct {
 	SortBy         string           `json:"sortBy,omitempty"`
 	Order          string           `json:"order,omitempty"`
 	TenantID       string           `json:"tenantId,omitempty"`
-	Expression     []*SqlExpression `json:"expression,omitempty"`
+	Expression     []*SQLExpression `json:"expression,omitempty"`
 }
 
 // SortByField is a field to use for sorting user accounts.

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -2013,23 +2013,23 @@ func TestQueryUsersWithTenant(t *testing.T) {
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
 
+	tenantClient, err := s.Client.TenantManager.AuthForTenant("test-tenant")
+	if err != nil {
+		t.Fatalf("Failed to create tenant client: %v", err)
+	}
+
 	query := &QueryUsersRequest{
 		ReturnUserInfo: true,
-		TenantID:       "test-tenant",
 	}
 
-	_, err := s.Client.QueryUsers(context.Background(), query)
+	_, err = tenantClient.QueryUsers(context.Background(), query)
 	if err != nil {
-		t.Fatalf("QueryUsers() = %v", err)
+		t.Fatalf("QueryUsers() with tenant client = %v", err)
 	}
 
-	var req map[string]interface{}
-	if err := json.Unmarshal(s.Rbody, &req); err != nil {
-		t.Fatal(err)
-	}
-
-	if req["tenantId"] != "test-tenant" {
-		t.Errorf("QueryUsers() tenantId = %q; want = %q", req["tenantId"], "test-tenant")
+	wantPath := "/projects/mock-project-id/tenants/test-tenant/accounts:query"
+	if s.Req[0].RequestURI != wantPath {
+		t.Errorf("QueryUsers() URL = %q; want = %q", s.Req[0].RequestURI, wantPath)
 	}
 }
 

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1947,7 +1947,7 @@ func TestQueryUsers(t *testing.T) {
 		Limit:          "1",
 		SortBy:         string(UserEmail),
 		Order:          string(Asc),
-		Expression: []*SqlExpression{
+		Expression: []*SQLExpression{
 			{
 				Email: "testuser@example.com",
 			},
@@ -1992,7 +1992,7 @@ func TestQueryUsersError(t *testing.T) {
 		Limit:          "1",
 		SortBy:         "USER_EMAIL",
 		Order:          "ASC",
-		Expression: []*SqlExpression{
+		Expression: []*SQLExpression{
 			{
 				Email: "testuser@example.com",
 			},

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1942,8 +1942,9 @@ func TestQueryUsers(t *testing.T) {
 	s := echoServer([]byte(resp), t)
 	defer s.Close()
 
-	query := &QueryUsersRequest{
-		ReturnUserInfo: true,
+	returnUserInfo := true
+	query := &QueryUsersRequest {
+		ReturnUserInfo: &returnUserInfo,
 		Limit:          1,
 		SortBy:         UserEmail,
 		Order:          Asc,
@@ -1987,8 +1988,9 @@ func TestQueryUsersError(t *testing.T) {
 	defer s.Close()
 	s.Status = http.StatusBadRequest
 
+	returnUserInfo := true
 	query := &QueryUsersRequest{
-		ReturnUserInfo: true,
+		ReturnUserInfo: &returnUserInfo,
 		Limit:          1,
 		SortBy:         UserEmail,
 		Order:          Asc,
@@ -2504,4 +2506,34 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 
 func (s *mockAuthServer) Close() {
 	s.Srv.Close()
+}
+
+func TestQueryUsersDefaultReturnUserInfo(t *testing.T) {
+	resp := `{
+		"userInfo": [{
+			"localId": "testuser"
+		}],
+		"recordsCount": "1"
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	// ReturnUserInfo is nil, should default to true in build()
+	query := &QueryUsersRequest{
+		Limit: 1,
+	}
+
+	_, err := s.Client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(s.Rbody, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["returnUserInfo"] != true {
+		t.Errorf("QueryUsers() request[\"returnUserInfo\"] = %v; want true", got["returnUserInfo"])
+	}
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -2005,34 +2005,6 @@ func TestQueryUsersError(t *testing.T) {
 	}
 }
 
-func TestQueryUsersWithTenant(t *testing.T) {
-	resp := `{
-		"usersInfo": [],
-		"recordsCount": "0"
-	}`
-	s := echoServer([]byte(resp), t)
-	defer s.Close()
-
-	tenantClient, err := s.Client.TenantManager.AuthForTenant("test-tenant")
-	if err != nil {
-		t.Fatalf("Failed to create tenant client: %v", err)
-	}
-
-	query := &QueryUsersRequest{
-		ReturnUserInfo: true,
-	}
-
-	_, err = tenantClient.QueryUsers(context.Background(), query)
-	if err != nil {
-		t.Fatalf("QueryUsers() with tenant client = %v", err)
-	}
-
-	wantPath := "/projects/mock-project-id/tenants/test-tenant/accounts:query"
-	if s.Req[0].RequestURI != wantPath {
-		t.Errorf("QueryUsers() URL = %q; want = %q", s.Req[0].RequestURI, wantPath)
-	}
-}
-
 func TestMakeExportedUser(t *testing.T) {
 	queryResponse := &userQueryResponse{
 		UID:                "testuser",

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -2078,6 +2078,68 @@ func TestQueryUsersDefaultReturnUserInfo(t *testing.T) {
 	}
 }
 
+func TestQueryUsersValidation(t *testing.T) {
+	s := echoServer([]byte("{}"), t)
+	defer s.Close()
+
+	tests := []struct {
+		name  string
+		query *QueryUsersRequest
+	}{
+		{
+			name: "Invalid Limit Low",
+			query: &QueryUsersRequest{
+				Limit: -1,
+			},
+		},
+		{
+			name: "Invalid Limit High",
+			query: &QueryUsersRequest{
+				Limit: 501,
+			},
+		},
+		{
+			name: "Invalid Offset",
+			query: &QueryUsersRequest{
+				Offset: -1,
+			},
+		},
+		{
+			name: "Invalid Email in Expression",
+			query: &QueryUsersRequest{
+				Expression: []*Expression{
+					{Email: "invalid-email"},
+				},
+			},
+		},
+		{
+			name: "Invalid Phone in Expression",
+			query: &QueryUsersRequest{
+				Expression: []*Expression{
+					{PhoneNumber: "invalid-phone"},
+				},
+			},
+		},
+		{
+			name: "Invalid UID in Expression",
+			query: &QueryUsersRequest{
+				Expression: []*Expression{
+					{UID: string(make([]byte, 129))},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := s.Client.QueryUsers(context.Background(), tt.query)
+			if err == nil {
+				t.Errorf("QueryUsers() with %s; want error, got nil", tt.name)
+			}
+		})
+	}
+}
+
 func TestMakeExportedUser(t *testing.T) {
 	queryResponse := &userQueryResponse{
 		UID:                "testuser",

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -2048,6 +2048,36 @@ func TestQueryUsersMalformedLastRefreshTimestamp(t *testing.T) {
 	}
 }
 
+func TestQueryUsersDefaultReturnUserInfo(t *testing.T) {
+	resp := `{
+		"userInfo": [{
+			"localId": "testuser"
+		}],
+		"recordsCount": "1"
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	// ReturnUserInfo is nil, should default to true in build()
+	query := &QueryUsersRequest{
+		Limit: 1,
+	}
+
+	_, err := s.Client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(s.Rbody, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	if got["returnUserInfo"] != true {
+		t.Errorf("QueryUsers() request[\"returnUserInfo\"] = %v; want true", got["returnUserInfo"])
+	}
+}
+
 func TestMakeExportedUser(t *testing.T) {
 	queryResponse := &userQueryResponse{
 		UID:                "testuser",
@@ -2506,34 +2536,4 @@ func echoServer(resp interface{}, t *testing.T) *mockAuthServer {
 
 func (s *mockAuthServer) Close() {
 	s.Srv.Close()
-}
-
-func TestQueryUsersDefaultReturnUserInfo(t *testing.T) {
-	resp := `{
-		"userInfo": [{
-			"localId": "testuser"
-		}],
-		"recordsCount": "1"
-	}`
-	s := echoServer([]byte(resp), t)
-	defer s.Close()
-
-	// ReturnUserInfo is nil, should default to true in build()
-	query := &QueryUsersRequest{
-		Limit: 1,
-	}
-
-	_, err := s.Client.QueryUsers(context.Background(), query)
-	if err != nil {
-		t.Fatalf("QueryUsers() = %v", err)
-	}
-
-	var got map[string]interface{}
-	if err := json.Unmarshal(s.Rbody, &got); err != nil {
-		t.Fatal(err)
-	}
-
-	if got["returnUserInfo"] != true {
-		t.Errorf("QueryUsers() request[\"returnUserInfo\"] = %v; want true", got["returnUserInfo"])
-	}
 }

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1901,7 +1901,7 @@ func TestDeleteUsers(t *testing.T) {
 
 func TestQueryUsers(t *testing.T) {
 	resp := `{
-		"usersInfo": [{
+		"userInfo": [{
 			"localId": "testuser",
 			"email": "testuser@example.com",
 			"phoneNumber": "+1234567890",
@@ -1944,9 +1944,9 @@ func TestQueryUsers(t *testing.T) {
 
 	query := &QueryUsersRequest{
 		ReturnUserInfo: true,
-		Limit:          "1",
-		SortBy:         string(UserEmail),
-		Order:          string(Asc),
+		Limit:          1,
+		SortBy:         UserEmail,
+		Order:          Asc,
 		Expression: []*SQLExpression{
 			{
 				Email: "testuser@example.com",
@@ -1963,8 +1963,8 @@ func TestQueryUsers(t *testing.T) {
 		t.Fatalf("QueryUsers() returned %d users; want 1", len(result.Users))
 	}
 
-	if result.Count != "1" {
-		t.Errorf("QueryUsers() returned count %q; want '1'", result.Count)
+	if result.Count != 1 {
+		t.Errorf("QueryUsers() returned count %d; want 1", result.Count)
 	}
 
 	if !reflect.DeepEqual(result.Users[0], testUser) {
@@ -1989,9 +1989,9 @@ func TestQueryUsersError(t *testing.T) {
 
 	query := &QueryUsersRequest{
 		ReturnUserInfo: true,
-		Limit:          "1",
-		SortBy:         "USER_EMAIL",
-		Order:          "ASC",
+		Limit:          1,
+		SortBy:         UserEmail,
+		Order:          Asc,
 		Expression: []*SQLExpression{
 			{
 				Email: "testuser@example.com",
@@ -1999,6 +1999,47 @@ func TestQueryUsersError(t *testing.T) {
 		},
 	}
 
+	result, err := s.Client.QueryUsers(context.Background(), query)
+	if result != nil || err == nil {
+		t.Fatalf("QueryUsers() = (%v, %v); want = (nil, error)", result, err)
+	}
+}
+
+func TestQueryUsersNilQuery(t *testing.T) {
+	s := echoServer([]byte("{}"), t)
+	defer s.Close()
+	result, err := s.Client.QueryUsers(context.Background(), nil)
+	if result != nil || err == nil {
+		t.Fatalf("QueryUsers(nil) = (%v, %v); want = (nil, error)", result, err)
+	}
+}
+
+func TestQueryUsersMalformedCustomAttributes(t *testing.T) {
+	resp := `{
+		"userInfo": [{
+			"localId": "testuser",
+			"customAttributes": "invalid-json"
+		}]
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+	query := &QueryUsersRequest{}
+	result, err := s.Client.QueryUsers(context.Background(), query)
+	if result != nil || err == nil {
+		t.Fatalf("QueryUsers() = (%v, %v); want = (nil, error)", result, err)
+	}
+}
+
+func TestQueryUsersMalformedLastRefreshTimestamp(t *testing.T) {
+	resp := `{
+		"userInfo": [{
+			"localId": "testuser",
+			"lastRefreshAt": "invalid-timestamp"
+		}]
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+	query := &QueryUsersRequest{}
 	result, err := s.Client.QueryUsers(context.Background(), query)
 	if result != nil || err == nil {
 		t.Fatalf("QueryUsers() = (%v, %v); want = (nil, error)", result, err)

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1899,6 +1899,140 @@ func TestDeleteUsers(t *testing.T) {
 	})
 }
 
+func TestQueryUsers(t *testing.T) {
+	resp := `{
+		"usersInfo": [{
+			"localId": "testuser",
+			"email": "testuser@example.com",
+			"phoneNumber": "+1234567890",
+			"emailVerified": true,
+			"displayName": "Test User",
+			"photoUrl": "http://www.example.com/testuser/photo.png",
+			"validSince": "1494364393",
+			"disabled": false,
+			"createdAt": "1234567890000",
+			"lastLoginAt": "1233211232000",
+			"customAttributes": "{\"admin\": true, \"package\": \"gold\"}",
+			"tenantId": "testTenant",
+			"providerUserInfo": [{
+				"providerId": "password",
+				"displayName": "Test User",
+				"photoUrl": "http://www.example.com/testuser/photo.png",
+				"email": "testuser@example.com",
+				"rawId": "testuid"
+			}, {
+				"providerId": "phone",
+				"phoneNumber": "+1234567890",
+				"rawId": "testuid"
+			}],
+			"mfaInfo": [{
+				"phoneInfo": "+1234567890",
+				"mfaEnrollmentId": "enrolledPhoneFactor",
+				"displayName": "My MFA Phone",
+				"enrolledAt": "2021-03-03T13:06:20.542896Z"
+			}, {
+				"totpInfo": {},
+				"mfaEnrollmentId": "enrolledTOTPFactor",
+				"displayName": "My MFA TOTP",
+				"enrolledAt": "2021-03-03T13:06:20.542896Z"
+			}]
+		}],
+		"recordsCount": "1"
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	query := &QueryUsersRequest{
+		ReturnUserInfo: true,
+		Limit:          "1",
+		SortBy:         string(UserEmail),
+		Order:          string(Asc),
+		Expression: []*SqlExpression{
+			{
+				Email: "testuser@example.com",
+			},
+		},
+	}
+
+	result, err := s.Client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+
+	if len(result.Users) != 1 {
+		t.Fatalf("QueryUsers() returned %d users; want 1", len(result.Users))
+	}
+
+	if result.Count != "1" {
+		t.Errorf("QueryUsers() returned count %q; want '1'", result.Count)
+	}
+
+	if !reflect.DeepEqual(result.Users[0], testUser) {
+		t.Errorf("QueryUsers() = %#v; want = %#v", result.Users[0], testUser)
+	}
+
+	wantPath := "/projects/mock-project-id/accounts:query"
+	if s.Req[0].RequestURI != wantPath {
+		t.Errorf("QueryUsers() URL = %q; want = %q", s.Req[0].RequestURI, wantPath)
+	}
+}
+
+func TestQueryUsersError(t *testing.T) {
+	resp := `{
+		"error": {
+			"message": "INVALID_QUERY"
+		}
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+	s.Status = http.StatusBadRequest
+
+	query := &QueryUsersRequest{
+		ReturnUserInfo: true,
+		Limit:          "1",
+		SortBy:         "USER_EMAIL",
+		Order:          "ASC",
+		Expression: []*SqlExpression{
+			{
+				Email: "testuser@example.com",
+			},
+		},
+	}
+
+	result, err := s.Client.QueryUsers(context.Background(), query)
+	if result != nil || err == nil {
+		t.Fatalf("QueryUsers() = (%v, %v); want = (nil, error)", result, err)
+	}
+}
+
+func TestQueryUsersWithTenant(t *testing.T) {
+	resp := `{
+		"usersInfo": [],
+		"recordsCount": "0"
+	}`
+	s := echoServer([]byte(resp), t)
+	defer s.Close()
+
+	query := &QueryUsersRequest{
+		ReturnUserInfo: true,
+		TenantID:       "test-tenant",
+	}
+
+	_, err := s.Client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+
+	var req map[string]interface{}
+	if err := json.Unmarshal(s.Rbody, &req); err != nil {
+		t.Fatal(err)
+	}
+
+	if req["tenantId"] != "test-tenant" {
+		t.Errorf("QueryUsers() tenantId = %q; want = %q", req["tenantId"], "test-tenant")
+	}
+}
+
 func TestMakeExportedUser(t *testing.T) {
 	queryResponse := &userQueryResponse{
 		UID:                "testuser",

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1943,7 +1943,7 @@ func TestQueryUsers(t *testing.T) {
 	defer s.Close()
 
 	returnUserInfo := true
-	query := &QueryUsersRequest {
+	query := &QueryUsersRequest{
 		ReturnUserInfo: &returnUserInfo,
 		Limit:          1,
 		SortBy:         UserEmail,

--- a/auth/user_mgt_test.go
+++ b/auth/user_mgt_test.go
@@ -1947,7 +1947,7 @@ func TestQueryUsers(t *testing.T) {
 		Limit:          1,
 		SortBy:         UserEmail,
 		Order:          Asc,
-		Expression: []*SQLExpression{
+		Expression: []*Expression{
 			{
 				Email: "testuser@example.com",
 			},
@@ -1992,7 +1992,7 @@ func TestQueryUsersError(t *testing.T) {
 		Limit:          1,
 		SortBy:         UserEmail,
 		Order:          Asc,
-		Expression: []*SQLExpression{
+		Expression: []*Expression{
 			{
 				Email: "testuser@example.com",
 			},

--- a/integration/auth/tenant_mgt_test.go
+++ b/integration/auth/tenant_mgt_test.go
@@ -427,6 +427,23 @@ func testTenantAwareUserManagement(t *testing.T, id string) {
 		}
 	})
 
+	t.Run("QueryUsers()", func(t *testing.T) {
+		query := &auth.QueryUsersRequest{
+			Expression: []*auth.Expression{
+				{
+					Email: want.Email,
+				},
+			},
+		}
+		result, err := tenantClient.QueryUsers(context.Background(), query)
+		if err != nil {
+			t.Fatalf("QueryUsers() = %v", err)
+		}
+		if len(result.Users) != 1 || result.Users[0].UID != user.UID {
+			t.Errorf("QueryUsers(email=%s) = %v; want user %s", want.Email, result.Users, user.UID)
+		}
+	})
+
 	t.Run("DeleteUser()", func(t *testing.T) {
 		if err := tenantClient.DeleteUser(context.Background(), user.UID); err != nil {
 			t.Fatalf("DeleteUser() = %v", err)

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -1461,7 +1461,7 @@ func TestQueryUsers(t *testing.T) {
 		t.Fatalf("QueryUsers() = %v", err)
 	}
 	if len(result.Users) != 1 || result.Users[0].UID != u1.UID {
-		t.Errorf("QueryUsers(email=%s) = %v; want user %s", u1.Email, result.Users, u1.UID)
+		t.Errorf("QueryUsers(uid=%s) = %v; want user %s", u1.UID, result.Users, u1.UID)
 	}
 
 	// Query with limit and sort

--- a/integration/auth/user_mgt_test.go
+++ b/integration/auth/user_mgt_test.go
@@ -1442,3 +1442,39 @@ func deletePhoneNumberUser(t *testing.T, phoneNumber string) {
 		t.Fatal(err)
 	}
 }
+func TestQueryUsers(t *testing.T) {
+	u1 := newUserWithParams(t)
+	defer deleteUser(u1.UID)
+	u2 := newUserWithParams(t)
+	defer deleteUser(u2.UID)
+
+	// Query by email
+	query := &auth.QueryUsersRequest{
+		Expression: []*auth.Expression{
+			{
+				Email: u1.Email,
+			},
+		},
+	}
+	result, err := client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+	if len(result.Users) != 1 || result.Users[0].UID != u1.UID {
+		t.Errorf("QueryUsers(email=%s) = %v; want user %s", u1.Email, result.Users, u1.UID)
+	}
+
+	// Query with limit and sort
+	query = &auth.QueryUsersRequest{
+		Limit:  2,
+		SortBy: auth.CreatedAt,
+		Order:  auth.Desc,
+	}
+	result, err = client.QueryUsers(context.Background(), query)
+	if err != nil {
+		t.Fatalf("QueryUsers() = %v", err)
+	}
+	if len(result.Users) < 2 {
+		t.Errorf("QueryUsers(limit=2) = %d users; want >= 2", len(result.Users))
+	}
+}

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -167,8 +167,6 @@ func (c *HTTPClient) DoAndUnmarshal(ctx context.Context, req *Request, v interfa
 		return nil, err
 	}
 
-	//log.Printf("%+v \n", string(resp.Body))
-
 	if v != nil {
 		if err := json.Unmarshal(resp.Body, v); err != nil {
 			return nil, fmt.Errorf("error while parsing response: %v", err)

--- a/internal/http_client.go
+++ b/internal/http_client.go
@@ -167,6 +167,8 @@ func (c *HTTPClient) DoAndUnmarshal(ctx context.Context, req *Request, v interfa
 		return nil, err
 	}
 
+	//log.Printf("%+v \n", string(resp.Body))
+
 	if v != nil {
 		if err := json.Unmarshal(resp.Body, v); err != nil {
 			return nil, fmt.Errorf("error while parsing response: %v", err)


### PR DESCRIPTION
This change implements the `accounts:query` functionality, providing a new `QueryUsers` method that allows searching for users with filters and sorting options.

RELEASE_NOTE: Added `QueryUsers()` API to support querying user accounts with filters, sorting, and pagination.