### PR TITLE
chore(snippets): updated code samples to use ADC and supported APIs

### DIFF
--- a/snippets/db.go
+++ b/snippets/db.go
@@ -22,7 +22,6 @@ import (
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/db"
-	"google.golang.org/api/option"
 )
 
 // [END authenticate_db_imports]
@@ -33,11 +32,9 @@ func authenticateWithAdminPrivileges() {
 	conf := &firebase.Config{
 		DatabaseURL: "https://databaseName.firebaseio.com",
 	}
-	// Fetch the service account key JSON file contents
-	opt := option.WithCredentialsFile("path/to/serviceAccountKey.json")
 
-	// Initialize the app with a service account, granting admin privileges
-	app, err := firebase.NewApp(ctx, conf, opt)
+	// Initialize the app with Application Default Credentials, granting admin privileges
+	app, err := firebase.NewApp(ctx, conf)
 	if err != nil {
 		log.Fatalln("Error initializing app:", err)
 	}
@@ -67,10 +64,7 @@ func authenticateWithLimitedPrivileges() {
 		AuthOverride: &ao,
 	}
 
-	// Fetch the service account key JSON file contents
-	opt := option.WithCredentialsFile("path/to/serviceAccountKey.json")
-
-	app, err := firebase.NewApp(ctx, conf, opt)
+	app, err := firebase.NewApp(ctx, conf)
 	if err != nil {
 		log.Fatalln("Error initializing app:", err)
 	}
@@ -100,10 +94,7 @@ func authenticateWithGuestPrivileges() {
 		AuthOverride: &nilMap,
 	}
 
-	// Fetch the service account key JSON file contents
-	opt := option.WithCredentialsFile("path/to/serviceAccountKey.json")
-
-	app, err := firebase.NewApp(ctx, conf, opt)
+	app, err := firebase.NewApp(ctx, conf)
 	if err != nil {
 		log.Fatalln("Error initializing app:", err)
 	}

--- a/snippets/messaging.go
+++ b/snippets/messaging.go
@@ -129,7 +129,7 @@ func sendAll(ctx context.Context, client *messaging.Client) {
 		},
 	}
 
-	br, err := client.SendAll(context.Background(), messages)
+	br, err := client.SendEach(context.Background(), messages)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -191,7 +191,7 @@ func sendMulticast(ctx context.Context, client *messaging.Client) {
 		Tokens: registrationTokens,
 	}
 
-	br, err := client.SendMulticast(context.Background(), message)
+	br, err := client.SendEachForMulticast(context.Background(), message)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -219,7 +219,7 @@ func sendMulticastAndHandleErrors(ctx context.Context, client *messaging.Client)
 		Tokens: registrationTokens,
 	}
 
-	br, err := client.SendMulticast(context.Background(), message)
+	br, err := client.SendEachForMulticast(context.Background(), message)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/snippets/storage.go
+++ b/snippets/storage.go
@@ -19,7 +19,6 @@ import (
 	"log"
 
 	firebase "firebase.google.com/go/v4"
-	"google.golang.org/api/option"
 )
 
 // ==================================================================
@@ -31,8 +30,7 @@ func cloudStorage() {
 	config := &firebase.Config{
 		StorageBucket: "<BUCKET_NAME>.appspot.com",
 	}
-	opt := option.WithCredentialsFile("path/to/serviceAccountKey.json")
-	app, err := firebase.NewApp(context.Background(), config, opt)
+	app, err := firebase.NewApp(context.Background(), config)
 	if err != nil {
 		log.Fatalln(err)
 	}


### PR DESCRIPTION
Updated code samples in the snippets directory to use Application Default Credentials (ADC) wherever appropriate instead of requiring explicit service account keys. Also replaced the deprecated messaging APIs `SendAll` and `SendMulticast` with their modern, supported equivalents `SendEach` and `SendEachForMulticast`.
