### PR TITLE
Give iamSigner pointer receivers so the email cache works

### DIFF
--- a/auth/token_generator.go
+++ b/auth/token_generator.go
@@ -188,11 +188,11 @@ func newIAMSigner(ctx context.Context, config *internal.AuthConfig) (*iamSigner,
 	}, nil
 }
 
-func (s iamSigner) Algorithm() string {
+func (s *iamSigner) Algorithm() string {
 	return algorithmRS256
 }
 
-func (s iamSigner) Sign(ctx context.Context, b []byte) ([]byte, error) {
+func (s *iamSigner) Sign(ctx context.Context, b []byte) ([]byte, error) {
 	account, err := s.Email(ctx)
 	if err != nil {
 		return nil, err
@@ -217,7 +217,7 @@ func (s iamSigner) Sign(ctx context.Context, b []byte) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(signResponse.Signature)
 }
 
-func (s iamSigner) Email(ctx context.Context) (string, error) {
+func (s *iamSigner) Email(ctx context.Context) (string, error) {
 	if s.serviceAcct != "" {
 		return s.serviceAcct, nil
 	}
@@ -237,7 +237,7 @@ func (s iamSigner) Email(ctx context.Context) (string, error) {
 	return result, nil
 }
 
-func (s iamSigner) callMetadataService(ctx context.Context) (string, error) {
+func (s *iamSigner) callMetadataService(ctx context.Context) (string, error) {
 	// Use the built-in default client without request authorization or retries for this call.
 	noAuthClient := &internal.HTTPClient{
 		Client: http.DefaultClient,

--- a/auth/token_generator.go
+++ b/auth/token_generator.go
@@ -218,12 +218,12 @@ func (s *iamSigner) Sign(ctx context.Context, b []byte) ([]byte, error) {
 }
 
 func (s *iamSigner) Email(ctx context.Context) (string, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	if s.serviceAcct != "" {
 		return s.serviceAcct, nil
 	}
 
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
 	result, err := s.callMetadataService(ctx)
 	if err != nil {
 		msg := "failed to determine service account: %v; initialize the SDK with service " +

--- a/auth/token_generator_test.go
+++ b/auth/token_generator_test.go
@@ -24,6 +24,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"firebase.google.com/go/v4/errorutils"
@@ -358,4 +360,42 @@ func iamServer(t *testing.T, serviceAcct, signature string) *httptest.Server {
 		w.Write(b)
 	})
 	return httptest.NewServer(handler)
+}
+
+func TestIAMSignerEmailConcurrent(t *testing.T) {
+	var hits int64
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		atomic.AddInt64(&hits, 1)
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte("discovered-service-account"))
+	})
+	metadata := httptest.NewServer(handler)
+	defer metadata.Close()
+
+	conf := &internal.AuthConfig{
+		Opts:    optsWithTokenSource,
+		Version: testVersion,
+	}
+	signer, err := newIAMSigner(context.Background(), conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer.metadataHost = metadata.URL
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := signer.Email(context.Background()); err != nil {
+				t.Error(err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt64(&hits); got != 1 {
+		t.Errorf("concurrent Email() made %d metadata requests; want = 1", got)
+	}
 }


### PR DESCRIPTION
`iamSigner.Email` is written to discover the service account once and cache it:

```go
func (s iamSigner) Email(ctx context.Context) (string, error) {
	if s.serviceAcct != "" {
		return s.serviceAcct, nil
	}

	s.mutex.Lock()
	defer s.mutex.Unlock()
	result, err := s.callMetadataService(ctx)
	...
	s.serviceAcct = result
	return result, nil
}
```

The receiver is a value, so `s.serviceAcct = result` writes to a copy that is discarded when the method returns. The guard at the top therefore never sees a cached value, and **every call re-queries the GCE metadata server over HTTP**. `Sign` calls `Email`, so that is an extra round trip per custom token minted through the IAM path.

Two things say caching is the intent rather than the value receiver being deliberate: the early-return check exists at all, and `mutex` is held as a `*sync.Mutex` so that copies of the struct still share one lock. Guarding a write that cannot persist is only explicable as an oversight.

staticcheck reports it as SA4005, "ineffective assignment to field iamSigner.serviceAcct".

The change moves all four `iamSigner` methods to pointer receivers together, so the method set stays consistent. `newIAMSigner` already returns `*iamSigner`, `newCryptoSigner` passes that straight through, and `auth_test.go:129` asserts `client.signer.(*iamSigner)`, so nothing stores a bare `iamSigner` value and the `cryptoSigner` interface is still satisfied.

Verified: `go build ./...` passes, `go test ./auth/...` green, `gofmt -l` clean, SA4005 gone under `GOOS=linux` and `GOOS=darwin`.

Separately, and not included here since it is a different concern: `auth/user_mgt.go:1463-1464` and `auth/project_config_mgt.go:29` spell the struct tag option `omitEmpty`, which `encoding/json` does not recognise (it only accepts `omitempty`). Both structs are decode-only today so nothing misbehaves at runtime, but the tags do not do what they read as. Say the word and it goes in a separate PR.